### PR TITLE
docs: add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## NodeAgent
+# Node-Agent
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kubescape/node-agent/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kubescape/node-agent)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkubescape%2Fsniffer.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkubescape%2Fsniffer?ref=badge_shield&issueType=license)
 
@@ -15,12 +15,14 @@ sudo SNIFFER_CONFIG=./configuration/SnifferConfigurationFile.json ./sniffer
 ```
 
 ## Limitations:
+
 1. This feature is using EBPF technology that is implemented only on linux.
 2. the linux kernel version that supported it 5.4 and above.
 
-
 ## Debugging
-# file for vscode:
+
+### file for vscode:
+
 ```
 {
     // Use IntelliSense to learn about possible attributes.
@@ -42,8 +44,19 @@ sudo SNIFFER_CONFIG=./configuration/SnifferConfigurationFile.json ./sniffer
         }
     ]
 }
-
 ```
+## Troubleshooting
+
+```json
+{"level":"fatal", "msg":"error starting the container watcher", "error":"failed to initialize container collection: starting runc fanotify: no runc instance can be monitored with fanotify. The following paths were tested: /bin/runc,/usr/bin/runc,/usr/sbin/runc,/usr/local/bin/runc,/usr/local/sbin/runc,/usr/lib/cri-o-runc/sbin/runc,/run/torcx/unpack/docker/bin/runc,/usr/bin/crun. You can use the RUNC_PATH env variable to specify a custom path. If you are succesful doing so, please open a PR to add your custom path to runcPaths\n"}
+```
+
+In case you read this error from the `node-agent` logs, you can solve by re-install the **helm-chart** with the following parameters, replacing the `</path/to/your/runc>` with your own path:
+
+```shell
+--set nodeAgent.env[0].name=RUNC_PATH,nodeAgent.env[0].value=</path/to/your/runc>
+```
+
 ## Changelog
 
 Kubescape Node-agent changes are tracked on the [release](https://github.com/kubescape/node-agent/releases) page


### PR DESCRIPTION
## PR Type:
Documentation

___
## PR Description:
This PR introduces a new troubleshooting section in the README file to address a known issue related to the missing `runc` binary. It also includes minor adjustments to the README, such as changing the title from 'NodeAgent' to 'Node-Agent' and adding some formatting changes for better readability.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`README.md`: The README.md file has been updated with a new troubleshooting section that provides a solution for a known issue related to the missing `runc` binary. The solution involves reinstalling the helm-chart with specific parameters. Additionally, the title has been changed from 'NodeAgent' to 'Node-Agent' and some formatting changes have been made for better readability.
</details>

___
## User Description:
## Overview

This PR provides a troubleshooting section to solve a well know issue of the missing `runc` binary.

Thanks to @GibliX for reporting this.

## Examples/Screenshots

> Here you add related screenshots 

![image](https://github.com/kubescape/node-agent/assets/16689706/010d8973-16b8-4fd6-b167-1f24c6306356)

## Related issues/PRs:

Closes #138 

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes
