### PR TITLE
create filteredSBOM for incomplete SBOMs

### DIFF
--- a/pkg/relevancymanager/relevancy_manager_interface.go
+++ b/pkg/relevancymanager/relevancy_manager_interface.go
@@ -2,9 +2,15 @@ package relevancymanager
 
 import (
 	"context"
+	"errors"
 	"node-agent/pkg/containerwatcher"
 
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+)
+
+var (
+	ContainerHasTerminatedError = errors.New("container has terminated")
+	IncompleteSBOMError         = errors.New("incomplete SBOM")
 )
 
 type RelevancyManagerClient interface {

--- a/pkg/relevancymanager/v1/relevancy_manager_test.go
+++ b/pkg/relevancymanager/v1/relevancy_manager_test.go
@@ -46,7 +46,7 @@ func TestRelevancyManager(t *testing.T) {
 	fileHandler, err := filehandler.CreateInMemoryFileHandler()
 	assert.NoError(t, err)
 	k8sClient := &k8sclient.K8sClientMock{}
-	storageClient := storage.CreateSBOMStorageHttpClientMock()
+	storageClient := storage.CreateSBOMStorageHttpClientMock("nginx-spdx-format-mock.json")
 	sbomHandler := sbomhandler.CreateSBOMHandler(storageClient)
 	relevancyManager, err := CreateRelevancyManager(cfg, "cluster", fileHandler, k8sClient, sbomHandler)
 	assert.NoError(t, err)
@@ -105,4 +105,50 @@ func TestRelevancyManager(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	_, err = fileHandler.GetAndDeleteFiles("ns/pod/cont")
 	assert.ErrorContains(t, err, "bucket does not exist for container ns/pod/cont")
+}
+
+func TestRelevancyManagerIncompleteSBOM(t *testing.T) {
+	// create a new relevancy manager
+	cfg := config.Config{
+		EnableRelevancy:  true,
+		InitialDelay:     1 * time.Second,
+		MaxSniffingTime:  5 * time.Minute,
+		UpdateDataPeriod: 20 * time.Second,
+	}
+	ctx := context.TODO()
+	fileHandler, err := filehandler.CreateInMemoryFileHandler()
+	assert.NoError(t, err)
+	k8sClient := &k8sclient.K8sClientMock{}
+	storageClient := storage.CreateSBOMStorageHttpClientMock("sbom-incomplete-mock.json")
+	sbomHandler := sbomhandler.CreateSBOMHandler(storageClient)
+	relevancyManager, err := CreateRelevancyManager(cfg, "cluster", fileHandler, k8sClient, sbomHandler)
+	assert.NoError(t, err)
+	relevancyManager.SetContainerHandler(containerwatcher.ContainerWatcherMock{})
+	// report container started
+	container := &containercollection.Container{
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: types.BasicK8sMetadata{
+				Namespace:     "ns",
+				PodName:       "pod",
+				ContainerName: "cont",
+			},
+		},
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+				ContainerID: "5fff6a395ce4e6984a9447cc6cfb09f473eaf278498243963fcc944889bc8400",
+			},
+		},
+	}
+	relevancyManager.ReportContainerStarted(ctx, container)
+	// report file access
+	relevancyManager.ReportFileAccess(ctx, "ns", "pod", "cont", "/usr/sbin/deluser")
+	// let it run for a while
+	time.Sleep(10 * time.Second)
+	// report container stopped
+	relevancyManager.ReportContainerTerminated(ctx, container)
+	// let it stop
+	time.Sleep(1 * time.Second)
+	// verify filtered SBOM is created
+	assert.NotNil(t, storageClient.FilteredSBOMs)
+	assert.Equal(t, 1, len(storageClient.FilteredSBOMs))
 }

