### PR TITLE
Support non-default namespace

### DIFF
--- a/pkg/storage/v1/storage_test.go
+++ b/pkg/storage/v1/storage_test.go
@@ -60,7 +60,7 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 			want: &v1beta1.SBOMSPDXv2p3{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      storage.NginxKey,
-					Namespace: KubescapeNamespace,
+					Namespace: defaultNamespace,
 				},
 			},
 		},
@@ -76,7 +76,7 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sc, _ := CreateFakeStorageNoCache()
 			if tt.createSBOM {
-				_, _ = sc.StorageClient.SBOMSPDXv2p3s(KubescapeNamespace).Create(context.Background(), tt.want, v1.CreateOptions{})
+				_, _ = sc.StorageClient.SBOMSPDXv2p3s(defaultNamespace).Create(context.Background(), tt.want, v1.CreateOptions{})
 			}
 			got, err := sc.GetSBOM(tt.args.name)
 			if (err != nil) != tt.wantErr {
@@ -120,11 +120,11 @@ func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
 					Name: tt.args.name,
 				},
 			}
-			_, _ = sc.StorageClient.SBOMSPDXv2p3Filtereds(KubescapeNamespace).Create(context.Background(), filteredSBOM, v1.CreateOptions{})
+			_, _ = sc.StorageClient.SBOMSPDXv2p3Filtereds(defaultNamespace).Create(context.Background(), filteredSBOM, v1.CreateOptions{})
 			if err := sc.PatchFilteredSBOM(tt.args.name, tt.args.SBOM); (err != nil) != tt.wantErr {
 				t.Errorf("PatchFilteredSBOM() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			got, err := sc.StorageClient.SBOMSPDXv2p3Filtereds(KubescapeNamespace).Get(context.Background(), tt.args.name, v1.GetOptions{})
+			got, err := sc.StorageClient.SBOMSPDXv2p3Filtereds(defaultNamespace).Get(context.Background(), tt.args.name, v1.GetOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(got.Spec.SPDX.Files))
 		})


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the ability to use a non-default namespace in Kubescape by setting an environment variable. Previously, the namespace was hardcoded to "kubescape", but now it can be customized. If no namespace is specified through the environment variable, it defaults to "kubescape".

___
## PR Main Files Walkthrough:
`pkg/storage/v1/storage_nocache.go`: Introduced a new variable 'namespace' in the StorageNoCache struct. Added a function 'getNamespace' to fetch the namespace from the environment variable "NAMESPACE". If the environment variable is not set, it defaults to "kubescape". Updated the namespace in CreateFilteredSBOM, GetSBOM, and PatchFilteredSBOM methods to use the new 'namespace' variable instead of the hardcoded "kubescape".
`pkg/storage/v1/storage_test.go`: Updated the namespace in the test cases to use 'defaultNamespace' instead of the hardcoded "kubescape".

___
## User Description:
## Overview

Support non default "kubescape" namespace by env var
