### PR TITLE
add patching for applicationprofiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kubescape/backend v0.0.16
 	github.com/kubescape/go-logger v0.0.22
 	github.com/kubescape/k8s-interface v0.0.158-0.20240123155300-c2a152fdc0d8
-	github.com/kubescape/storage v0.0.59
+	github.com/kubescape/storage v0.0.61
 	github.com/panjf2000/ants/v2 v2.9.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
 github.com/kubescape/k8s-interface v0.0.158-0.20240123155300-c2a152fdc0d8 h1:1B73UU9XFPn0HtVwDHFIUg+Hw1RwTSsbKvwqhweoqtI=
 github.com/kubescape/k8s-interface v0.0.158-0.20240123155300-c2a152fdc0d8/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
-github.com/kubescape/storage v0.0.59 h1:Su7Rn0JxMCzo2DkMD/yRniivvYP1p3fbNhhUtuUKZdE=
-github.com/kubescape/storage v0.0.59/go.mod h1:I7LUpFfRwVeVphrB83cw4Hz+48sy3Qe6l5H2RDpD43A=
+github.com/kubescape/storage v0.0.61 h1:T6NIZP+80ILKLVOV9KFU/0OuH4unoLGXo4mO0zwv6/Q=
+github.com/kubescape/storage v0.0.61/go.mod h1:uMwudLhZCPgjf4JEbRSUZ20JmQJitLVrexZb7S1N4b0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=

--- a/pkg/storage/storage_interface.go
+++ b/pkg/storage/storage_interface.go
@@ -8,6 +8,7 @@ type StorageClient interface {
 	CreateApplicationActivity(activity *v1beta1.ApplicationActivity, namespace string) error
 	GetApplicationActivity(namespace, name string) (*v1beta1.ApplicationActivity, error)
 	CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error
+	PatchApplicationProfile(name, namespace string, profile *v1beta1.ApplicationProfile) error
 	GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error)
 	CreateApplicationProfileSummary(profile *v1beta1.ApplicationProfileSummary, namespace string) error
 	CreateFilteredSBOM(SBOM *v1beta1.SBOMSyftFiltered) error

--- a/pkg/storage/v1/storage_nocache.go
+++ b/pkg/storage/v1/storage_nocache.go
@@ -110,6 +110,18 @@ func (sc StorageNoCache) CreateApplicationProfile(profile *v1beta1.ApplicationPr
 	return nil
 }
 
+func (sc StorageNoCache) PatchApplicationProfile(name, namespace string, profile *v1beta1.ApplicationProfile) error {
+	bytes, err := json.Marshal(profile)
+	if err != nil {
+		return fmt.Errorf("marshal neighbors: %w", err)
+	}
+	_, err = sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.StrategicMergePatchType, bytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patch neighbors: %w", err)
+	}
+	return nil
+}
+
 func (sc StorageNoCache) GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error) {
 	return sc.StorageClient.ApplicationProfiles(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
This PR introduces patching for application profiles. The main changes include:
- Added new fields `savedCapabilities` and `savedSyscalls` to the `ApplicationProfileManager` struct in `pkg/applicationprofilemanager/v1/applicationprofile_manager.go`.
- Implemented saving new activities, updating profiles, and handling errors during these operations in `pkg/applicationprofilemanager/v1/applicationprofile_manager.go`.
- Added the `PatchApplicationProfile` method to the `StorageClient` interface in `pkg/storage/storage_interface.go`.
- Implemented the `PatchApplicationProfile` method in the `StorageNoCache` struct in `pkg/storage/v1/storage_nocache.go`.
- Added a mock for the `PatchApplicationProfile` method and updated the `CreateApplicationProfile` method to simulate a failure on the first call in `pkg/storage/storage_mock.go`.
- Added new test cases for the `PatchNetworkNeighbors` and `PatchApplicationProfile` methods in `pkg/storage/v1/storage_test.go`.
- Updated the `TestApplicationProfileManager` test case to accommodate the changes made in the `applicationprofile_manager.go` file in `pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go`.
- Updated the version of the `github.com/kubescape/storage` package in `go.sum` and `go.mod`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager.go<br><br>

**Added patching for application profiles. This includes <br>saving new activities, updating profiles, and handling <br>errors during these operations. Also, added new fields <br>`savedCapabilities` and `savedSyscalls` to the <br>`ApplicationProfileManager` struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e"> +65/-46</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_nocache.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/storage/v1/storage_nocache.go<br><br>

**Implemented the `PatchApplicationProfile` method in the <br>`StorageNoCache` struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-f3093b908b4dcb2e91a2c300f81311dd287f33199f7b7b90fd0de9c686f6a641"> +12/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_interface.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/storage/storage_interface.go<br><br>

**Added the `PatchApplicationProfile` method to the <br>`StorageClient` interface.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-10ca0067a9eb8643e8200cd9f92e44615fda1d2323abfcc2333c13620667d2d9"> +1/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/storage/v1/storage_test.go<br><br>

**Added new test cases for the `PatchNetworkNeighbors` and <br>`PatchApplicationProfile` methods.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-a3f74845de048f84a365723757b46f999a189c33fa27c48c5c0a1169bacdeabe"> +135/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go<br><br>

**Updated the `TestApplicationProfileManager` test case to <br>accommodate the changes made in the <br>`applicationprofile_manager.go` file.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1"> +15/-5</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_mock.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        pkg/storage/storage_mock.go<br><br>

**Added a mock for the `PatchApplicationProfile` method and <br>updated the `CreateApplicationProfile` method to simulate a <br>failure on the first call.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-46ba336587e6a6a63e35733ffff9449ccc4b58a4dae87718d60bc991ca9adc9a"> +14/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.sum&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.sum<br><br>

**Updated the version of the `github.com/kubescape/storage` <br>package.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.mod&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.mod<br><br>

**Updated the version of the `github.com/kubescape/storage` <br>package.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/174/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6"> +1/-1</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
