### PR TITLE
fix FilterSBOM forgetting files on subsequent runs

### DIFF
--- a/pkg/sbomhandler/v1/sbomhandler.go
+++ b/pkg/sbomhandler/v1/sbomhandler.go
@@ -118,9 +118,17 @@ func (sc *SBOMHandler) FilterSBOM(watchedContainer *utils.WatchedContainerData, 
 				}
 			}
 		}
+		// save files, packages and relationships
+		files := watchedContainer.FilteredSpdxData.Spec.SPDX.Files
+		packages := watchedContainer.FilteredSpdxData.Spec.SPDX.Packages
+		relationships := watchedContainer.FilteredSpdxData.Spec.SPDX.Relationships
 		// copy spec and status
 		watchedContainer.FilteredSpdxData.Spec = spdxData.Spec
 		watchedContainer.FilteredSpdxData.Status = spdxData.Status
+		// restore files, packages and relationships
+		watchedContainer.FilteredSpdxData.Spec.SPDX.Files = files
+		watchedContainer.FilteredSpdxData.Spec.SPDX.Packages = packages
+		watchedContainer.FilteredSpdxData.Spec.SPDX.Relationships = relationships
 		// rewrite creation info
 		if watchedContainer.FilteredSpdxData.Spec.SPDX.CreationInfo != nil {
 			watchedContainer.FilteredSpdxData.Spec.SPDX.CreationInfo.Creators = append(watchedContainer.FilteredSpdxData.Spec.SPDX.CreationInfo.Creators, []v1beta1.Creator{
@@ -134,12 +142,9 @@ func (sc *SBOMHandler) FilterSBOM(watchedContainer *utils.WatchedContainerData, 
 				},
 			}...)
 		}
-		// empty some data
-		watchedContainer.FilteredSpdxData.Spec.SPDX.Files = make([]*v1beta1.File, 0)
-		watchedContainer.FilteredSpdxData.Spec.SPDX.Packages = make([]*v1beta1.Package, 0)
-		watchedContainer.FilteredSpdxData.Spec.SPDX.Relationships = make([]*v1beta1.Relationship, 0)
 		// update resource version
 		watchedContainer.SBOMResourceVersion = utils.Atoi(spdxData.ResourceVersion)
+		watchedContainer.NewRelevantData = true
 	}
 
 	// filter relevant file list


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This pull request addresses a bug where the FilterSBOM function was forgetting files on subsequent runs. The changes involve saving and restoring files, packages, and relationships in the FilterSBOM function. Additionally, the unit test for this function has been updated to include a second run to ensure that the files are not forgotten.

___
## PR Main Files Walkthrough:
`pkg/sbomhandler/v1/sbomhandler.go`: The FilterSBOM function has been updated to save and restore files, packages, and relationships. This prevents these items from being forgotten on subsequent runs of the function. A new flag, NewRelevantData, has been added to the watchedContainer object.
`pkg/sbomhandler/v1/sbomhandler_test.go`: The unit test for the FilterSBOM function has been updated to include a second run of the function. This is to ensure that the files are not forgotten on subsequent runs. The test now checks that the files are still present after the second run.

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
