### PR TITLE
add top level permissions: read-all for openssf

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -1,11 +1,12 @@
 name: pull_request_created
+add top level permissions: read-all for openssf
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    branches: 
+    branches:
       - 'main'
     paths-ignore:
-      - '*.md' 
+      - '*.md'
       - '*.yaml'
       - '.github/workflows/*'
 

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -1,16 +1,17 @@
 name: build
+add top level permissions: read-all for openssf
 on:
   pull_request_target:
     types: [closed]
-    branches: 
+    branches:
     - 'main'
     paths-ignore:
       - '**.md' ### Ignore running when README.MD changed.
       - '.github/workflows/*' ### Ignore running when files under path: .github/workflows/* changed.
-      
+
 jobs:
   pr-merged:
-    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged 
+    if: ${{ github.event.pull_request.merged == true }} ## Skip if not merged
     uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@main
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/node-agent


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new top-level permission, 'read-all', for the openssf organization. This permission has been added to both the 'pr-created' and 'pr-merged' GitHub workflows.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`.github/workflows/pr-created.yaml`: Added a new top-level permission 'read-all' for openssf. Some formatting changes have also been made.
`.github/workflows/pr-merged.yaml`: Added a new top-level permission 'read-all' for openssf. Some formatting changes have also been made.
</details>
