### PR TITLE
Phase 3

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 		dWatcher.Start(ctx)
 
 		// create object cache
-		objCache := objectcache.NewObjectCache(k8sObjectCache, apc, nnc)
+		objCache := objectcache.NewObjectCache(k8sObjectCache, apc, aac, nnc)
 
 		// create exporter
 		ex := exporters.InitExporters(cfg.Exporters)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"node-agent/pkg/relevancymanager"
 	relevancymanagerv1 "node-agent/pkg/relevancymanager/v1"
 	rulebindingcache "node-agent/pkg/rulebindingmanager/cache"
+	"node-agent/pkg/ruleengine/objectcache/applicationactivitiescache"
 	"node-agent/pkg/ruleengine/objectcache/applicationprofilecache"
 	"node-agent/pkg/ruleengine/objectcache/k8scache"
 	"node-agent/pkg/ruleengine/objectcache/networkneighborscache"
@@ -155,7 +156,11 @@ func main() {
 		apc := applicationprofilecache.NewApplicationProfileCache(nodeName, k8sClient)
 		dWatcher.AddAdaptor(apc)
 
-		nnc, _ := networkneighborscache.NewNetworkNeighborsCache(k8sClient)
+		nnc := networkneighborscache.NewNetworkNeighborsCache(nodeName, k8sClient)
+		dWatcher.AddAdaptor(nnc)
+
+		aac := applicationactivitiescache.NewApplicationActivityCache(nodeName, k8sClient)
+		dWatcher.AddAdaptor(aac)
 
 		// start watching
 		dWatcher.Start(ctx)

--- a/pkg/ruleengine/objectcache/applicationactivitiescache_interface.go
+++ b/pkg/ruleengine/objectcache/applicationactivitiescache_interface.go
@@ -1,0 +1,16 @@
+package objectcache
+
+import "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+
+type ApplicationActivityCache interface {
+	GetApplicationActivity(namespace, name string) *v1beta1.ApplicationActivity
+}
+
+var _ ApplicationActivityCache = (*ApplicationActivityCacheMock)(nil)
+
+type ApplicationActivityCacheMock struct {
+}
+
+func (ap *ApplicationActivityCacheMock) GetApplicationActivity(namespace, name string) *v1beta1.ApplicationActivity {
+	return nil
+}

--- a/pkg/ruleengine/objectcache/networkneighborscache/networkneighborscache.go
+++ b/pkg/ruleengine/objectcache/networkneighborscache/networkneighborscache.go
@@ -1,26 +1,250 @@
 package networkneighborscache
 
 import (
+	"context"
+	"encoding/json"
 	"node-agent/pkg/k8sclient"
 	"node-agent/pkg/ruleengine/objectcache"
+	"node-agent/pkg/watcher"
 
+	mapset "github.com/deckarep/golang-set/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/goradd/maps"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+var _ objectcache.NetworkNeighborsCache = (*NetworkNeighborsCacheImp)(nil)
+var _ watcher.Adaptor = (*NetworkNeighborsCacheImp)(nil)
 
 var _ objectcache.NetworkNeighborsCache = (*NetworkNeighborsCacheImp)(nil)
 
 type NetworkNeighborsCacheImp struct {
-	k8sClient k8sclient.K8sClientInterface
+	nodeName              string
+	k8sClient             k8sclient.K8sClientInterface
+	podToSlug             maps.SafeMap[string, string]                    // cache the pod to slug mapping, this will enable a quick lookup of the network neighbors
+	slugToNetworkNeighbor maps.SafeMap[string, *v1beta1.NetworkNeighbors] // cache the network neighbors
+	slugToPods            maps.SafeMap[string, mapset.Set[string]]        // cache the pods that belong to the network neighbors, this will enable removing from cache AP without pods
+	allNeighbors          mapset.Set[string]                              // cache all the network neighbors that are ready. this will enable removing from cache AP without pods that are running on the same node
 }
 
-func NewNetworkNeighborsCache(k8sClient k8sclient.K8sClientInterface) (*NetworkNeighborsCacheImp, error) {
+func NewNetworkNeighborsCache(nodeName string, k8sClient k8sclient.K8sClientInterface) *NetworkNeighborsCacheImp {
 	return &NetworkNeighborsCacheImp{
+		nodeName:  nodeName,
 		k8sClient: k8sClient,
-	}, nil
+	}
 
 }
+
+// ------------------ objectcache.NetworkNeighborsCache methods -----------------------
 
 func (np *NetworkNeighborsCacheImp) GetNetworkNeighbors(namespace, name string) *v1beta1.NetworkNeighbors {
-	// TODO: implement
+	uniqueName := objectcache.UniqueName(namespace, name)
+	if np.slugToNetworkNeighbor.Has(uniqueName) {
+		return np.slugToNetworkNeighbor.Get(uniqueName)
+	}
 	return nil
+}
+
+// ------------------ watcher.Adaptor methods -----------------------
+
+// ------------------ watcher.WatchResources methods -----------------------
+
+func (np *NetworkNeighborsCacheImp) WatchResources() []watcher.WatchResource {
+	w := []watcher.WatchResource{}
+
+	// add pod
+	p := watcher.NewWatchResource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	},
+		metav1.ListOptions{
+			FieldSelector: "spec.nodeName=" + np.nodeName,
+		},
+	)
+	w = append(w, p)
+
+	// add network neighbors
+	apl := watcher.NewWatchResource(schema.GroupVersionResource{
+		Group:    "spdx.softwarecomposition.kubescape.io",
+		Version:  "v1beta1",
+		Resource: "networkneighborses",
+	}, metav1.ListOptions{})
+	w = append(w, apl)
+
+	return w
+}
+
+// ------------------ watcher.Watcher methods -----------------------
+func (np *NetworkNeighborsCacheImp) AddHandler(ctx context.Context, obj *unstructured.Unstructured) {
+	switch obj.GetKind() {
+	case "Pod":
+		np.addPod(obj)
+	case "NetworkNeighbors":
+		np.addNetworkNeighbor(ctx, obj)
+	}
+}
+func (np *NetworkNeighborsCacheImp) ModifyHandler(ctx context.Context, obj *unstructured.Unstructured) {
+	switch obj.GetKind() {
+	case "Pod":
+		// do nothing
+	case "NetworkNeighbors":
+		np.addNetworkNeighbor(ctx, obj)
+	}
+}
+func (np *NetworkNeighborsCacheImp) DeleteHandler(_ context.Context, obj *unstructured.Unstructured) {
+	switch obj.GetKind() {
+	case "Pod":
+		np.deletePod(obj)
+	case "NetworkNeighbors":
+		np.deleteNetworkNeighbor(obj)
+	}
+}
+
+// ------------------ watch pod methods -----------------------
+
+func (np *NetworkNeighborsCacheImp) addPod(podU *unstructured.Unstructured) {
+	podName := objectcache.UnstructuredUniqueName(podU)
+
+	if np.podToSlug.Has(podName) {
+		return
+	}
+	podB, err := podU.MarshalJSON()
+	if err != nil {
+		return
+	}
+
+	pod, err := workloadinterface.NewWorkload(podB)
+	if err != nil {
+		return
+	}
+
+	slug, err := np.getNetworkNeighborNameFromPod(pod)
+	if err != nil {
+		logger.L().Error("failed to get network neighbors name from pod", helpers.Error(err))
+		return
+	}
+
+	uniqueSlug := objectcache.UniqueName(pod.GetNamespace(), slug)
+	np.podToSlug.Set(podName, uniqueSlug)
+
+	if !np.slugToPods.Has(uniqueSlug) {
+		np.slugToPods.Set(uniqueSlug, mapset.NewSet[string]())
+	}
+	np.slugToPods.Get(uniqueSlug).Add(podName)
+
+	// if network neighbors exists but is not cached
+	if np.allNeighbors.Contains(uniqueSlug) && !np.slugToNetworkNeighbor.Has(uniqueSlug) {
+
+		// get the network neighbors
+		appProfile, err := np.getNetworkNeighbors(pod.GetNamespace(), slug)
+		if err != nil {
+			logger.L().Error("failed to get network neighbors", helpers.Error(err))
+			return
+		}
+		np.slugToNetworkNeighbor.Set(uniqueSlug, appProfile)
+	}
+}
+
+func (np *NetworkNeighborsCacheImp) deletePod(obj *unstructured.Unstructured) {
+	podName := objectcache.UnstructuredUniqueName(obj)
+	uniqueSlug := np.podToSlug.Get(podName)
+	np.podToSlug.Delete(podName)
+
+	// remove pod form the network neighbors mapping
+	if np.slugToPods.Has(uniqueSlug) {
+		np.slugToPods.Get(uniqueSlug).Remove(podName)
+		if np.slugToPods.Get(uniqueSlug).Cardinality() == 0 {
+			np.slugToPods.Delete(uniqueSlug)
+			// remove full network neighbors from cache
+			np.slugToNetworkNeighbor.Delete(uniqueSlug)
+		}
+	}
+}
+
+// ------------------ watch network neighbors methods -----------------------
+func (np *NetworkNeighborsCacheImp) addNetworkNeighbor(_ context.Context, obj *unstructured.Unstructured) {
+	apName := objectcache.UnstructuredUniqueName(obj)
+
+	appProfile, err := unstructuredToNetworkNeighbors(obj)
+	if err != nil {
+		logger.L().Error("failed to unmarshal network neighbors", helpers.Error(err))
+		return
+	}
+
+	// check if the network neighbors is ready
+	// TODO: @amir
+	// if was ready and now is not, remove from cache
+	// if np.slugToNetworkNeighbor.Has(apName) {
+	// 	return
+	// }
+
+	// get the full network neighbors from the storage
+	// the watch only returns the metadata
+	fullAP, err := np.getNetworkNeighbors(appProfile.GetNamespace(), appProfile.GetName())
+	if err != nil {
+		logger.L().Error("failed to get full network neighbors", helpers.Error(err))
+		return
+	}
+
+	np.slugToNetworkNeighbor.Set(apName, fullAP)
+	np.allNeighbors.Add(apName)
+	np.podToSlug.Range(func(podName, uniqueSlug string) bool {
+		if uniqueSlug == apName {
+			if !np.slugToPods.Has(uniqueSlug) {
+				np.slugToPods.Set(uniqueSlug, mapset.NewSet[string]())
+			}
+			np.slugToPods.Get(uniqueSlug).Add(podName)
+		}
+		return true
+	})
+}
+
+func (np *NetworkNeighborsCacheImp) deleteNetworkNeighbor(obj *unstructured.Unstructured) {
+	apName := objectcache.UnstructuredUniqueName(obj)
+	np.slugToNetworkNeighbor.Delete(apName)
+	np.allNeighbors.Remove(apName)
+	np.slugToPods.Delete(apName)
+}
+
+func unstructuredToNetworkNeighbors(obj *unstructured.Unstructured) (*v1beta1.NetworkNeighbors, error) {
+	bytes, err := obj.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var np *v1beta1.NetworkNeighbors
+	err = json.Unmarshal(bytes, np)
+	if err != nil {
+		return nil, err
+	}
+	return np, nil
+}
+func (np *NetworkNeighborsCacheImp) getNetworkNeighbors(namespace, name string) (*v1beta1.NetworkNeighbors, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "spdx.softwarecomposition.kubescape.io",
+		Version:  "v1beta1",
+		Resource: "networkneighborses",
+	}
+	u, err := np.k8sClient.GetDynamicClient().Resource(gvr).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return unstructuredToNetworkNeighbors(u)
+}
+
+func (np *NetworkNeighborsCacheImp) getNetworkNeighborNameFromPod(pod workloadinterface.IWorkload) (string, error) {
+	// find parentWlid
+	kind, name, err := np.k8sClient.CalculateWorkloadParentRecursive(pod)
+	if err != nil {
+		return "", err
+	}
+
+	return kind + "/" + name, nil
 }

