### PR TITLE
update applicationprofile type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/kubescape/backend v0.0.13
 	github.com/kubescape/go-logger v0.0.21
 	github.com/kubescape/k8s-interface v0.0.148
-	github.com/kubescape/storage v0.0.33
+	github.com/kubescape/storage v0.0.38
 	github.com/panjf2000/ants/v2 v2.8.1
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/kubescape/go-logger v0.0.21 h1:4ZRIEw3UGUH6BG/cH3yiqFipzQSfGAoCrxlsZu
 github.com/kubescape/go-logger v0.0.21/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
 github.com/kubescape/k8s-interface v0.0.148 h1:vtXDUjvCow5wMdDvb5c/Td9SpafeRqsV/LnOd0NVVsE=
 github.com/kubescape/k8s-interface v0.0.148/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
-github.com/kubescape/storage v0.0.33 h1:CAD2A6cO1mekX6ecOGYrHfY5HMOZWm3uzoxSTafqxgs=
-github.com/kubescape/storage v0.0.33/go.mod h1:ObCIVOnVyWwRwU0iuKTzOnrJQScqPgkw0FgvSINwosY=
+github.com/kubescape/storage v0.0.38 h1:LR+QTqjeYw4kM1repIltDLDQGqHgKmG196lQyHP+xUw=
+github.com/kubescape/storage v0.0.38/go.mod h1:ObCIVOnVyWwRwU0iuKTzOnrJQScqPgkw0FgvSINwosY=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Create the application profile manager
 	var applicationProfileManager applicationprofilemanager.ApplicationProfileManagerClient
 	if cfg.EnableApplicationProfile {
-		applicationProfileManager, err = applicationprofilemanagerv1.CreateApplicationProfileManager(ctx, cfg, k8sClient, storageClient)
+		applicationProfileManager, err = applicationprofilemanagerv1.CreateApplicationProfileManager(ctx, cfg, clusterData.ClusterName, k8sClient, storageClient)
 		if err != nil {
 			logger.L().Ctx(ctx).Fatal("error creating the application profile manager", helpers.Error(err))
 		}

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -181,13 +181,10 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		ObjectMeta: metav1.ObjectMeta{
 			Name: slug,
 			Annotations: map[string]string{
-				instanceidhandler.WlidMetadataKey:          watchedContainer.Wlid,
-				instanceidhandler.InstanceIDMetadataKey:    watchedContainer.InstanceID.GetStringFormatted(),
-				instanceidhandler.ContainerNameMetadataKey: watchedContainer.InstanceID.GetContainerName(),
-				instanceidhandler.ImageIDMetadataKey:       watchedContainer.ImageID,
-				instanceidhandler.StatusMetadataKey:        "",
+				instanceidhandler.WlidMetadataKey:   watchedContainer.Wlid,
+				instanceidhandler.StatusMetadataKey: "",
 			},
-			Labels: utils.GetLabels(watchedContainer),
+			Labels: utils.GetLabels(watchedContainer, true),
 		},
 	}
 	// add syscalls
@@ -229,16 +226,15 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		ObjectMeta: metav1.ObjectMeta{
 			Name: slug,
 			Annotations: map[string]string{
-				instanceidhandler.WlidMetadataKey:          watchedContainer.Wlid,
-				instanceidhandler.InstanceIDMetadataKey:    watchedContainer.InstanceID.GetStringFormatted(),
-				instanceidhandler.ContainerNameMetadataKey: watchedContainer.InstanceID.GetContainerName(),
-				instanceidhandler.ImageIDMetadataKey:       watchedContainer.ImageID,
-				instanceidhandler.StatusMetadataKey:        "",
+				instanceidhandler.WlidMetadataKey:   watchedContainer.Wlid,
+				instanceidhandler.StatusMetadataKey: "",
 			},
-			Labels: utils.GetLabels(watchedContainer),
+			Labels: utils.GetLabels(watchedContainer, true),
 		},
 	}
