### PR TITLE
Feature/role fixes

### DIFF
--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -51,19 +51,21 @@ type ApplicationProfileManager struct {
 	k8sClient                k8sclient.K8sClientInterface
 	storageClient            storage.StorageClient
 	syscallPeekFunc          func(nsMountId uint64) ([]string, error)
+	preRunningContainerIDs   mapset.Set[string]
 }
 
 var _ applicationprofilemanager.ApplicationProfileManagerClient = (*ApplicationProfileManager)(nil)
 
-func CreateApplicationProfileManager(ctx context.Context, cfg config.Config, clusterName string, k8sClient k8sclient.K8sClientInterface, storageClient storage.StorageClient) (*ApplicationProfileManager, error) {
+func CreateApplicationProfileManager(ctx context.Context, cfg config.Config, clusterName string, k8sClient k8sclient.K8sClientInterface, storageClient storage.StorageClient, preRunningContainerIDs mapset.Set[string]) (*ApplicationProfileManager, error) {
 	return &ApplicationProfileManager{
-		cfg:               cfg,
-		clusterName:       clusterName,
-		ctx:               ctx,
-		k8sClient:         k8sClient,
-		storageClient:     storageClient,
-		containerMutexes:  storageUtils.NewMapMutex[string](),
-		trackedContainers: mapset.NewSet[string](),
+		cfg:                    cfg,
+		clusterName:            clusterName,
+		ctx:                    ctx,
+		k8sClient:              k8sClient,
+		storageClient:          storageClient,
+		containerMutexes:       storageUtils.NewMapMutex[string](),
+		trackedContainers:      mapset.NewSet[string](),
+		preRunningContainerIDs: preRunningContainerIDs,
 	}, nil
 }
 

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -24,7 +24,7 @@ func TestApplicationProfileManager(t *testing.T) {
 	ctx := context.TODO()
 	k8sClient := &k8sclient.K8sClientMock{}
 	storageClient := &storage.StorageHttpClientMock{}
-	am, err := CreateApplicationProfileManager(ctx, cfg, "cluster", k8sClient, storageClient)
+	am, err := CreateApplicationProfileManager(ctx, cfg, "cluster", k8sClient, storageClient, nil)
 	assert.NoError(t, err)
 	// prepare container
 	container := &containercollection.Container{

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -24,6 +24,7 @@ func (ch *IGContainerWatcher) containerCallback(notif containercollection.PubSub
 			ch.unregisterContainer(notif.Container)
 		})
 	case containercollection.EventTypeRemoveContainer:
+		ch.preRunningContainers.Remove(notif.Container.Runtime.ContainerID)
 		logger.L().Info("stop monitor on container - container has terminated", helpers.String("container ID", notif.Container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
 	}
 }

--- a/pkg/containerwatcher/v1/open_test.go
+++ b/pkg/containerwatcher/v1/open_test.go
@@ -18,11 +18,11 @@ func BenchmarkIGContainerWatcher_openEventCallback(b *testing.B) {
 	ctx := context.TODO()
 	fileHandler, err := filehandler.CreateInMemoryFileHandler()
 	assert.NoError(b, err)
-	relevancyManager, err := relevancymanager.CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil)
+	relevancyManager, err := relevancymanager.CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil, nil)
 	assert.NoError(b, err)
 	mockExporter := metricsmanager.NewMetricsMock()
 
-	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, mockExporter, nil)
+	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, mockExporter, nil, nil)
 	assert.NoError(b, err)
 	event := &traceropentype.Event{
 		Event: types.Event{

--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -56,18 +56,20 @@ type NetworkManager struct {
 	watchedContainerChannels   maps.SafeMap[string, chan error] // key is ContainerID
 	dnsResolverClient          dnsmanager.DNSResolver
 	status                     string
+	preRunningContainerIDs     mapset.Set[string]
 }
 
 var _ NetworkManagerClient = (*NetworkManager)(nil)
 
-func CreateNetworkManager(ctx context.Context, cfg config.Config, k8sClient k8sclient.K8sClientInterface, storageClient storage.StorageClient, clusterName string, dnsResolverClient dnsmanager.DNSResolver) *NetworkManager {
+func CreateNetworkManager(ctx context.Context, cfg config.Config, k8sClient k8sclient.K8sClientInterface, storageClient storage.StorageClient, clusterName string, dnsResolverClient dnsmanager.DNSResolver, preRunningContainerIDs mapset.Set[string]) *NetworkManager {
 	return &NetworkManager{
-		cfg:               cfg,
-		ctx:               ctx,
-		k8sClient:         k8sClient,
-		storageClient:     storageClient,
-		clusterName:       clusterName,
-		dnsResolverClient: dnsResolverClient,
+		cfg:                    cfg,
+		ctx:                    ctx,
+		k8sClient:              k8sClient,
+		storageClient:          storageClient,
+		clusterName:            clusterName,
+		dnsResolverClient:      dnsResolverClient,
+		preRunningContainerIDs: preRunningContainerIDs,
 	}
 }
 

--- a/pkg/networkmanager/network_manager_test.go
+++ b/pkg/networkmanager/network_manager_test.go
@@ -791,7 +791,7 @@ func TestGenerateNetworkNeighborsEntries(t *testing.T) {
 			dnsResolver.addressToDomainMap.Set(k, v)
 		}
 
-		am := CreateNetworkManager(context.TODO(), config.Config{}, nil, nil, "", &dnsResolver)
+		am := CreateNetworkManager(context.TODO(), config.Config{}, nil, nil, "", &dnsResolver, nil)
 		networkEventsSet := mapset.NewSet[NetworkEvent]()
 		for _, ne := range tc.networkEvents {
 			networkEventsSet.Add(ne)
@@ -959,7 +959,7 @@ func TestIsValidEvent(t *testing.T) {
 	}
 
 	dnsResolver := dnsmanager.CreateDNSManagerMock()
-	am := CreateNetworkManager(context.TODO(), config.Config{}, nil, nil, "test", dnsResolver)
+	am := CreateNetworkManager(context.TODO(), config.Config{}, nil, nil, "test", dnsResolver, nil)
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("Input: %s", tc.name), func(t *testing.T) {

--- a/pkg/relevancymanager/v1/relevancy_manager.go
+++ b/pkg/relevancymanager/v1/relevancy_manager.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	mapset "github.com/deckarep/golang-set/v2"
 
 	"github.com/armosec/utils-k8s-go/wlid"
 	"github.com/goradd/maps"
@@ -36,18 +37,20 @@ type RelevancyManager struct {
 	k8sClient                k8sclient.K8sClientInterface
 	sbomHandler              sbomhandler.SBOMHandlerClient
 	watchedContainerChannels maps.SafeMap[string, chan error] // key is ContainerID
+	preRunningContainersIDs  mapset.Set[string]
 }
 
 var _ relevancymanager.RelevancyManagerClient = (*RelevancyManager)(nil)
 
-func CreateRelevancyManager(ctx context.Context, cfg config.Config, clusterName string, fileHandler filehandler.FileHandler, k8sClient k8sclient.K8sClientInterface, sbomHandler sbomhandler.SBOMHandlerClient) (*RelevancyManager, error) {
+func CreateRelevancyManager(ctx context.Context, cfg config.Config, clusterName string, fileHandler filehandler.FileHandler, k8sClient k8sclient.K8sClientInterface, sbomHandler sbomhandler.SBOMHandlerClient, preRunningContainerIDs mapset.Set[string]) (*RelevancyManager, error) {
 	return &RelevancyManager{
-		cfg:         cfg,
-		clusterName: clusterName,
-		ctx:         ctx,
-		fileHandler: fileHandler,
-		k8sClient:   k8sClient,
-		sbomHandler: sbomHandler,
+		cfg:                     cfg,
+		clusterName:             clusterName,
+		ctx:                     ctx,
+		fileHandler:             fileHandler,
+		k8sClient:               k8sClient,
+		sbomHandler:             sbomHandler,
+		preRunningContainersIDs: preRunningContainerIDs,
 	}, nil
 }
 

--- a/pkg/relevancymanager/v1/relevancy_manager_test.go
+++ b/pkg/relevancymanager/v1/relevancy_manager_test.go
@@ -30,7 +30,7 @@ func BenchmarkRelevancyManager_ReportFileExec(b *testing.B) {
 	ctx := context.TODO()
 	fileHandler, err := filehandler.CreateInMemoryFileHandler()
 	assert.NoError(b, err)
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil, nil)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		relevancyManager.ReportFileExec("ns", "file")
@@ -61,7 +61,7 @@ func TestRelevancyManager(t *testing.T) {
 	storageClient := storage.CreateSyftSBOMStorageHttpClientMock(syftDoc)
 	sbomHandler := syfthandler.CreateSyftSBOMHandler(storageClient)
 
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, nil)
 	assert.NoError(t, err)
 	// report container started
 	container := &containercollection.Container{
@@ -164,7 +164,7 @@ func TestRelevancyManagerIncompleteSBOM(t *testing.T) {
 
 	storageClient := storage.CreateSyftSBOMStorageHttpClientMock(syftDoc)
 	sbomHandler := syfthandler.CreateSyftSBOMHandler(storageClient)
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, nil)
 	assert.NoError(t, err)
 
 	// report container started

--- a/pkg/ruleengine/v1/helpers.go
+++ b/pkg/ruleengine/v1/helpers.go
@@ -14,6 +14,7 @@ func getExecPathFromEvent(event *tracerexectype.Event) string {
 	}
 	return event.Comm
 }
+
 func getContainerFromApplicationProfile(ap *v1beta1.ApplicationProfile, containerName string) (v1beta1.ApplicationProfileContainer, error) {
 	for i := range ap.Spec.Containers {
 		if ap.Spec.Containers[i].Name == containerName {

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -145,6 +145,7 @@ func RandomxToGeneralEvent(event *tracerrandomxtype.Event) *GeneralEvent {
 	return &GeneralEvent{
 		ProcessDetails: ProcessDetails{
 			Pid:  event.Pid,
+			Ppid: event.PPid,
 			Comm: event.Comm,
 			Uid:  event.Uid,
 			Gid:  event.Gid,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"github.com/deckarep/golang-set/v2"
 	"math/rand"
 	"path/filepath"
 	"runtime"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
 
 	"github.com/goradd/maps"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1/containerinstance"


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Added support for handling pre-existing container IDs across various managers (`ApplicationProfileManager`, `NetworkManager`, `RelevancyManager`, `RuleManager`) and the `ContainerWatcher`.
- Enhanced `ContainerWatcher` to generate container events on startup for pre-existing containers.
- Updated constructor functions to accept `preRunningContainerIDs` for integrating pre-existing container support.
- Modified tests and benchmarks to accommodate new changes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add Support for Pre-existing Container IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go
<li>Added support for pre-existing container IDs using <code>mapset</code> library.<br> <li> Passed <code>preRunningContainersIDs</code> to various manager creation functions.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+10/-5</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Integrate Pre-existing Container IDs into Application Profile Manager</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Added <code>preRunningContainerIDs</code> to <code>ApplicationProfileManager</code> struct.<br> <li> Modified <code>CreateApplicationProfileManager</code> to accept <br><code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+10/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Enhance Container Watcher with Pre-existing Container Support</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Added <code>preRunningContainers</code> field to <code>IGContainerWatcher</code>.<br> <li> Updated <code>CreateIGContainerWatcher</code> to accept <code>preRunningContainers</code>.<br> <li> Implemented logic to handle pre-existing containers at startup.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+41/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher_private.go</strong><dd><code>Update Container Removal Logic for Pre-existing Containers</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher_private.go
<li>Remove pre-existing container ID from <code>preRunningContainers</code> on <br>container removal.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-6f95b4caa6090a17da5aed1923600fd049392d228e0fba99cc212f48111f3ffe">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Integrate Pre-existing Container IDs into Network Manager</code></dd></summary>
<hr>

pkg/networkmanager/network_manager.go
<li>Added <code>preRunningContainerIDs</code> to <code>NetworkManager</code> struct.<br> <li> Modified <code>CreateNetworkManager</code> to accept <code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-cbcd69c2d2fb59b909f8b3cec3ff32348a1ddb4f1d465ece79ead0fa0ba7168b">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager.go</strong><dd><code>Integrate Pre-existing Container IDs into Relevancy Manager</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager.go
<li>Added <code>preRunningContainersIDs</code> to <code>RelevancyManager</code> struct.<br> <li> Modified <code>CreateRelevancyManager</code> to accept <code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-f665b80e0e8d6552b56e677f5579b3b90cb7cd78999a4bec61d41522469393a3">+10/-7</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Integrate Pre-existing Container IDs into Rule Manager</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Added <code>preRunningContainerIDs</code> to <code>RuleManager</code> struct.<br> <li> Modified <code>CreateRuleManager</code> to accept <code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+21/-35</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go</strong><dd><code>Update Application Profile Manager Tests for Pre-existing Container </code><br><code>IDs</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
<li>Updated <code>CreateApplicationProfileManager</code> call in tests to include <br><code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>open_test.go</strong><dd><code>Update Container Watcher Benchmark for Pre-existing Container Support</code></dd></summary>
<hr>

pkg/containerwatcher/v1/open_test.go
<li>Updated <code>CreateIGContainerWatcher</code> call in benchmark to include <br><code>preRunningContainers</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-108b6c5c8056d52d17a43bba61a908715238d3bc3a2919f6332ca926509d2ec2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager_test.go</strong><dd><code>Update Network Manager Tests for Pre-existing Container IDs</code></dd></summary>
<hr>

pkg/networkmanager/network_manager_test.go
<li>Updated <code>CreateNetworkManager</code> call in tests to include <br><code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-e8a17f0b67b47061eaf0c83c3f844cb397d281e1eb7ea9a4cb1b5ee48e9f57e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_test.go</strong><dd><code>Update Relevancy Manager Tests for Pre-existing Container IDs</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager_test.go
<li>Updated <code>CreateRelevancyManager</code> call in tests to include <br><code>preRunningContainerIDs</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/208/files#diff-03d056dd81b53a3e65816a06b634ac3b332d230d23c5ca3ade4376fafb39143a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

