### PR TITLE
use arm64 fix merged upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/google/uuid v1.4.0
 	github.com/goradd/maps v0.1.5
-	github.com/inspektor-gadget/inspektor-gadget v0.21.0
+	github.com/inspektor-gadget/inspektor-gadget v0.22.1-0.20231128180916-c54d8a4b979c
 	github.com/kinbiko/jsonassert v1.1.1
 	github.com/kubescape/backend v0.0.13
 	github.com/kubescape/go-logger v0.0.21
@@ -176,7 +176,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20231128122238-ce3af6eccf0a
 
 replace github.com/vishvananda/netns => github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/inspektor-gadget/inspektor-gadget v0.22.1-0.20231128180916-c54d8a4b979c h1:B7lr1ZLFiBCtnMFEQyGSiFVJ0J4/A8OZThwWGN0tbNU=
+github.com/inspektor-gadget/inspektor-gadget v0.22.1-0.20231128180916-c54d8a4b979c/go.mod h1:LElJGW/d8vPV4UcDkDnXG+YnCt9AWDSvJl2AgJbUXV4=
 github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6 h1:fQqkJ+WkYfzy6BoUh32fr9uYrXfOGtsfw0skMQkfOic=
 github.com/inspektor-gadget/netns v0.0.5-0.20230524185006-155d84c555d6/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
@@ -326,8 +328,6 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/matthyx/inspektor-gadget v0.0.0-20231128122238-ce3af6eccf0a h1:DPu3tD5DwWlbhg0rGqb63TxLVvl+wMWcLOERcYSMYyY=
-github.com/matthyx/inspektor-gadget v0.0.0-20231128122238-ce3af6eccf0a/go.mod h1:LElJGW/d8vPV4UcDkDnXG+YnCt9AWDSvJl2AgJbUXV4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=


### PR DESCRIPTION
## type:
enhancement

___
## description:
This PR updates the inspektor-gadget dependency from v0.21.0 to v0.22.1. The previous replace directive for inspektor-gadget with a forked version has been removed. The changes are reflected in both go.mod and go.sum files.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `go.mod`: Updated the version of inspektor-gadget from v0.21.0 to v0.22.1. Removed the replace directive for inspektor-gadget.
- `go.sum`: Updated the checksums for the new version of inspektor-gadget. Removed the checksums for the previously replaced version.
</details>