--- a/pkg/ruleengine/objectcache/objectcache_interface.go
+++ b/pkg/ruleengine/objectcache/objectcache_interface.go
@@ -3,6 +3,7 @@ package objectcache
 type ObjectCache interface {
 	K8sObjectCache() K8sObjectCache
 	ApplicationProfileCache() ApplicationProfileCache
+	ApplicationActivityCache() ApplicationActivityCache
 	NetworkNeighborsCache() NetworkNeighborsCache
 }
 
@@ -20,4 +21,7 @@ func (om *ObjectCacheMock) ApplicationProfileCache() ApplicationProfileCache {
 }
 func (om *ObjectCacheMock) NetworkNeighborsCache() NetworkNeighborsCache {
 	return &NetworkNeighborsCacheMock{}
+}
+func (om *ObjectCacheMock) ApplicationActivityCache() ApplicationActivityCache {
+	return &ApplicationActivityCacheMock{}
 }

--- a/pkg/ruleengine/objectcache/v1/objectcache.go
+++ b/pkg/ruleengine/objectcache/v1/objectcache.go
@@ -9,14 +9,16 @@ var _ objectcache.ObjectCache = (*ObjectCacheImpl)(nil)
 type ObjectCacheImpl struct {
 	k  objectcache.K8sObjectCache
 	ap objectcache.ApplicationProfileCache
+	aa objectcache.ApplicationActivityCache
 	np objectcache.NetworkNeighborsCache
 }
 
