### PR TITLE
skip exec events with empty path

### DIFF
--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -356,6 +356,10 @@ func (am *ApplicationProfileManager) ReportCapability(k8sContainerID, capability
 }
 
 func (am *ApplicationProfileManager) ReportFileExec(k8sContainerID, path string, args []string) {
+	// skip empty path
+	if path == "" {
+		return
+	}
 	execMap := am.execSets.Get(k8sContainerID)
 	if execMap.Has(path) {
 		execMap.Get(path).Append(args...)

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -52,6 +52,7 @@ func TestApplicationProfileManager(t *testing.T) {
 	// report capability
 	am.ReportCapability("ns/pod/cont", "NET_BIND_SERVICE")
 	// report file exec
+	am.ReportFileExec("ns/pod/cont", "", []string{"ls"})
 	am.ReportFileExec("ns/pod/cont", "/bin/bash", []string{"-c", "ls"})
 	// report file open
 	am.ReportFileOpen("ns/pod/cont", "/etc/passwd", []string{"O_RDONLY"})


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR introduces a check to skip exec events with an empty path. This is a bug fix to prevent potential errors or unexpected behavior when an exec event with an empty path is reported. The changes include:
- A condition to return early from the `ReportFileExec` function in the `ApplicationProfileManager` if the path is empty.
- A corresponding test case to verify the correct behavior when an empty path is reported.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager.go<br><br>
        <strong>Added a condition to return early from the `ReportFileExec` <br>function if the path is empty.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/162/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e"> +4/-0</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go<br><br>
        <strong>Added a test case to verify the correct behavior when an <br>empty path is reported in the `ReportFileExec` function.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/162/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>