### PR TITLE
unittest: not creating a new filtered SBOM when reporting known files

### DIFF
--- a/pkg/relevancymanager/v1/relevancy_manager_test.go
+++ b/pkg/relevancymanager/v1/relevancy_manager_test.go
@@ -77,8 +77,12 @@ func TestRelevancyManager(t *testing.T) {
 		relevancyManager.ReportFileAccess(ctx, "ns", "pod", "cont", file)
 	}
 	// let it run for a while
-	time.Sleep(10 * time.Second)
-	// verify files are reported
+	time.Sleep(5 * time.Second)
+	// report a same file again, should do noop
+	relevancyManager.ReportFileAccess(ctx, "ns", "pod", "cont", "/usr/sbin/deluser")
+	// let it run for a while
+	time.Sleep(5 * time.Second)
+	// verify files are reported and we have only 1 filtered SBOM
 	assert.NotNil(t, storageClient.FilteredSBOMs)
 	assert.Equal(t, 1, len(storageClient.FilteredSBOMs))
 	assert.Equal(t, 1, len(storageClient.FilteredSBOMs[0].Spec.SPDX.Files))


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR enhances the unit test for the Relevancy Manager in the `relevancy_manager_test.go` file. The changes include reporting the same file again to check if it results in a no-operation, and verifying that only one filtered SBOM is created even when the same file is reported multiple times.

___
## PR Main Files Walkthrough:
`pkg/relevancymanager/v1/relevancy_manager_test.go`: The sleep time has been reduced from 10 seconds to 5 seconds. A file access report has been added for the same file, and another sleep period of 5 seconds has been added. The test now also checks that only one filtered SBOM is created even when the same file is reported again.
