### PR TITLE
Get namespace from config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// Create clients
 	k8sClient := k8sinterface.NewKubernetesApi()
-	storageClient, err := storage.CreateStorageNoCache()
+	storageClient, err := storage.CreateStorageNoCache(clusterData.Namespace)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("error creating the storage client", helpers.Error(err))
 	}

--- a/pkg/storage/v1/storage_nocache.go
+++ b/pkg/storage/v1/storage_nocache.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	KubeConfig       = "KUBECONFIG"
-	defaultNamespace = "kubescape"
+	KubeConfig = "KUBECONFIG"
 )
 
 type StorageNoCache struct {
@@ -29,7 +28,7 @@ type StorageNoCache struct {
 
 var _ storage.StorageClient = (*StorageNoCache)(nil)
 
-func CreateStorageNoCache() (*StorageNoCache, error) {
+func CreateStorageNoCache(defaultNamespace string) (*StorageNoCache, error) {
 	var config *rest.Config
 	kubeconfig := os.Getenv(KubeConfig)
 	// use the current context in kubeconfig
@@ -48,22 +47,15 @@ func CreateStorageNoCache() (*StorageNoCache, error) {
 
 	return &StorageNoCache{
 		StorageClient: clientset.SpdxV1beta1(),
-		namespace:     getNamespace(),
+		namespace:     defaultNamespace,
 	}, nil
 }
 
-func CreateFakeStorageNoCache() (*StorageNoCache, error) {
+func CreateFakeStorageNoCache(defaultNamespace string) (*StorageNoCache, error) {
 	return &StorageNoCache{
 		StorageClient: fake.NewSimpleClientset().SpdxV1beta1(),
-		namespace:     getNamespace(),
+		namespace:     defaultNamespace,
 	}, nil
-}
-
-func getNamespace() string {
-	if ns, ok := os.LookupEnv("NAMESPACE"); ok {
-		return ns
-	}
-	return defaultNamespace
 }
 
 func (sc StorageNoCache) CreateApplicationActivity(activity *v1beta1.ApplicationActivity, namespace string) error {

--- a/pkg/storage/v1/storage_nocache.go
+++ b/pkg/storage/v1/storage_nocache.go
@@ -28,7 +28,7 @@ type StorageNoCache struct {
 
 var _ storage.StorageClient = (*StorageNoCache)(nil)
 
-func CreateStorageNoCache(defaultNamespace string) (*StorageNoCache, error) {
+func CreateStorageNoCache(namespace string) (*StorageNoCache, error) {
 	var config *rest.Config
 	kubeconfig := os.Getenv(KubeConfig)
 	// use the current context in kubeconfig
@@ -47,14 +47,14 @@ func CreateStorageNoCache(defaultNamespace string) (*StorageNoCache, error) {
 
 	return &StorageNoCache{
 		StorageClient: clientset.SpdxV1beta1(),
-		namespace:     defaultNamespace,
+		namespace:     namespace,
 	}, nil
 }
 
-func CreateFakeStorageNoCache(defaultNamespace string) (*StorageNoCache, error) {
+func CreateFakeStorageNoCache(namespace string) (*StorageNoCache, error) {
 	return &StorageNoCache{
 		StorageClient: fake.NewSimpleClientset().SpdxV1beta1(),
-		namespace:     defaultNamespace,
+		namespace:     namespace,
 	}, nil
 }
 

--- a/pkg/storage/v1/storage_test.go
+++ b/pkg/storage/v1/storage_test.go
@@ -32,7 +32,7 @@ func TestStorageNoCache_CreateFilteredSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache()
+			sc, _ := CreateFakeStorageNoCache("kubescape")
 			if err := sc.CreateFilteredSBOM(tt.args.SBOM); (err != nil) != tt.wantErr {
 				t.Errorf("CreateFilteredSBOM() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -114,7 +114,7 @@ func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache()
+			sc, _ := CreateFakeStorageNoCache("kubescape")
 			filteredSBOM := &v1beta1.SBOMSPDXv2p3Filtered{
 				ObjectMeta: v1.ObjectMeta{
 					Name: tt.args.name,

--- a/pkg/storage/v1/storage_test.go
+++ b/pkg/storage/v1/storage_test.go
@@ -60,7 +60,7 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 			want: &v1beta1.SBOMSPDXv2p3{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      storage.NginxKey,
-					Namespace: defaultNamespace,
+					Namespace: "kubescape",
 				},
 			},
 		},
@@ -74,9 +74,9 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache()
+			sc, _ := CreateFakeStorageNoCache("kubescape")
 			if tt.createSBOM {
-				_, _ = sc.StorageClient.SBOMSPDXv2p3s(defaultNamespace).Create(context.Background(), tt.want, v1.CreateOptions{})
+				_, _ = sc.StorageClient.SBOMSPDXv2p3s("kubescape").Create(context.Background(), tt.want, v1.CreateOptions{})
 			}
 			got, err := sc.GetSBOM(tt.args.name)
 			if (err != nil) != tt.wantErr {
@@ -120,11 +120,11 @@ func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
 					Name: tt.args.name,
 				},
 			}
-			_, _ = sc.StorageClient.SBOMSPDXv2p3Filtereds(defaultNamespace).Create(context.Background(), filteredSBOM, v1.CreateOptions{})
+			_, _ = sc.StorageClient.SBOMSPDXv2p3Filtereds("kubescape").Create(context.Background(), filteredSBOM, v1.CreateOptions{})
 			if err := sc.PatchFilteredSBOM(tt.args.name, tt.args.SBOM); (err != nil) != tt.wantErr {
 				t.Errorf("PatchFilteredSBOM() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			got, err := sc.StorageClient.SBOMSPDXv2p3Filtereds(defaultNamespace).Get(context.Background(), tt.args.name, v1.GetOptions{})
+			got, err := sc.StorageClient.SBOMSPDXv2p3Filtereds("kubescape").Get(context.Background(), tt.args.name, v1.GetOptions{})
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(got.Spec.SPDX.Files))
 		})


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This pull request refactors the way the namespace is retrieved from the configuration file. Instead of hardcoding the default namespace and using an environment variable, the namespace is now passed as an argument to the `CreateStorageNoCache` and `CreateFakeStorageNoCache` functions. This change improves the flexibility and maintainability of the code.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`main.go`: The namespace is now passed as an argument to the `CreateStorageNoCache` function.
`pkg/storage/v1/storage_nocache.go`: The `CreateStorageNoCache` and `CreateFakeStorageNoCache` functions now accept the namespace as an argument. The `getNamespace` function and the `defaultNamespace` constant have been removed.
`pkg/storage/v1/storage_test.go`: The tests have been updated to pass the namespace as an argument to the `CreateFakeStorageNoCache` function. The hardcoded namespace in the tests has been replaced with a string literal "kubescape".
</details>

___
## User Description:
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