-	newProfileContainer := v1beta1.ApplicationProfileContainer{}
+	newProfileContainer := v1beta1.ApplicationProfileContainer{
+		Name: watchedContainer.InstanceID.GetContainerName(),
+	}
 	// add capabilities
 	newProfileContainer.Capabilities = capabilities.ToSlice()
 	sort.Strings(newProfileContainer.Capabilities)

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -69,9 +69,9 @@ func TestApplicationProfileManager(t *testing.T) {
 	sort.Strings(storageClient.ApplicationActivities[0].Spec.Syscalls)
 	assert.Equal(t, []string{"dup", "listen", "open"}, storageClient.ApplicationActivities[0].Spec.Syscalls)
 	assert.Equal(t, 2, len(storageClient.ApplicationProfiles))
-	sort.Strings(storageClient.ApplicationProfiles[0].Spec.Capabilities)
-	assert.Equal(t, []string{"NET_BIND_SERVICE", "NET_BROADCAST"}, storageClient.ApplicationProfiles[0].Spec.Capabilities)
-	assert.Equal(t, []v1beta1.ExecCalls{{Path: "/bin/bash", Args: []string{"-c", "ls"}, Envs: []string(nil)}}, storageClient.ApplicationProfiles[0].Spec.Execs)
-	assert.Equal(t, []v1beta1.OpenCalls{{Path: "/etc/passwd", Flags: []string{"O_RDONLY"}}}, storageClient.ApplicationProfiles[0].Spec.Opens)
+	sort.Strings(storageClient.ApplicationProfiles[0].Spec.Containers[0].Capabilities)
+	assert.Equal(t, []string{"NET_BIND_SERVICE", "NET_BROADCAST"}, storageClient.ApplicationProfiles[0].Spec.Containers[1].Capabilities)
+	assert.Equal(t, []v1beta1.ExecCalls{{Path: "/bin/bash", Args: []string{"-c", "ls"}, Envs: []string(nil)}}, storageClient.ApplicationProfiles[0].Spec.Containers[1].Execs)
+	assert.Equal(t, []v1beta1.OpenCalls{{Path: "/etc/passwd", Flags: []string{"O_RDONLY"}}}, storageClient.ApplicationProfiles[0].Spec.Containers[1].Opens)
 	assert.Equal(t, 2, len(storageClient.ApplicationProfileSummaries))
 }

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -24,7 +24,7 @@ func TestApplicationProfileManager(t *testing.T) {
 	ctx := context.TODO()
 	k8sClient := &k8sclient.K8sClientMock{}
 	storageClient := &storage.StorageHttpClientMock{}
-	am, err := CreateApplicationProfileManager(ctx, cfg, k8sClient, storageClient)
+	am, err := CreateApplicationProfileManager(ctx, cfg, "cluster", k8sClient, storageClient)
 	assert.NoError(t, err)
 	// report container started
 	container := &containercollection.Container{

--- a/pkg/k8sclient/k8sclient_mock.go
+++ b/pkg/k8sclient/k8sclient_mock.go
@@ -22,6 +22,10 @@ func (k K8sClientMock) GetWorkload(namespace, _, name string) (k8sinterface.IWor
 		"spec": map[string]interface{}{
 			"containers": []interface{}{
 				map[string]interface{}{
+					"name":  "log",
+					"image": "fluentbit",
+				},
+				map[string]interface{}{
 					"name":  "cont",
 					"image": "nginx",
 				},

--- a/pkg/sbomhandler/v1/sbomhandler.go
+++ b/pkg/sbomhandler/v1/sbomhandler.go
@@ -76,7 +76,7 @@ func (sc *SBOMHandler) FilterSBOM(watchedContainer *utils.WatchedContainerData, 
 					instanceidhandler.ImageIDMetadataKey:       watchedContainer.ImageID,
 					instanceidhandler.StatusMetadataKey:        "",
 				},
-				Labels: utils.GetLabels(watchedContainer),
+				Labels: utils.GetLabels(watchedContainer, false),
 			},
 		}
 	}

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -37,7 +37,10 @@ func (sc *StorageHttpClientMock) GetApplicationActivity(_, _ string) (*spdxv1bet
 func (sc *StorageHttpClientMock) GetApplicationProfile(_, _ string) (*spdxv1beta1.ApplicationProfile, error) {
 	return &spdxv1beta1.ApplicationProfile{
 		Spec: spdxv1beta1.ApplicationProfileSpec{
-			Capabilities: []string{"NET_BROADCAST"},
+			Containers: []spdxv1beta1.ApplicationProfileContainer{
+				{Capabilities: []string{"SYS_ADMIN"}},
+				{Capabilities: []string{"NET_BROADCAST"}},
+			},
 		},
 	}, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -112,10 +112,12 @@ func Atoi(s string) int {
 	return i
 }
 
-func GetLabels(watchedContainer *WatchedContainerData) map[string]string {
+func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[string]string {
 	labels := watchedContainer.InstanceID.GetLabels()
 	for i := range labels {
 		if labels[i] == "" {
+			delete(labels, i)
+		} else if stripContainer && i == instanceidhandler2.ContainerNameMetadataKey {
 			delete(labels, i)
 		} else {
 			if i == instanceidhandler2.KindMetadataKey {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,8 +28,19 @@ type PackageSourceInfoData struct {
 	PackageSPDXIdentifier []v1beta1.ElementID
 }
 
+type ContainerType int
+
+const (
+	Unknown = iota
+	Container
+	InitContainer
+	EphemeralContainer
+)
+
 type WatchedContainerData struct {
 	ContainerID                              string
+	ContainerIndex                           int
+	ContainerType                            ContainerType
 	FilteredSpdxData                         *v1beta1.SBOMSPDXv2p3Filtered
 	ImageID                                  string
 	ImageTag                                 string
@@ -123,4 +134,33 @@ func GetLabels(watchedContainer *WatchedContainerData) map[string]string {
 		}
 	}
 	return labels
+}
+
+func GetApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) v1beta1.ApplicationProfileContainer {
+	switch containerType {
+	case Container:
+		if len(profile.Spec.Containers) > containerIndex {
+			return profile.Spec.Containers[containerIndex]
+		}
+	case InitContainer:
+		if len(profile.Spec.InitContainers) > containerIndex {
+			return profile.Spec.InitContainers[containerIndex]
+		}
+	}
+	return v1beta1.ApplicationProfileContainer{}
+}
+
+func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int, profileContainer v1beta1.ApplicationProfileContainer) {
+	switch containerType {
+	case Container:
+		if len(profile.Spec.Containers) <= containerIndex {
+			profile.Spec.Containers = append(profile.Spec.Containers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.Containers)+1)...)
+		}
+		profile.Spec.Containers[containerIndex] = profileContainer
+	case InitContainer:
+		if len(profile.Spec.InitContainers) <= containerIndex {
+			profile.Spec.InitContainers = append(profile.Spec.InitContainers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.InitContainers)+1)...)
+		}
+		profile.Spec.InitContainers[containerIndex] = profileContainer
+	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -138,31 +138,34 @@ func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[
 	return labels
 }
 
-func GetApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) v1beta1.ApplicationProfileContainer {
+func GetApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) *v1beta1.ApplicationProfileContainer {
+	if profile == nil {
+		return nil
+	}
 	switch containerType {
 	case Container:
 		if len(profile.Spec.Containers) > containerIndex {
-			return profile.Spec.Containers[containerIndex]
+			return &profile.Spec.Containers[containerIndex]
 		}
 	case InitContainer:
 		if len(profile.Spec.InitContainers) > containerIndex {
-			return profile.Spec.InitContainers[containerIndex]
+			return &profile.Spec.InitContainers[containerIndex]
 		}
 	}
-	return v1beta1.ApplicationProfileContainer{}
+	return nil
 }
 
-func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int, profileContainer v1beta1.ApplicationProfileContainer) {
+func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int, profileContainer *v1beta1.ApplicationProfileContainer) {
 	switch containerType {
 	case Container:
 		if len(profile.Spec.Containers) <= containerIndex {
 			profile.Spec.Containers = append(profile.Spec.Containers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.Containers)+1)...)
 		}
-		profile.Spec.Containers[containerIndex] = profileContainer
+		profile.Spec.Containers[containerIndex] = *profileContainer
 	case InitContainer:
 		if len(profile.Spec.InitContainers) <= containerIndex {
 			profile.Spec.InitContainers = append(profile.Spec.InitContainers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.InitContainers)+1)...)
 		}
