### PR TITLE
avoid race condition between container start and activity reporting

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"github.com/goradd/maps"
 	"math/rand"
 	"path/filepath"
 	"runtime"
@@ -171,5 +172,21 @@ func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, cont
 			profile.Spec.InitContainers = append(profile.Spec.InitContainers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.InitContainers)+1)...)
 		}
 		profile.Spec.InitContainers[containerIndex] = *profileContainer
+	}
+}
+
+// WaitGetSafeMap waits for a value to be loaded into a SafeMap, with a timeout of 1 minute
+func WaitGetSafeMap[K comparable, V any](m *maps.SafeMap[K, V], k K) (V, error) {
+	var tries int
+	for {
+		v, ok := m.Load(k)
+		if ok {
+			return v, nil
+		}
+		if tries > 60 {
+			return v, errors.New("timeout")
+		}
+		time.Sleep(1 * time.Second)
+		tries++
 	}
 }


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR addresses a race condition between container start and activity reporting. The main changes include:
- A new utility function `WaitGetSafeMap` has been added to safely retrieve the map for capabilities, execSets, and openSets.
- The `ReportCapability`, `ReportFileExec`, and `ReportFileOpen` functions in `applicationprofile_manager.go` have been updated to use `WaitGetSafeMap` and handle any errors it returns.
- The test in `applicationprofile_manager_test.go` has been updated to prepare the container before reporting capabilities, file execution, and file opening. These operations are also now run in goroutines to simulate concurrent execution.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager.go<br><br>

**The changes in this file are primarily focused on avoiding <br>race conditions between container start and activity <br>reporting. This is achieved by using a new utility function <br>`WaitGetSafeMap` to safely retrieve the map for <br>capabilities, execSets, and openSets. Error handling has <br>been added to return early if there is an error retrieving <br>the map.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/164/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e"> +13/-3</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go<br><br>

**The changes in this file are related to the testing of the <br>changes made in `applicationprofile_manager.go`. The changes <br>include modifying the order of operations to prepare the <br>container before reporting capabilities, file execution, and <br>file opening. The operations are also now run in goroutines <br>to simulate concurrent execution.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/164/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1"> +11/-10</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/utils/utils.go<br><br>

**A new utility function `WaitGetSafeMap` has been added. This <br>function waits for a value to be loaded into a SafeMap, with <br>a timeout of 1 minute. If the value is not loaded within the <br>timeout, it returns an error.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/164/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045"> +17/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>