### PR TITLE
Add TemplateHash label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kinbiko/jsonassert v1.1.1
 	github.com/kubescape/backend v0.0.16
 	github.com/kubescape/go-logger v0.0.22
-	github.com/kubescape/k8s-interface v0.0.152
+	github.com/kubescape/k8s-interface v0.0.154
 	github.com/kubescape/storage v0.0.39
 	github.com/panjf2000/ants/v2 v2.9.0
 	github.com/spf13/viper v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/kubescape/backend v0.0.16 h1:bkQGY39GSoNIeFfnAJ2zlcrGEyXk6LGYv1/MgS51
 github.com/kubescape/backend v0.0.16/go.mod h1:ug9NFmmxT4DcQx3sgdLRzlLPWMKGHE/fpbcYUm5G5Qo=
 github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil6JXHE=
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
-github.com/kubescape/k8s-interface v0.0.152 h1:1tm2zPYVK7+1fewpca0/MCoK3TgUNButpM3F3uZz6yo=
-github.com/kubescape/k8s-interface v0.0.152/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
+github.com/kubescape/k8s-interface v0.0.154 h1:D6TRgSBjbD/eTf2FKswSB9rdd9dsW2AQJL0RUm3NPH8=
+github.com/kubescape/k8s-interface v0.0.154/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
 github.com/kubescape/storage v0.0.39 h1:zxdu6pQ/8Fdzp0Er0yX+KWApMYvNZh9y7ONWyJcbb08=
 github.com/kubescape/storage v0.0.39/go.mod h1:ObCIVOnVyWwRwU0iuKTzOnrJQScqPgkw0FgvSINwosY=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -61,6 +61,10 @@ func (am *ApplicationProfileManager) ensureInstanceID(ctx context.Context, conta
 		return
 	}
 	pod := wl.(*workloadinterface.Workload)
+
+	// get pod template hash
+	watchedContainer.TemplateHash, _ = pod.GetLabel("pod-template-hash")
+
 	// find parentWlid
 	kind, name, err := am.k8sClient.CalculateWorkloadParentRecursive(pod)
 	if err != nil {

--- a/pkg/relevancymanager/v1/testdata/nginx-spdx-filtered.json
+++ b/pkg/relevancymanager/v1/testdata/nginx-spdx-filtered.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "name": "ns-pod-pod-cb3a-a929",
+    "name": "pod-pod",
     "creationTimestamp": null,
     "labels": {
       "kubescape.io/workload-api-version": "v1",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,13 +2,14 @@ package utils
 
 import (
 	"errors"
-	"github.com/goradd/maps"
 	"math/rand"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goradd/maps"
 
 	"github.com/armosec/utils-k8s-go/wlid"
 	"github.com/kubescape/go-logger"
@@ -39,23 +40,24 @@ const (
 )
 
 type WatchedContainerData struct {
-	ContainerID                              string
-	ContainerIndex                           int
-	ContainerType                            ContainerType
-	FilteredSpdxData                         *v1beta1.SBOMSPDXv2p3Filtered
-	ImageID                                  string
-	ImageTag                                 string
-	InitialDelayExpired                      bool
 	InstanceID                               instanceidhandler.IInstanceID
-	K8sContainerID                           string
-	ParentResourceVersion                    string
-	RelevantRealtimeFilesByPackageSourceInfo map[string]*PackageSourceInfoData
-	RelevantRealtimeFilesBySPDXIdentifier    map[v1beta1.ElementID]bool
-	SBOMResourceVersion                      int
-	SyncChannel                              chan error
 	UpdateDataTicker                         *time.Ticker
+	SyncChannel                              chan error
+	FilteredSpdxData                         *v1beta1.SBOMSPDXv2p3Filtered
+	RelevantRealtimeFilesBySPDXIdentifier    map[v1beta1.ElementID]bool
+	RelevantRealtimeFilesByPackageSourceInfo map[string]*PackageSourceInfoData
+	K8sContainerID                           string
+	ContainerID                              string
+	ParentResourceVersion                    string
+	ImageTag                                 string
+	ImageID                                  string
 	Wlid                                     string
+	TemplateHash                             string
+	SBOMResourceVersion                      int
+	ContainerType                            ContainerType
+	ContainerIndex                           int
 	NsMntId                                  uint64
+	InitialDelayExpired                      bool
 }
 
 func Between(value string, a string, b string) string {
@@ -139,6 +141,9 @@ func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[
 	}
 	if watchedContainer.ParentResourceVersion != "" {
 		labels[instanceidhandler2.ResourceVersionMetadataKey] = watchedContainer.ParentResourceVersion
+	}
+	if watchedContainer.TemplateHash != "" {
+		labels[instanceidhandler2.TemplateHashKey] = watchedContainer.TemplateHash
 	}
 	return labels
 }


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces several enhancements:
- It retrieves the pod template hash and assigns it to the `watchedContainer.TemplateHash` variable in `pkg/applicationprofilemanager/v1/applicationprofile_manager.go`.
- It handles the error if the workload parent calculation fails in `pkg/applicationprofilemanager/v1/applicationprofile_manager.go`.
- The structure of `WatchedContainerData` in `pkg/utils/utils.go` has been rearranged, and a new field `TemplateHash` has been added.
- The function `GetLabels` in `pkg/utils/utils.go` has been updated to include `TemplateHash` in the labels if it is not an empty string.
- The version of `github.com/kubescape/k8s-interface` has been updated from `v0.0.152` to `v0.0.154` in `go.mod` and `go.sum`.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager.go<br><br>

**The code retrieves the pod template hash and assigns it to <br>the `watchedContainer.TemplateHash` variable. Also, it <br>handles the error if the workload parent calculation fails.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/165/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e"> +4/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/utils/utils.go<br><br>

**The structure of `WatchedContainerData` has been rearranged, <br>and a new field `TemplateHash` has been added. The function <br>`GetLabels` has been updated to include `TemplateHash` in <br>the labels if it is not an empty string.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/165/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045"> +18/-13</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.mod<br><br>

**The version of `github.com/kubescape/k8s-interface` has been <br>updated from `v0.0.152` to `v0.0.154`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/165/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.sum<br><br>

**The checksums for `github.com/kubescape/k8s-interface` have <br>been updated to reflect the new version `v0.0.154`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/165/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63"> +2/-2</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