-func NewObjectCache(k objectcache.K8sObjectCache, ap objectcache.ApplicationProfileCache, np objectcache.NetworkNeighborsCache) *ObjectCacheImpl {
+func NewObjectCache(k objectcache.K8sObjectCache, ap objectcache.ApplicationProfileCache, aa objectcache.ApplicationActivityCache, np objectcache.NetworkNeighborsCache) *ObjectCacheImpl {
 	return &ObjectCacheImpl{
 		k:  k,
 		ap: ap,
 		np: np,
+		aa: aa,
 	}
 }
 
@@ -29,4 +31,7 @@ func (o *ObjectCacheImpl) ApplicationProfileCache() objectcache.ApplicationProfi
 }
 func (o *ObjectCacheImpl) NetworkNeighborsCache() objectcache.NetworkNeighborsCache {
 	return o.np
+}
+func (o *ObjectCacheImpl) ApplicationActivityCache() objectcache.ApplicationActivityCache {
+	return o.aa
 }

--- a/pkg/watcher/dynamicwatcher/watch.go
+++ b/pkg/watcher/dynamicwatcher/watch.go
@@ -116,8 +116,10 @@ func (wh *WatchHandler) watch(ctx context.Context, resource watcher.WatchResourc
 	return nil
 }
 
-func (wh *WatchHandler) Stop(_ context.Context) error {
-	return nil
+func (wh *WatchHandler) Stop(_ context.Context) {
+	for _, q := range wh.eventQueues {
+		q.Stop()
+	}
 }
 
 func (wh *WatchHandler) watchRetry(ctx context.Context, res schema.GroupVersionResource, watchOpts metav1.ListOptions, eventQueue *cooldownqueue.CooldownQueue) {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Implemented and integrated `ApplicationActivityCache` with watcher adaptor methods.
- Enhanced `ApplicationProfileCache` and `NetworkNeighborsCache` with new caching logic and watcher adaptors.
- Extended `ObjectCache` interface to include `ApplicationActivityCache`.
- Fixed dynamic watcher `Stop` method to properly stop all event queues.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Integrate Application Activities Cache and Update Network Neighbors </code><br><code>Cache Initialization</code></dd></summary>
<hr>

main.go
<li>Added <code>applicationactivitiescache</code> to the imports and object cache <br>initialization.<br> <li> Modified <code>networkneighborscache</code> initialization to include <code>nodeName</code>.<br> <li> Added <code>applicationactivitiescache</code> and <code>networkneighborscache</code> adaptors to <br>the dynamic watcher.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationactivitiescache.go</strong><dd><code>Implement Application Activities Cache with Watcher Adaptor</code></dd></summary>
<hr>

pkg/ruleengine/objectcache/applicationactivitiescache/applicationactivitiescache.go
<li>Implemented <code>ApplicationActivityCacheImpl</code> with methods to handle <br>application activities cache.<br> <li> Added watcher adaptor methods to watch, add, modify, and delete <br>application activities.<br> <li> Implemented logic to manage pod-to-application activity mappings and <br>cache updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-f392b7703e91cf5ad2b471d27f142b12b419e167310289ff7f8521592a3a2f7c">+249/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationactivitiescache_interface.go</strong><dd><code>Define Application Activity Cache Interface and Mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/objectcache/applicationactivitiescache_interface.go
<li>Defined <code>ApplicationActivityCache</code> interface with <code>GetApplicationActivity</code> <br>method.<br> <li> Added <code>ApplicationActivityCacheMock</code> for mocking the cache in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-a3c50b6081a196bb83a772000baf3015487f144925ebded05728ede7c8f5977e">+16/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofilecache.go</strong><dd><code>Enhance Application Profile Cache Logic and Refactoring</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/objectcache/applicationprofilecache/applicationprofilecache.go
<li>Enhanced pod and application profile caching logic with slug-to-pods <br>mapping and all profiles set.<br> <li> Refactored <code>addApplicationProfile</code> method to handle application profile <br>updates more efficiently.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-80d6aada16baa81cd4a1662ae719881b3debd9562984cc366f9d7118aa27eb4b">+50/-28</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkneighborscache.go</strong><dd><code>Implement Network Neighbors Cache with Watcher Adaptor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/objectcache/networkneighborscache/networkneighborscache.go
<li>Added nodeName to <code>NetworkNeighborsCacheImp</code> struct and updated <br>constructor.<br> <li> Implemented watcher adaptor methods for network neighbors cache.<br> <li> Added logic for pod-to-network neighbor mappings and cache updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-2996e46535e3831ace138a1ac527204b16be7a459d4f49e2408f939afcc7855e">+228/-4</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>objectcache_interface.go</strong><dd><code>Extend ObjectCache Interface to Include Application Activity Cache</code></dd></summary>
<hr>

pkg/ruleengine/objectcache/objectcache_interface.go
<li>Added <code>ApplicationActivityCache</code> to the <code>ObjectCache</code> interface.<br> <li> Implemented <code>ApplicationActivityCache</code> method in <code>ObjectCacheMock</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-ae91dc81603fbe9dac9d01dbbbfcd79e47ee11d1b7fcba03f10393b35254e8a0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>objectcache.go</strong><dd><code>Update ObjectCache Implementation to Include Application Activity </code><br><code>Cache</code></dd></summary>
<hr>

pkg/ruleengine/objectcache/v1/objectcache.go
<li>Added <code>ApplicationActivityCache</code> to <code>ObjectCacheImpl</code> struct.<br> <li> Updated constructor to include <code>ApplicationActivityCache</code>.<br> <li> Implemented <code>ApplicationActivityCache</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-465e4a81b9aedad01ca669cf6321ddff1ca0896b837194abc80e68ea5b460cbb">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>watch.go</strong><dd><code>Fix Dynamic Watcher Stop Method to Properly Stop Event Queues</code></dd></summary>
<hr>

pkg/watcher/dynamicwatcher/watch.go
<li>Modified <code>Stop</code> method to stop all event queues in the dynamic watcher.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/201/files#diff-f29578a7352bf2f04d5b87fd277128222fa7ce282adc7d71a9d628c9880a5722">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