--- a/pkg/sbomhandler/v1/sbomhandler.go
+++ b/pkg/sbomhandler/v1/sbomhandler.go
@@ -2,6 +2,7 @@ package sbomhandler
 
 import (
 	"errors"
+	"node-agent/pkg/relevancymanager"
 	"node-agent/pkg/sbomhandler"
 	"node-agent/pkg/storage"
 	"node-agent/pkg/utils"
@@ -96,8 +97,8 @@ func (sc *SBOMHandler) FilterSBOM(watchedContainer *utils.WatchedContainerData, 
 	if status, ok := spdxData.Annotations[instanceidhandler.StatusMetadataKey]; ok {
 		watchedContainer.FilteredSpdxData.Annotations[instanceidhandler.StatusMetadataKey] = status
 		if status == instanceidhandler.Incomplete {
-			logger.L().Debug("SBOM is incomplete, skipping", helpers.String("containerID", watchedContainer.ContainerID), helpers.String("k8s workload", watchedContainer.K8sContainerID))
-			return nil
+			// stop processing after storing filtered SBOM
+			watchedContainer.SyncChannel <- relevancymanager.IncompleteSBOMError
 		}
 	}
 

--- a/pkg/sbomhandler/v1/sbomhandler_test.go
+++ b/pkg/sbomhandler/v1/sbomhandler_test.go
@@ -27,7 +27,7 @@ func TestSBOMHandler_CountImageUse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			storageClient := storage.CreateSBOMStorageHttpClientMock()
+			storageClient := storage.CreateSBOMStorageHttpClientMock("nginx-spdx-format-mock.json")
 			sc := CreateSBOMHandler(storageClient)
 			sc.IncrementImageUse(tt.args.imageID)
 			assert.Equal(t, 1, storageClient.ImageCounters[tt.args.imageID])
@@ -48,7 +48,7 @@ func TestSBOMHandler_FilterSBOM(t *testing.T) {
 		sbomFileRelevantMap map[string]bool
 	}
 	instanceID, _ := instanceidhandler.GenerateInstanceIDFromString("apiVersion-v1/namespace-aaa/kind-deployment/name-redis/containerName-redis")
-	storageClient := storage.CreateSBOMStorageHttpClientMock()
+	storageClient := storage.CreateSBOMStorageHttpClientMock("nginx-spdx-format-mock.json")
 	tests := []struct {
 		name   string
 		fields fields

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -23,9 +23,9 @@ type StorageHttpClientMock struct {
 
 var _ StorageClient = (*StorageHttpClientMock)(nil)
 
-func CreateSBOMStorageHttpClientMock() *StorageHttpClientMock {
+func CreateSBOMStorageHttpClientMock(sbom string) *StorageHttpClientMock {
 	var data spdxv1beta1.SBOMSPDXv2p3
-	nginxSBOMPath := path.Join(utils.CurrentDir(), "testdata", "nginx-spdx-format-mock.json")
+	nginxSBOMPath := path.Join(utils.CurrentDir(), "testdata", sbom)
 	bytes, err := os.ReadFile(nginxSBOMPath)
 	if err != nil {
 		return nil

--- a/pkg/storage/testdata/sbom-incomplete-mock.json
+++ b/pkg/storage/testdata/sbom-incomplete-mock.json
@@ -6,7 +6,8 @@
         "annotations": {
             "kubescape.io/image-id": "quay.io/kubescape/kubevuln@sha256:0a992168e92055d1905c34d1e11cb7d3f0847759998458443561bd0a4d60b4e2",
             "kubescape.io/status": "incomplete"
-        }
+        },
+        "resourceVersion": "1"
     },
     "spec": {
         "spdx": {


### PR DESCRIPTION
## PR Type:
Refactoring, Enhancement

___
## PR Description:
This PR introduces changes to handle incomplete Software Bill of Materials (SBOMs) in the Relevancy Manager. It includes the creation of new error types for container termination and incomplete SBOMs, and the modification of existing functions to handle these errors. Additionally, it includes tests for the new functionality and updates to the mock storage client to support testing.

___
## PR Main Files Walkthrough:
`pkg/relevancymanager/relevancy_manager_interface.go`: Introduced two new error types: ContainerHasTerminatedError and IncompleteSBOMError.
`pkg/relevancymanager/v1/relevancy_manager.go`: Refactored error handling in the monitorContainer function to accommodate the new error types. Also, updated the ReportContainerTerminated function to use the new ContainerHasTerminatedError.
`pkg/relevancymanager/v1/relevancy_manager_test.go`: Updated the existing test to use the new mock storage client function. Added a new test to check the handling of incomplete SBOMs.
`pkg/sbomhandler/v1/sbomhandler.go`: Modified the FilterSBOM function to stop processing and send an IncompleteSBOMError when the SBOM is incomplete.
`pkg/sbomhandler/v1/sbomhandler_test.go`: Updated the existing tests to use the new mock storage client function.
`pkg/storage/storage_mock.go`: Updated the CreateSBOMStorageHttpClientMock function to accept a SBOM file name as an argument, allowing for more flexible testing.
`pkg/storage/testdata/sbom-incomplete-mock.json`: Added a new mock SBOM file for testing the handling of incomplete SBOMs.
