### PR TITLE
Omit trailing dot for absolute domain names

### DIFF
--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -337,7 +337,6 @@ func (am *NetworkManager) handleNetworkEvents(ctx context.Context, container *co
 		}
 		return
 	}
-	// TODO: dns enrichment
 
 	// update CRD based on events
 	networkNeighborsSpec := am.generateNetworkNeighborsEntries(container.K8s.Namespace, networkEvents, networkNeighbors.Spec)
@@ -471,7 +470,7 @@ func (am *NetworkManager) generateNetworkNeighborsEntries(namespace string, netw
 			if am.dnsResolverClient != nil {
 				domain, ok := am.dnsResolverClient.ResolveIPAddress(networkEvent.Destination.IPAddress)
 				if ok {
-					neighborEntry.DNS = domain
+					neighborEntry.DNS = strings.TrimSuffix(domain, ".")
 				}
 			}
 		}

--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -614,7 +614,10 @@ func getNamespaceMatchLabels(destinationNamespace, sourceNamespace string) map[s
 func generateNeighborsIdentifier(neighborEntry v1beta1.NetworkNeighbor) (string, error) {
 
 	// Add . to the dns name to avoid breaking backward compatibility (https://github.com/kubescape/node-agent/pull/189/commits/40c066b0850a813246e7791dc0484dfbd89f1de4)
-	dnsName := neighborEntry.DNS + "."
+	dnsName := ""
+	if neighborEntry.DNS != "" {
+		dnsName = neighborEntry.DNS + "."
+	}
 
 	// identifier is hash of everything in egress except ports
 	identifier := fmt.Sprintf("%s-%s-%s-%s-%s", neighborEntry.Type, neighborEntry.IPAddress, dnsName, neighborEntry.NamespaceSelector, neighborEntry.PodSelector)

--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -612,8 +612,12 @@ func getNamespaceMatchLabels(destinationNamespace, sourceNamespace string) map[s
 }
 
 func generateNeighborsIdentifier(neighborEntry v1beta1.NetworkNeighbor) (string, error) {
+
+	// Add . to the dns name to avoid breaking backward compatibility (https://github.com/kubescape/node-agent/pull/189/commits/40c066b0850a813246e7791dc0484dfbd89f1de4)
+	dnsName := neighborEntry.DNS + "."
+
 	// identifier is hash of everything in egress except ports
-	identifier := fmt.Sprintf("%s-%s-%s-%s-%s", neighborEntry.Type, neighborEntry.IPAddress, neighborEntry.DNS, neighborEntry.NamespaceSelector, neighborEntry.PodSelector)
+	identifier := fmt.Sprintf("%s-%s-%s-%s-%s", neighborEntry.Type, neighborEntry.IPAddress, dnsName, neighborEntry.NamespaceSelector, neighborEntry.PodSelector)
 	hash := sha256.New()
 	_, err := hash.Write([]byte(identifier))
 	if err != nil {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- This PR addresses the issue of trailing dots in absolute domain names resolved by the DNS resolver within the network manager. It ensures that the domain names stored and used within the application are normalized by removing any trailing dots.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Trim Trailing Dot from Resolved DNS Domain Names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/network_manager.go
<li>Modified <code>generateNetworkNeighborsEntries</code> function to trim the trailing <br>dot from the DNS domain names resolved.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/189/files#diff-cbcd69c2d2fb59b909f8b3cec3ff32348a1ddb4f1d465ece79ead0fa0ba7168b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