-		profile.Spec.InitContainers[containerIndex] = profileContainer
+		profile.Spec.InitContainers[containerIndex] = *profileContainer
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -173,6 +173,7 @@ func TestAtoi(t *testing.T) {
 func Test_GetLabels(t *testing.T) {
 	type args struct {
 		watchedContainer *WatchedContainerData
+		stripContainer   bool
 	}
 	instanceID, _ := instanceidhandler.GenerateInstanceIDFromString("apiVersion-v1/namespace-aaa/kind-deployment/name-redis/containerName-redis")
 	tests := []struct {
@@ -196,10 +197,26 @@ func Test_GetLabels(t *testing.T) {
 				"kubescape.io/workload-namespace":      "aaa",
 			},
 		},
+		{
+			name: "TestGetLabels",
+			args: args{
+				watchedContainer: &WatchedContainerData{
+					InstanceID: instanceID,
+					Wlid:       "wlid://cluster-name/namespace-aaa/deployment-redis",
+				},
+				stripContainer: true,
+			},
+			want: map[string]string{
+				"kubescape.io/workload-api-version": "v1",
+				"kubescape.io/workload-kind":        "Deployment",
+				"kubescape.io/workload-name":        "redis",
+				"kubescape.io/workload-namespace":   "aaa",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetLabels(tt.args.watchedContainer)
+			got := GetLabels(tt.args.watchedContainer, tt.args.stripContainer)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces several enhancements to the Application Profile Manager:
- Adds support for Workload ID (WLID) to application profile objects.
- Incorporates the cluster name into the Application Profile Manager.
- Adds container type and index to the WatchedContainerData structure.
- Modifies the application profile saving process to accommodate the new container type and index.
- Updates the application profile manager tests to reflect these changes.
- Updates the storage package version in go.mod.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `main.go`: The cluster name is now passed as an argument when creating the Application Profile Manager.
- `pkg/applicationprofilemanager/v1/applicationprofile_manager.go`: The Application Profile Manager structure now includes a cluster name. The CreateApplicationProfileManager function has been updated to accept the cluster name as an argument. Additional logic has been added to calculate and validate the WLID, find the container type and index, and save the application profile accordingly.
- `pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go`: The test for the Application Profile Manager has been updated to pass the cluster name as an argument when creating the Application Profile Manager.
- `pkg/k8sclient/k8sclient_mock.go`: A new container with the name "log" and image "fluentbit" has been added to the mock workload.
- `pkg/storage/storage_mock.go`: The mock Application Profile now includes a list of containers, each with its own capabilities.
- `pkg/utils/utils.go`: The WatchedContainerData structure now includes a container type and index. New functions have been added to get and insert an Application Profile Container based on the container type and index.
- `go.mod`: The version of the storage package has been updated from v0.0.33 to v0.0.38.
</details>
