### PR TITLE
use cronjob labels

### DIFF
--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -162,29 +162,11 @@ func (am *NetworkManager) handleContainerStarted(ctx context.Context, container 
 		return
 	}
 
-	var selector *metav1.LabelSelector
-	if parentWL.GetKind() == "CronJob" {
-		obj := parentWL.GetObject()
-		jsonBytes, err := json.Marshal(obj)
-		if err != nil {
-			logger.L().Warning("NetworkManager - failed to marshal cronjob", helpers.String("reason", err.Error()), helpers.String("container ID", container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
-			return
-		}
-		var cronjob k8sv1beta1.CronJob
-		if err = json.Unmarshal(jsonBytes, &cronjob); err != nil {
-			logger.L().Warning("NetworkManager - failed to unmarshal cronjob", helpers.String("reason", err.Error()), helpers.String("container ID", container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
-			return
-		}
-		selector = &metav1.LabelSelector{
-			MatchLabels: cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta.Labels,
-		}
-	} else {
-		selector, err = parentWL.GetSelector()
-		if err != nil {
-			// if we get not selector, we can't create/update network neighbor
-			logger.L().Warning("NetworkManager - failed to get selector", helpers.String("reason", err.Error()), helpers.String("container ID", container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
-			return
-		}
+	selector, err := getSelectorFromWorkload(parentWL)
+	if err != nil {
+		// if we get not selector, we can't create/update network neighbor
+		logger.L().Warning("NetworkManager - failed to get selector", helpers.String("reason", err.Error()), helpers.String("container ID", container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
+		return
 	}
 
 	if selector == nil {
@@ -224,6 +206,30 @@ func (am *NetworkManager) handleContainerStarted(ctx context.Context, container 
 	}
 
 	am.deleteResources(container)
+}
+
+func getSelectorFromWorkload(parentWL k8sinterface.IWorkload) (*metav1.LabelSelector, error) {
+	if parentWL.GetKind() == "CronJob" {
+		obj := parentWL.GetObject()
+		jsonBytes, err := json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		var cronjob k8sv1beta1.CronJob
+		if err = json.Unmarshal(jsonBytes, &cronjob); err != nil {
+			return nil, err
+		}
+		selector := &metav1.LabelSelector{
+			MatchLabels: cronjob.Spec.JobTemplate.Spec.Template.ObjectMeta.Labels,
+		}
+		return selector, nil
+	}
+
+	selector, err := parentWL.GetSelector()
+	if err != nil {
+		return nil, err
+	}
+	return selector, nil
 }
 
 // TODO: use same function in relevancy

--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -208,9 +208,9 @@ func (am *NetworkManager) handleContainerStarted(ctx context.Context, container 
 	am.deleteResources(container)
 }
 
-func getSelectorFromWorkload(parentWL k8sinterface.IWorkload) (*metav1.LabelSelector, error) {
-	if parentWL.GetKind() == "CronJob" {
-		obj := parentWL.GetObject()
+func getSelectorFromWorkload(workload k8sinterface.IWorkload) (*metav1.LabelSelector, error) {
+	if workload.GetKind() == "CronJob" {
+		obj := workload.GetObject()
 		jsonBytes, err := json.Marshal(obj)
 		if err != nil {
 			return nil, err
@@ -225,7 +225,7 @@ func getSelectorFromWorkload(parentWL k8sinterface.IWorkload) (*metav1.LabelSele
 		return selector, nil
 	}
 
-	selector, err := parentWL.GetSelector()
+	selector, err := workload.GetSelector()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkmanager/network_neighbors_test.go
+++ b/pkg/networkmanager/network_neighbors_test.go
@@ -12,6 +12,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+//go:embed testdata/cronjob.json
+var cronjobJson []byte
+
 //go:embed testdata/deployment.json
 var deploymentJson []byte
 

--- a/pkg/networkmanager/testdata/cronjob.json
+++ b/pkg/networkmanager/testdata/cronjob.json
@@ -1,0 +1,109 @@
+{
+    "apiVersion": "batch/v1",
+    "kind": "CronJob",
+    "metadata": {
+        "annotations": {
+            "meta.helm.sh/release-name": "kubescape",
+            "meta.helm.sh/release-namespace": "kubescape"
+        },
+        "creationTimestamp": "2023-12-03T16:02:57Z",
+        "generation": 1,
+        "labels": {
+            "app": "kubescape-scheduler",
+            "app.kubernetes.io/managed-by": "Helm",
+            "app.kubernetes.io/name": "kubescape-scheduler",
+            "armo.tier": "kubescape-scan",
+            "tier": "ks-control-plane"
+        },
+        "name": "kubescape-scheduler",
+        "namespace": "kubescape",
+        "resourceVersion": "71390981",
+        "uid": "4560b643-2667-4f20-9cb8-5d27fc4f42ae"
+    },
+    "spec": {
+        "concurrencyPolicy": "Allow",
+        "failedJobsHistoryLimit": 1,
+        "jobTemplate": {
+            "metadata": {
+                "creationTimestamp": null
+            },
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "kubescape-scheduler",
+                            "app.kubernetes.io/name": "kubescape-scheduler",
+                            "armo.tier": "kubescape-scan"
+                        }
+                    },
+                    "spec": {
+                        "automountServiceAccountToken": false,
+                        "containers": [
+                            {
+                                "args": [
+                                    "-method=post",
+                                    "-scheme=http",
+                                    "-host=operator:4002",
+                                    "-path=v1/triggerAction",
+                                    "-headers=\"Content-Type:application/json\"",
+                                    "-path-body=/home/ks/request-body.json"
+                                ],
+                                "image": "quay.io/kubescape/http-request:v0.0.14",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "kubescape-scheduler",
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "10m",
+                                        "memory": "20Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "1m",
+                                        "memory": "10Mi"
+                                    }
+                                },
+                                "securityContext": {
+                                    "allowPrivilegeEscalation": false,
+                                    "readOnlyRootFilesystem": true,
+                                    "runAsNonRoot": true,
+                                    "runAsUser": 100
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/home/ks/request-body.json",
+                                        "name": "kubescape-scheduler",
+                                        "readOnly": true,
+                                        "subPath": "request-body.json"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Never",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "configMap": {
+                                    "defaultMode": 420,
+                                    "name": "kubescape-scheduler"
+                                },
+                                "name": "kubescape-scheduler"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "schedule": "23 5 * * *",
+        "successfulJobsHistoryLimit": 3,
+        "suspend": false
+    },
+    "status": {
+        "lastScheduleTime": "2023-12-04T05:23:00Z",
+        "lastSuccessfulTime": "2023-12-04T05:23:16Z"
+    }
+}

--- a/pkg/networkmanager/testdata/deployment.json
+++ b/pkg/networkmanager/testdata/deployment.json
@@ -9,7 +9,8 @@
         "creationTimestamp": "2023-10-22T10:56:49Z",
         "generation": 1,
         "labels": {
-            "app": "nginx"
+            "app": "nginx",
+            "bla3": "blu3"
         },
         "name": "nginx-deployment",
         "namespace": "default",


### PR DESCRIPTION
## type:
bug_fix

___
## description:
This PR addresses an issue with the labels of `NetworkNeighbors` generated for `CronJobs`. Previously, the labels of the `CronJob` were used as the labels of the `NetworkNeighbors`, which could lead to incorrect policy enforcement, as the labels of the `Pod` generated by the `Job` may differ. The PR modifies this behavior to use the labels from the `podTemplate` inside the `jobSpec`, which will be present in the `Pods` generated by the `Job`.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `pkg/networkmanager/network_manager.go`: The changes in this file include a new condition to check if the parent workload is a `CronJob`. If it is, the labels from the `podTemplate` inside the `jobSpec` are used to create a new `LabelSelector`. If the parent workload is not a `CronJob`, the previous behavior is maintained. This change ensures that the correct labels are used for `NetworkNeighbors` in the case of `CronJobs`.
</details>

___
## User Description:
## Overview
This PR fixes the labels of `NetworkNeighbors` generated for `CronJobs`. Previously we were using the labels of the `CronJob` as the labels of the `NetworkNeighbors`, which will cause the policy to be not always correct, since the labels of the `Pod` generated by the `Job` may differ. Instead, we will take the labels from the `podTemplate` inside the `jobSpec`, which will be present at the `Pods` generated by the `Job`.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
