### PR TITLE
improve patching for applicationprofiles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/kubescape/backend v0.0.16
 	github.com/kubescape/go-logger v0.0.22
 	github.com/kubescape/k8s-interface v0.0.159-0.20240128085543-a829d861c684
-	github.com/kubescape/storage v0.0.61
+	github.com/kubescape/storage v0.0.66
 	github.com/panjf2000/ants/v2 v2.9.0
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.21.4
 
 require (
 	github.com/armosec/utils-k8s-go v0.0.25
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/cilium/ebpf v0.12.3
 	github.com/deckarep/golang-set/v2 v2.5.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
@@ -52,7 +53,6 @@ require (
 	github.com/becheran/wildmatch-go v1.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/briandowns/spinner v1.23.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
 	github.com/containerd/containerd v1.7.12 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -493,8 +493,8 @@ github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
 github.com/kubescape/k8s-interface v0.0.159-0.20240128085543-a829d861c684 h1:TaNa599lecZK5oUBKhWn9OgJj4rE1NwIsj698+a3Pl8=
 github.com/kubescape/k8s-interface v0.0.159-0.20240128085543-a829d861c684/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
-github.com/kubescape/storage v0.0.61 h1:T6NIZP+80ILKLVOV9KFU/0OuH4unoLGXo4mO0zwv6/Q=
-github.com/kubescape/storage v0.0.61/go.mod h1:uMwudLhZCPgjf4JEbRSUZ20JmQJitLVrexZb7S1N4b0=
+github.com/kubescape/storage v0.0.66 h1:mp3bh2bTh1ki+9VeofU+hoKYPwvquRGh7WYU1Oltkqo=
+github.com/kubescape/storage v0.0.66/go.mod h1:U27QNwTwRrOoFRQL7Whz6WC5rxonytuwHg4G/wEvH/A=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRnB5PcgP0RXtQvnMSgIF14M7CBd2shtXs=

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -10,8 +10,11 @@ import (
 	"node-agent/pkg/k8sclient"
 	"node-agent/pkg/storage"
 	"node-agent/pkg/utils"
-	"sort"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 
@@ -26,8 +29,6 @@ import (
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,12 +37,15 @@ type ApplicationProfileManager struct {
 	cfg                      config.Config
 	clusterName              string
 	ctx                      context.Context
-	capabilitiesSets         maps.SafeMap[string, mapset.Set[string]]                        // key is k8sContainerID
-	execMaps                 maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
-	openMaps                 maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
+	trackedContainers        mapset.Set[string]                                              // key is k8sContainerID
+	savedCapabilities        maps.SafeMap[string, mapset.Set[string]]                        // key is k8sContainerID
+	savedExecs               maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
+	savedOpens               maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
+	savedSyscalls            maps.SafeMap[string, mapset.Set[string]]                        // key is k8sContainerID
+	toSaveCapabilities       maps.SafeMap[string, mapset.Set[string]]                        // key is k8sContainerID
+	toSaveExecs              maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
+	toSaveOpens              maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
 	watchedContainerChannels maps.SafeMap[string, chan error]                                // key is ContainerID
-	savedCapabilities        maps.SafeMap[string, int]
-	savedSyscalls            maps.SafeMap[string, int]
 	k8sClient                k8sclient.K8sClientInterface
 	storageClient            storage.StorageClient
 	syscallPeekFunc          func(nsMountId uint64) ([]string, error)
@@ -51,11 +55,12 @@ var _ applicationprofilemanager.ApplicationProfileManagerClient = (*ApplicationP
 
 func CreateApplicationProfileManager(ctx context.Context, cfg config.Config, clusterName string, k8sClient k8sclient.K8sClientInterface, storageClient storage.StorageClient) (*ApplicationProfileManager, error) {
 	return &ApplicationProfileManager{
-		cfg:           cfg,
-		clusterName:   clusterName,
-		ctx:           ctx,
-		k8sClient:     k8sClient,
-		storageClient: storageClient,
+		cfg:               cfg,
+		clusterName:       clusterName,
+		ctx:               ctx,
+		k8sClient:         k8sClient,
+		storageClient:     storageClient,
+		trackedContainers: mapset.NewSet[string](),
 	}, nil
 }
 
@@ -65,7 +70,10 @@ func (am *ApplicationProfileManager) ensureInstanceID(ctx context.Context, conta
 	}
 	wl, err := am.k8sClient.GetWorkload(container.K8s.Namespace, "Pod", container.K8s.PodName)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get workload", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get workload", helpers.Error(err),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 	pod := wl.(*workloadinterface.Workload)
@@ -76,26 +84,38 @@ func (am *ApplicationProfileManager) ensureInstanceID(ctx context.Context, conta
 	// find parentWlid
 	kind, name, err := am.k8sClient.CalculateWorkloadParentRecursive(pod)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to calculate workload parent", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to calculate workload parent", helpers.Error(err),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 	parentWorkload, err := am.k8sClient.GetWorkload(pod.GetNamespace(), kind, name)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get parent workload", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get parent workload", helpers.Error(err),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 	w := parentWorkload.(*workloadinterface.Workload)
 	watchedContainer.Wlid = w.GenerateWlid(am.clusterName)
 	err = wlid.IsWlidValid(watchedContainer.Wlid)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to validate WLID", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to validate WLID", helpers.Error(err),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 	watchedContainer.ParentResourceVersion = w.GetResourceVersion()
 	// find instanceID
 	instanceIDs, err := instanceidhandler.GenerateInstanceID(pod)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to generate instanceID", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to generate instanceID", helpers.Error(err),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 	watchedContainer.InstanceID = instanceIDs[0]
@@ -114,9 +134,14 @@ func (am *ApplicationProfileManager) ensureInstanceID(ctx context.Context, conta
 
 func (am *ApplicationProfileManager) deleteResources(watchedContainer *utils.WatchedContainerData) {
 	watchedContainer.UpdateDataTicker.Stop()
-	am.capabilitiesSets.Delete(watchedContainer.K8sContainerID)
-	am.execMaps.Delete(watchedContainer.K8sContainerID)
-	am.openMaps.Delete(watchedContainer.K8sContainerID)
+	am.trackedContainers.Remove(watchedContainer.K8sContainerID)
+	am.savedCapabilities.Delete(watchedContainer.K8sContainerID)
+	am.savedExecs.Delete(watchedContainer.K8sContainerID)
+	am.savedOpens.Delete(watchedContainer.K8sContainerID)
+	am.savedSyscalls.Delete(watchedContainer.K8sContainerID)
+	am.toSaveCapabilities.Delete(watchedContainer.K8sContainerID)
+	am.toSaveExecs.Delete(watchedContainer.K8sContainerID)
+	am.toSaveOpens.Delete(watchedContainer.K8sContainerID)
 	am.watchedContainerChannels.Delete(watchedContainer.ContainerID)
 }
 
@@ -142,35 +167,50 @@ func (am *ApplicationProfileManager) monitorContainer(ctx context.Context, conta
 	}
 }
 
-type PatchOperation struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value"`
-}
-
 func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedContainer *utils.WatchedContainerData, namespace string) {
 	ctx, span := otel.Tracer("").Start(ctx, "ApplicationProfileManager.saveProfile")
 	defer span.End()
 
 	if watchedContainer.InstanceID == nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - instanceID is nil")
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - instanceID is nil",
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 
 	// leave container name empty this way the "slug" will represent a workload
 	slug, err := names.InstanceIDToSlug(watchedContainer.InstanceID.GetName(), watchedContainer.InstanceID.GetKind(), "", watchedContainer.InstanceID.GetHashed())
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get slug", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get slug", helpers.Error(err),
+			helpers.String("slug", slug),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		return
 	}
 
+	// sleep for container index second to desynchronize the profiles saving
+	time.Sleep(time.Duration(watchedContainer.ContainerIndex) * time.Second)
+
+	// application activity
 	// get syscalls from IG
 	observedSyscalls, err := am.syscallPeekFunc(watchedContainer.NsMntId)
 	if err != nil {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get syscalls", helpers.Error(err))
+		logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get syscalls", helpers.Error(err),
+			helpers.String("slug", slug),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 	}
 	// check if we have new activities to save
-	if len(observedSyscalls) > am.savedSyscalls.Get(watchedContainer.K8sContainerID) {
+	savedSyscalls, ok := am.savedSyscalls.Load(watchedContainer.K8sContainerID)
+	if !ok {
+		// fallback to empty set
+		savedSyscalls = mapset.NewSet[string]()
+	}
+	toSaveSyscalls := mapset.NewSet[string](observedSyscalls...).Difference(savedSyscalls)
+	if !toSaveSyscalls.IsEmpty() {
 		newActivity := &v1beta1.ApplicationActivity{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: slug,
@@ -185,166 +225,240 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		newActivity.Spec.Syscalls = observedSyscalls
 		// save application activity
 		if err := am.storageClient.CreateApplicationActivity(newActivity, namespace); err != nil {
-			logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to save application activity", helpers.Error(err))
+			logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to save application activity", helpers.Error(err),
+				helpers.String("slug", slug),
+				helpers.Int("container index", watchedContainer.ContainerIndex),
+				helpers.String("container ID", watchedContainer.ContainerID),
+				helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		} else {
-			am.savedSyscalls.Set(watchedContainer.K8sContainerID, len(observedSyscalls))
-			logger.L().Debug("ApplicationProfileManager - saved application activity", helpers.String("slug", slug), helpers.String("container ID", watchedContainer.ContainerID), helpers.String("k8s workload", watchedContainer.K8sContainerID))
+			// record saved syscalls
+			am.savedSyscalls.Get(watchedContainer.K8sContainerID).Append(toSaveSyscalls.ToSlice()...)
+			logger.L().Debug("ApplicationProfileManager - saved application activity",
+				helpers.Int("syscalls", toSaveSyscalls.Cardinality()),
+				helpers.String("slug", slug),
+				helpers.Int("container index", watchedContainer.ContainerIndex),
+				helpers.String("container ID", watchedContainer.ContainerID),
+				helpers.String("k8s workload", watchedContainer.K8sContainerID))
 		}
 	}
 
-	// profile sets
-	var addedProfiles int
+	// application profile
+	var capabilities []string
 	execs := make(map[string]mapset.Set[string])
 	opens := make(map[string]mapset.Set[string])
-	// get capabilities, execs and opens from IG
-	var observedCapabilities []string
-	newCapabilitiesSet := mapset.NewSet[string]()
-	capabilitiesSet, ok := am.capabilitiesSets.Load(watchedContainer.K8sContainerID)
-	if ok {
-		// replace the capabilities set with a new one
-		am.capabilitiesSets.Set(watchedContainer.K8sContainerID, newCapabilitiesSet)
-		observedCapabilities = capabilitiesSet.ToSlice()
+	// get capabilities from IG
+	if v, ok := am.toSaveCapabilities.Load(watchedContainer.K8sContainerID); ok {
+		// remove capabilities to save in a thread safe way using Pop
+		for {
+			capability, continuePop := v.Pop()
+			if continuePop {
+				capabilities = append(capabilities, capability)
+			} else {
+				break
+			}
+		}
 	}
-	newExecMap := new(maps.SafeMap[string, mapset.Set[string]])
-	execMap, ok := am.execMaps.Load(watchedContainer.K8sContainerID)
-	if ok {
-		// replace the exec map with a new one
-		am.execMaps.Set(watchedContainer.K8sContainerID, newExecMap)
-		// if we fail to save the profile we will restore execMap entries
-		execMap.Range(func(path string, exec mapset.Set[string]) bool {
-			if _, exist := execs[path]; !exist {
-				execs[path] = mapset.NewSet[string]()
-			}
-			addedProfiles += execs[path].Append(exec.ToSlice()...)
-			return true
-		})
+	// get pointer to execs map from IG
+	toSaveExecs, ok := am.toSaveExecs.Load(watchedContainer.K8sContainerID)
+	if !ok {
+		// fallback to empty map
+		toSaveExecs = new(maps.SafeMap[string, mapset.Set[string]])
 	}
-	newOpenMap := new(maps.SafeMap[string, mapset.Set[string]])
-	openMap, ok := am.openMaps.Load(watchedContainer.K8sContainerID)
-	if ok {
-		// replace the open map with a new one
-		am.openMaps.Set(watchedContainer.K8sContainerID, newOpenMap)
-		// if we fail to save the profile we will restore openMap entries
-		openMap.Range(func(path string, open mapset.Set[string]) bool {
-			if _, exist := opens[path]; !exist {
-				opens[path] = mapset.NewSet[string]()
-			}
-			addedProfiles += opens[path].Append(open.ToSlice()...)
-			return true
-		})
+	// point IG to a new exec map
+	am.toSaveExecs.Set(watchedContainer.K8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+	// prepare execs map
+	toSaveExecs.Range(func(path string, exec mapset.Set[string]) bool {
+		if _, exist := execs[path]; !exist {
+			execs[path] = mapset.NewSet[string]()
+		}
+		execs[path].Append(exec.ToSlice()...)
+		return true
+	})
+	// get pointer to opens map from IG
+	toSaveOpens, ok := am.toSaveOpens.Load(watchedContainer.K8sContainerID)
+	if !ok {
+		// fallback to empty map
+		toSaveOpens = new(maps.SafeMap[string, mapset.Set[string]])
 	}
-	// new profile
-	if addedProfiles > 0 || len(observedCapabilities) > am.savedCapabilities.Get(watchedContainer.K8sContainerID) {
-		var profileOperations []PatchOperation
-		newProfile := &v1beta1.ApplicationProfile{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: slug,
-				Annotations: map[string]string{
-					helpersv1.WlidMetadataKey:   watchedContainer.Wlid,
-					helpersv1.StatusMetadataKey: helpersv1.Ready,
-				},
-				Labels: utils.GetLabels(watchedContainer, true),
-			},
+	// point IG to a new opens map
+	am.toSaveOpens.Set(watchedContainer.K8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+	// prepare opens map
+	toSaveOpens.Range(func(path string, open mapset.Set[string]) bool {
+		if _, exist := opens[path]; !exist {
+			opens[path] = mapset.NewSet[string]()
 		}
-		newProfileContainer := &v1beta1.ApplicationProfileContainer{
-			Name: watchedContainer.InstanceID.GetContainerName(),
-		}
-		// add capabilities
-		sort.Strings(observedCapabilities)
-		newProfileContainer.Capabilities = observedCapabilities
-		capabilitiesPath := fmt.Sprintf("/spec/containers/%d/capabilities/-", watchedContainer.ContainerIndex)
-		for _, capability := range observedCapabilities {
-			profileOperations = append(profileOperations, PatchOperation{
-				Op:    "add",
-				Path:  capabilitiesPath,
-				Value: capability,
-			})
-		}
-		// add execs
-		newProfileContainer.Execs = make([]v1beta1.ExecCalls, 0)
-		execsPath := fmt.Sprintf("/spec/containers/%d/execs/-", watchedContainer.ContainerIndex)
-		for path, exec := range execs {
-			args := exec.ToSlice()
-			sort.Strings(args)
-			newExec := v1beta1.ExecCalls{
-				Path: path,
-				Args: args,
-			}
-			newProfileContainer.Execs = append(newProfileContainer.Execs, newExec)
-			profileOperations = append(profileOperations, PatchOperation{
-				Op:    "add",
-				Path:  execsPath,
-				Value: newExec,
-			})
-		}
-		// add opens
-		newProfileContainer.Opens = make([]v1beta1.OpenCalls, 0)
-		opensPath := fmt.Sprintf("/spec/containers/%d/opens/-", watchedContainer.ContainerIndex)
-		for path, open := range opens {
-			flags := open.ToSlice()
-			sort.Strings(flags)
-			newOpen := v1beta1.OpenCalls{
-				Path:  path,
-				Flags: flags,
-			}
-			newProfileContainer.Opens = append(newProfileContainer.Opens, newOpen)
-			profileOperations = append(profileOperations, PatchOperation{
-				Op:    "add",
-				Path:  opensPath,
-				Value: newOpen,
-			})
-		}
-		// insert application profile container
-		utils.InsertApplicationProfileContainer(newProfile, watchedContainer.ContainerType, watchedContainer.ContainerIndex, newProfileContainer)
+		opens[path].Append(open.ToSlice()...)
+		return true
+	})
+	// new profile activity
+	if len(capabilities) > 0 || len(execs) > 0 || len(opens) > 0 {
 		// calculate patch
+		profileOperations := utils.CreatePatchOperations(capabilities, execs, opens, watchedContainer.ContainerType.String(), watchedContainer.ContainerIndex)
 		patch, err := json.Marshal(profileOperations)
 		if err != nil {
-			logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to marshal patch", helpers.Error(err))
+			logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to marshal patch", helpers.Error(err),
+				helpers.String("slug", slug),
+				helpers.Int("container index", watchedContainer.ContainerIndex),
+				helpers.String("container ID", watchedContainer.ContainerID),
+				helpers.String("k8s workload", watchedContainer.K8sContainerID))
 			return
 		}
-		// save application profile
+		// try to patch application profile
 		var gotErr error
 		if err := am.storageClient.PatchApplicationProfile(slug, namespace, patch); err != nil {
 			if apierrors.IsNotFound(err) {
+				// new application profile
+				newProfile := &v1beta1.ApplicationProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: slug,
+						Annotations: map[string]string{
+							helpersv1.WlidMetadataKey:   watchedContainer.Wlid,
+							helpersv1.StatusMetadataKey: helpersv1.Ready,
+						},
+						Labels: utils.GetLabels(watchedContainer, true),
+					},
+				}
+				// new profile container
+				newProfileContainer := &v1beta1.ApplicationProfileContainer{
+					Name: watchedContainer.InstanceID.GetContainerName(),
+				}
+				utils.EnrichProfileContainer(newProfileContainer, capabilities, execs, opens)
+				// insert application profile container
+				utils.InsertApplicationProfileContainer(newProfile, watchedContainer.ContainerType, watchedContainer.ContainerIndex, newProfileContainer)
+				// try to create application profile
 				if err := am.storageClient.CreateApplicationProfile(newProfile, namespace); err != nil {
 					gotErr = err
-					logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to create application profile", helpers.Error(err))
+					logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to create application profile", helpers.Error(err),
+						helpers.String("slug", slug),
+						helpers.Int("container index", watchedContainer.ContainerIndex),
+						helpers.String("container ID", watchedContainer.ContainerID),
+						helpers.String("k8s workload", watchedContainer.K8sContainerID))
 				}
 			} else {
-				gotErr = err
-				logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to patch application profile", helpers.Error(err))
+				logger.L().Ctx(ctx).Debug("ApplicationProfileManager - failed to patch application profile, will get existing one and adjust patch", helpers.Error(err),
+					helpers.String("slug", slug),
+					helpers.Int("container index", watchedContainer.ContainerIndex),
+					helpers.String("container ID", watchedContainer.ContainerID),
+					helpers.String("k8s workload", watchedContainer.K8sContainerID))
+				// get existing profile
+				existingProfile, err := am.storageClient.GetApplicationProfile(namespace, slug)
+				if err != nil {
+					gotErr = err
+					logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get existing application profile", helpers.Error(err),
+						helpers.String("slug", slug),
+						helpers.Int("container index", watchedContainer.ContainerIndex),
+						helpers.String("container ID", watchedContainer.ContainerID),
+						helpers.String("k8s workload", watchedContainer.K8sContainerID))
+				} else {
+					var replaceOperations []utils.PatchOperation
+					// check existing profile container
+					existingProfileContainer := utils.GetApplicationProfileContainer(existingProfile, watchedContainer.ContainerType, watchedContainer.ContainerIndex)
+					var addProfileContainer bool
+					if existingProfileContainer == nil {
+						existingProfileContainer = &v1beta1.ApplicationProfileContainer{
+							Name: watchedContainer.InstanceID.GetContainerName(),
+						}
+						addProfileContainer = true
+					}
+					// update it
+					utils.EnrichProfileContainer(existingProfileContainer, capabilities, execs, opens)
+					// get existing containers
+					var existingContainers []v1beta1.ApplicationProfileContainer
+					if watchedContainer.ContainerType == utils.Container {
+						existingContainers = existingProfile.Spec.Containers
+					} else {
+						existingContainers = existingProfile.Spec.InitContainers
+					}
+					// replace or add application profile container using patch
+					switch {
+					case existingContainers == nil:
+						// insert a new container slice, with the new container at the right index
+						containers := make([]v1beta1.ApplicationProfileContainer, watchedContainer.ContainerIndex+1)
+						containers[watchedContainer.ContainerIndex] = *existingProfileContainer
+						replaceOperations = append(replaceOperations, utils.PatchOperation{
+							Op:    "add",
+							Path:  fmt.Sprintf("/spec/%s", watchedContainer.ContainerType),
+							Value: containers,
+						})
+					case addProfileContainer:
+						for i := len(existingContainers); i < watchedContainer.ContainerIndex; i++ {
+							replaceOperations = append(replaceOperations, utils.PatchOperation{
+								Op:    "add",
+								Path:  fmt.Sprintf("/spec/%s/%d", watchedContainer.ContainerType, i),
+								Value: v1beta1.ApplicationProfileContainer{},
+							})
+						}
+						replaceOperations = append(replaceOperations, utils.PatchOperation{
+							Op:    "add",
+							Path:  fmt.Sprintf("/spec/%s/%d", watchedContainer.ContainerType, watchedContainer.ContainerIndex),
+							Value: existingProfileContainer,
+						})
+					default:
+						replaceOperations = append(replaceOperations, utils.PatchOperation{
+							Op:    "replace",
+							Path:  fmt.Sprintf("/spec/%s/%d", watchedContainer.ContainerType, watchedContainer.ContainerIndex),
+							Value: existingProfileContainer,
+						})
+					}
+					patch, err := json.Marshal(replaceOperations)
+					if err != nil {
+						logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to marshal patch", helpers.Error(err),
+							helpers.String("slug", slug),
+							helpers.Int("container index", watchedContainer.ContainerIndex),
+							helpers.String("container ID", watchedContainer.ContainerID),
+							helpers.String("k8s workload", watchedContainer.K8sContainerID))
+						return
+					}
+					if err := am.storageClient.PatchApplicationProfile(slug, namespace, patch); err != nil {
+						gotErr = err
+						logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to patch application profile", helpers.Error(err),
+							helpers.String("slug", slug),
+							helpers.Int("container index", watchedContainer.ContainerIndex),
+							helpers.String("container ID", watchedContainer.ContainerID),
+							helpers.String("k8s workload", watchedContainer.K8sContainerID))
+					}
+				}
 			}
 		}
 		if gotErr != nil {
 			// restore capabilities set
-			newCapabilitiesSet.Append(capabilitiesSet.ToSlice()...)
-			// restore execMap entries
-			execMap.Range(func(k string, v mapset.Set[string]) bool {
-				if newExecMap.Has(k) {
-					newExecMap.Get(k).Append(v.ToSlice()...)
-				} else {
-					newExecMap.Set(k, v)
-				}
-				return true
-			})
-			// restore openMap entries
-			openMap.Range(func(k string, v mapset.Set[string]) bool {
-				if newOpenMap.Has(k) {
-					newOpenMap.Get(k).Append(v.ToSlice()...)
-				} else {
-					newOpenMap.Set(k, v)
-				}
-				return true
-			})
+			am.toSaveCapabilities.Get(watchedContainer.K8sContainerID).Append(capabilities...)
+			// restore execs map entries
+			toSaveExecs.Range(utils.SetInMap(am.toSaveExecs.Get(watchedContainer.K8sContainerID)))
+			// restore opens map entries
+			toSaveOpens.Range(utils.SetInMap(am.toSaveOpens.Get(watchedContainer.K8sContainerID)))
 		} else {
-			am.savedCapabilities.Set(watchedContainer.K8sContainerID, len(observedCapabilities))
-			logger.L().Debug("ApplicationProfileManager - saved application profile", helpers.String("slug", slug), helpers.String("container ID", watchedContainer.ContainerID), helpers.String("k8s workload", watchedContainer.K8sContainerID))
+			// record saved capabilities
+			am.savedCapabilities.Get(watchedContainer.K8sContainerID).Append(capabilities...)
+			// record saved execs
+			toSaveExecs.Range(utils.SetInMap(am.savedExecs.Get(watchedContainer.K8sContainerID)))
+			// record saved opens
+			toSaveOpens.Range(utils.SetInMap(am.savedOpens.Get(watchedContainer.K8sContainerID)))
+			logger.L().Debug("ApplicationProfileManager - saved application profile",
+				helpers.Int("capabilities", len(capabilities)),
+				helpers.Int("execs", toSaveExecs.Len()),
+				helpers.Int("opens", toSaveOpens.Len()),
+				helpers.String("slug", slug),
+				helpers.Int("container index", watchedContainer.ContainerIndex),
+				helpers.String("container ID", watchedContainer.ContainerID),
+				helpers.String("k8s workload", watchedContainer.K8sContainerID))
 			// profile summary
 			summary := &v1beta1.ApplicationProfileSummary{
-				ObjectMeta: newProfile.ObjectMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name: slug,
+					Annotations: map[string]string{
+						helpersv1.WlidMetadataKey:   watchedContainer.Wlid,
+						helpersv1.StatusMetadataKey: helpersv1.Ready,
+					},
+					Labels: utils.GetLabels(watchedContainer, true),
+				},
 			}
 			if err := am.storageClient.CreateApplicationProfileSummary(summary, namespace); err != nil {
-				logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to save application profile summary", helpers.Error(err))
+				logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to save application profile summary", helpers.Error(err),
+					helpers.String("slug", slug),
+					helpers.Int("container index", watchedContainer.ContainerIndex),
+					helpers.String("container ID", watchedContainer.ContainerID),
+					helpers.String("k8s workload", watchedContainer.K8sContainerID))
 			}
 		}
 	}
@@ -366,10 +480,22 @@ func (am *ApplicationProfileManager) startApplicationProfiling(ctx context.Conte
 	}
 
 	if err := am.monitorContainer(ctx, container, watchedContainer); err != nil {
-		logger.L().Info("ApplicationProfileManager - stop monitor on container", helpers.String("reason", err.Error()), helpers.String("container ID", container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
+		logger.L().Info("ApplicationProfileManager - stop monitor on container", helpers.String("reason", err.Error()),
+			helpers.Int("container index", watchedContainer.ContainerIndex),
+			helpers.String("container ID", watchedContainer.ContainerID),
+			helpers.String("k8s workload", watchedContainer.K8sContainerID))
 	}
 
 	am.deleteResources(watchedContainer)
+}
+
+func (am *ApplicationProfileManager) waitForContainer(k8sContainerID string) error {
+	return backoff.Retry(func() error {
+		if am.trackedContainers.Contains(k8sContainerID) {
+			return nil
+		}
+		return fmt.Errorf("container %s not found", k8sContainerID)
+	}, backoff.NewExponentialBackOff())
 }
 
 func (am *ApplicationProfileManager) ContainerCallback(notif containercollection.PubSubEvent) {
@@ -380,12 +506,19 @@ func (am *ApplicationProfileManager) ContainerCallback(notif containercollection
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
 		if am.watchedContainerChannels.Has(notif.Container.Runtime.ContainerID) {
-			logger.L().Debug("container already exist in memory", helpers.String("container ID", notif.Container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
+			logger.L().Debug("container already exist in memory",
+				helpers.String("container ID", notif.Container.Runtime.ContainerID),
+				helpers.String("k8s workload", k8sContainerID))
 			return
 		}
-		am.capabilitiesSets.Set(k8sContainerID, mapset.NewSet[string]())
-		am.execMaps.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
-		am.openMaps.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.savedCapabilities.Set(k8sContainerID, mapset.NewSet[string]())
+		am.savedExecs.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.savedOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.savedSyscalls.Set(k8sContainerID, mapset.NewSet[string]())
+		am.toSaveCapabilities.Set(k8sContainerID, mapset.NewSet[string]())
+		am.toSaveExecs.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.toSaveOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.trackedContainers.Add(k8sContainerID)
 		go am.startApplicationProfiling(ctx, notif.Container, k8sContainerID)
 	case containercollection.EventTypeRemoveContainer:
 		channel := am.watchedContainerChannels.Get(notif.Container.Runtime.ContainerID)
@@ -401,11 +534,13 @@ func (am *ApplicationProfileManager) RegisterPeekFunc(peek func(mntns uint64) ([
 }
 
 func (am *ApplicationProfileManager) ReportCapability(k8sContainerID, capability string) {
-	capabilitiesSet, err := utils.WaitGetSafeMap(&am.capabilitiesSets, k8sContainerID)
-	if err != nil {
+	if err := am.waitForContainer(k8sContainerID); err != nil {
 		return
 	}
-	capabilitiesSet.Add(capability)
+	if am.savedCapabilities.Has(capability) {
+		return
+	}
+	am.toSaveCapabilities.Get(k8sContainerID).Add(capability)
 }
 
 func (am *ApplicationProfileManager) ReportFileExec(k8sContainerID, path string, args []string) {
@@ -413,10 +548,16 @@ func (am *ApplicationProfileManager) ReportFileExec(k8sContainerID, path string,
 	if path == "" {
 		return
 	}
-	execMap, err := utils.WaitGetSafeMap(&am.execMaps, k8sContainerID)
-	if err != nil {
+	if err := am.waitForContainer(k8sContainerID); err != nil {
 		return
 	}
+	// check if we already have this exec
+	savedExecs := am.savedExecs.Get(k8sContainerID)
+	if savedExecs.Has(path) && savedExecs.Get(path).Contains(args...) {
+		return
+	}
+	// add to exec map
+	execMap := am.toSaveExecs.Get(k8sContainerID)
 	if execMap.Has(path) {
 		execMap.Get(path).Append(args...)
 	} else {
@@ -425,10 +566,16 @@ func (am *ApplicationProfileManager) ReportFileExec(k8sContainerID, path string,
 }
 
 func (am *ApplicationProfileManager) ReportFileOpen(k8sContainerID, path string, flags []string) {
-	openMap, err := utils.WaitGetSafeMap(&am.openMaps, k8sContainerID)
-	if err != nil {
+	if err := am.waitForContainer(k8sContainerID); err != nil {
 		return
 	}
+	// check if we already have this open
+	savedOpens := am.savedOpens.Get(k8sContainerID)
+	if savedOpens.Has(path) && savedOpens.Get(path).Contains(flags...) {
+		return
+	}
+	// add to open map
+	openMap := am.toSaveOpens.Get(k8sContainerID)
 	if openMap.Has(path) {
 		openMap.Get(path).Append(flags...)
 	} else {

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -19,7 +19,7 @@ func TestApplicationProfileManager(t *testing.T) {
 	cfg := config.Config{
 		InitialDelay:     1 * time.Second,
 		MaxSniffingTime:  5 * time.Minute,
-		UpdateDataPeriod: 2 * time.Second,
+		UpdateDataPeriod: 1 * time.Second,
 	}
 	ctx := context.TODO()
 	k8sClient := &k8sclient.K8sClientMock{}
@@ -48,7 +48,7 @@ func TestApplicationProfileManager(t *testing.T) {
 	// report capability
 	go am.ReportCapability("ns/pod/cont", "NET_BIND_SERVICE")
 	// report file exec
-	go am.ReportFileExec("ns/pod/cont", "", []string{"ls"})
+	go am.ReportFileExec("ns/pod/cont", "", []string{"ls"}) // will not be reported
 	go am.ReportFileExec("ns/pod/cont", "/bin/bash", []string{"-c", "ls"})
 	// report file open
 	go am.ReportFileOpen("ns/pod/cont", "/etc/passwd", []string{"O_RDONLY"})
@@ -58,7 +58,7 @@ func TestApplicationProfileManager(t *testing.T) {
 		Container: container,
 	})
 	// let it run for a while
-	time.Sleep(12 * time.Second) // need to sleep longer because of AddRandomDuration in startApplicationProfiling
+	time.Sleep(15 * time.Second) // need to sleep longer because of AddRandomDuration in startApplicationProfiling
 	// report another file open
 	go am.ReportFileOpen("ns/pod/cont", "/etc/hosts", []string{"O_RDONLY"})
 	// sleep more

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -41,14 +41,17 @@ func (sc *StorageHttpClientMock) GetApplicationActivity(_, _ string) (*spdxv1bet
 }
 
 func (sc *StorageHttpClientMock) GetApplicationProfile(_, _ string) (*spdxv1beta1.ApplicationProfile, error) {
-	return &spdxv1beta1.ApplicationProfile{
-		Spec: spdxv1beta1.ApplicationProfileSpec{
-			Containers: []spdxv1beta1.ApplicationProfileContainer{
-				{Capabilities: []string{"SYS_ADMIN"}},
-				{Capabilities: []string{"NET_BROADCAST"}},
+	if len(sc.ApplicationProfiles) == 0 {
+		return &spdxv1beta1.ApplicationProfile{
+			Spec: spdxv1beta1.ApplicationProfileSpec{
+				Containers: []spdxv1beta1.ApplicationProfileContainer{
+					{Capabilities: []string{"SYS_ADMIN"}},
+					{Capabilities: []string{"NET_BROADCAST"}},
+				},
 			},
-		},
-	}, nil
+		}, nil
+	}
+	return sc.ApplicationProfiles[len(sc.ApplicationProfiles)-1], nil
 }
 
 var _ StorageClient = (*StorageHttpClientMock)(nil)

--- a/pkg/storage/v1/storage_nocache.go
+++ b/pkg/storage/v1/storage_nocache.go
@@ -103,6 +103,8 @@ func (sc StorageNoCache) GetApplicationActivity(namespace, name string) (*v1beta
 }
 
 func (sc StorageNoCache) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error {
+	// unset resourceVersion
+	profile.ResourceVersion = ""
 	_, err := sc.StorageClient.ApplicationProfiles(namespace).Create(context.Background(), profile, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -111,7 +113,7 @@ func (sc StorageNoCache) CreateApplicationProfile(profile *v1beta1.ApplicationPr
 }
 
 func (sc StorageNoCache) PatchApplicationProfile(name, namespace string, patch []byte) error {
-	_, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, []byte(patch), metav1.PatchOptions{})
+	_, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("patch application profile: %w", err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -249,7 +249,7 @@ type PatchOperation struct {
 	Value interface{} `json:"value"`
 }
 
-func CreatePatchOperations(capabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
+func CreateCapabilitiesPatchOperations(capabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
 	var profileOperations []PatchOperation
 	// add capabilities
 	sort.Strings(capabilities)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"errors"
+	"fmt"
+	"github.com/deckarep/golang-set/v2"
 	"math/rand"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,6 +44,10 @@ const (
 	InitContainer
 	EphemeralContainer
 )
+
+func (c ContainerType) String() string {
+	return [...]string{"unknown", "containers", "initContainers", "ephemeralContainers"}[c]
+}
 
 type WatchedContainerData struct {
 	InstanceID                                 instanceidhandler.IInstanceID
@@ -152,6 +159,23 @@ func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[
 	return labels
 }
 
+func GetApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) *v1beta1.ApplicationProfileContainer {
+	if profile == nil {
+		return nil
+	}
+	switch containerType {
+	case Container:
+		if len(profile.Spec.Containers) > containerIndex {
+			return &profile.Spec.Containers[containerIndex]
+		}
+	case InitContainer:
+		if len(profile.Spec.InitContainers) > containerIndex {
+			return &profile.Spec.InitContainers[containerIndex]
+		}
+	}
+	return nil
+}
+
 func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int, profileContainer *v1beta1.ApplicationProfileContainer) {
 	switch containerType {
 	case Container:
@@ -193,19 +217,90 @@ func (watchedContainer *WatchedContainerData) SetContainerType(wl workloadinterf
 	}
 }
 
-// WaitGetSafeMap waits for a value to be loaded into a SafeMap, with a timeout of 1 minute
-func WaitGetSafeMap[K comparable, V any](m *maps.SafeMap[K, V], k K) (V, error) {
-	var tries int
-	for {
-		v, ok := m.Load(k)
-		if ok {
-			return v, nil
+func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
+	// add capabilities
+	sort.Strings(observedCapabilities)
+	newProfileContainer.Capabilities = observedCapabilities
+	// add execs
+	newProfileContainer.Execs = make([]v1beta1.ExecCalls, 0)
+	for path, exec := range execs {
+		args := exec.ToSlice()
+		sort.Strings(args)
+		newProfileContainer.Execs = append(newProfileContainer.Execs, v1beta1.ExecCalls{
+			Path: path,
+			Args: args,
+		})
+	}
+	// add opens
+	newProfileContainer.Opens = make([]v1beta1.OpenCalls, 0)
+	for path, open := range opens {
+		flags := open.ToSlice()
+		sort.Strings(flags)
+		newProfileContainer.Opens = append(newProfileContainer.Opens, v1beta1.OpenCalls{
+			Path:  path,
+			Flags: flags,
+		})
+	}
+}
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+func CreatePatchOperations(capabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
+	var profileOperations []PatchOperation
+	// add capabilities
+	sort.Strings(capabilities)
+	capabilitiesPath := fmt.Sprintf("/spec/%s/%d/capabilities/-", containerType, containerIndex)
+	for _, capability := range capabilities {
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:    "add",
+			Path:  capabilitiesPath,
+			Value: capability,
+		})
+	}
+	// add execs
+	execsPath := fmt.Sprintf("/spec/%s/%d/execs/-", containerType, containerIndex)
+	for path, exec := range execs {
+		args := exec.ToSlice()
+		sort.Strings(args)
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:   "add",
+			Path: execsPath,
+			Value: v1beta1.ExecCalls{
+				Path: path,
+				Args: args,
+			},
+		})
+	}
+	// add opens
+	opensPath := fmt.Sprintf("/spec/%s/%d/opens/-", containerType, containerIndex)
+	for path, open := range opens {
+		flags := open.ToSlice()
+		sort.Strings(flags)
+
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:   "add",
+			Path: opensPath,
+			Value: v1beta1.OpenCalls{
+				Path:  path,
+				Flags: flags,
+			},
+		})
+	}
+	return profileOperations
+}
+
+func SetInMap(newExecMap *maps.SafeMap[string, mapset.Set[string]]) func(k string, v mapset.Set[string]) bool {
+	return func(k string, v mapset.Set[string]) bool {
+		if newExecMap.Has(k) {
+			newExecMap.Get(k).Append(v.ToSlice()...)
+		} else {
+			newExecMap.Set(k, v)
 		}
-		if tries > 60 {
-			return v, errors.New("timeout")
-		}
-		time.Sleep(1 * time.Second)
-		tries++
+		return true
 	}
 }
 


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- This PR primarily focuses on improving the handling of application profiles.
- In `utils.go`, new functions are added to enrich profile containers, create patch operations, and set in map. A new type `PatchOperation` is also introduced.
- The tests for `PatchApplicationProfile` in `storage_test.go` are updated with new test cases and assertions.
- In `applicationprofile_manager_test.go`, the `UpdateDataPeriod` in the config is updated and the sleep time in the tests is increased.
- The `GetApplicationProfile` method in `storage_mock.go` is updated to return the last profile in the list if available.
- In `storage_nocache.go`, the `resourceVersion` is unset in `CreateApplicationProfile` and the `PatchApplicationProfile` method is updated to accept byte array directly.
- A new dependency `github.com/cenkalti/backoff/v4 v4.2.1` is added in `go.mod`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Enhancements to utils.go for better container profile management</code>&nbsp; </dd></summary>
<hr>

pkg/utils/utils.go
- Added new functions to enrich profile containers, create patch <br>  operations, and set in map.
- Added a new type `PatchOperation`.
- Added a new method for `ContainerType` to convert it to string.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+107/-12</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_mock.go</strong><dd><code>Update GetApplicationProfile in storage_mock.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/storage/storage_mock.go
- Updated the `GetApplicationProfile` method to return the last profile <br>  in the list if available.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-46ba336587e6a6a63e35733ffff9449ccc4b58a4dae87718d60bc991ca9adc9a">+10/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_nocache.go</strong><dd><code>Update methods in storage_nocache.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/storage/v1/storage_nocache.go
- Unset `resourceVersion` in `CreateApplicationProfile`.
- Updated the `PatchApplicationProfile` method to accept byte array <br>  directly.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-f3093b908b4dcb2e91a2c300f81311dd287f33199f7b7b90fd0de9c686f6a641">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>storage_test.go</strong><dd><code>Update tests for PatchApplicationProfile in storage_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/storage/v1/storage_test.go
- Added new test cases for `PatchApplicationProfile`.
- Updated the assertions in the test cases.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-a3f74845de048f84a365723757b46f999a189c33fa27c48c5c0a1169bacdeabe">+56/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go</strong><dd><code>Update tests in applicationprofile_manager_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
- Updated the `UpdateDataPeriod` in the config.
- Increased the sleep time in the tests.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update dependencies in go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod
- Added a new dependency `github.com/cenkalti/backoff/v4 v4.2.1`.
    </details>
  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/185/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
