### PR TITLE
Dropped events

### DIFF
--- a/pkg/containerwatcher/v1/container_watcher.go
+++ b/pkg/containerwatcher/v1/container_watcher.go
@@ -94,6 +94,13 @@ type IGContainerWatcher struct {
 	dnsWorkerPool          *ants.PoolWithFunc
 	randomxWorkerPool      *ants.PoolWithFunc
 
+	capabilitiesWorkerChan chan *tracercapabilitiestype.Event
+	execWorkerChan         chan *tracerexectype.Event
+	openWorkerChan         chan *traceropentype.Event
+	networkWorkerChan      chan *tracernetworktype.Event
+	dnsWorkerChan          chan *tracerdnstype.Event
+	randomxWorkerChan      chan *tracerandomxtype.Event
+
 	preRunningContainersIDs mapset.Set[string]
 
 	metrics metricsmanager.MetricsManager
@@ -259,6 +266,14 @@ func CreateIGContainerWatcher(cfg config.Config, applicationProfileManager appli
 		randomxWorkerPool:       randomxWorkerPool,
 		metrics:                 metrics,
 		preRunningContainersIDs: preRunningContainers,
+
+		// Channels
+		capabilitiesWorkerChan: make(chan *tracercapabilitiestype.Event, 10),
+		execWorkerChan:         make(chan *tracerexectype.Event, 50),
+		openWorkerChan:         make(chan *traceropentype.Event, 500),
+		networkWorkerChan:      make(chan *tracernetworktype.Event, 50),
+		dnsWorkerChan:          make(chan *tracerdnstype.Event, 50),
+		randomxWorkerChan:      make(chan *tracerandomxtype.Event, 10),
 	}, nil
 }
 

--- a/pkg/containerwatcher/v1/network.go
+++ b/pkg/containerwatcher/v1/network.go
@@ -35,7 +35,7 @@ func (ch *IGContainerWatcher) networkEventCallback(event *tracernetworktypes.Eve
 		}
 	}
 
-	_ = ch.networkWorkerPool.Invoke(*event)
+	ch.networkWorkerChan <- event
 }
 
 func (ch *IGContainerWatcher) startNetworkTracing() error {
@@ -48,6 +48,11 @@ func (ch *IGContainerWatcher) startNetworkTracing() error {
 	if err != nil {
 		return fmt.Errorf("creating tracer: %w", err)
 	}
+	go func() {
+		for event := range ch.networkWorkerChan {
+			ch.networkWorkerPool.Invoke(*event)
+		}
+	}()
 
 	tracerNetwork.SetEventHandler(ch.networkEventCallback)
 

--- a/pkg/containerwatcher/v1/open.go
+++ b/pkg/containerwatcher/v1/open.go
@@ -16,7 +16,7 @@ func (ch *IGContainerWatcher) openEventCallback(event *traceropentype.Event) {
 		logger.L().Ctx(ch.ctx).Warning("open tracer got drop events - we may miss some realtime data", helpers.Interface("event", event), helpers.String("error", event.Message))
 	}
 	if event.Ret > -1 && event.Path != "" {
-		_ = ch.openWorkerPool.Invoke(*event)
+		ch.openWorkerChan <- event
 	}
 }
 
@@ -24,6 +24,12 @@ func (ch *IGContainerWatcher) startOpenTracing() error {
 	if err := ch.tracerCollection.AddTracer(openTraceName, ch.containerSelector); err != nil {
 		return fmt.Errorf("adding tracer: %w", err)
 	}
+
+	go func() {
+		for c := range ch.openWorkerChan {
+			_ = ch.openWorkerPool.Invoke(*c)
+		}
+	}()
 
 	// Get mount namespace map to filter by containers
 	openMountnsmap, err := ch.tracerCollection.TracerMountNsMap(openTraceName)


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Implemented worker channels for handling various types of events (DNS, exec, network, open, randomx) in a non-blocking manner.
- Added goroutines for processing events from channels, enhancing the efficiency of event handling.
- Enhanced pod tracking in the RuleBinding cache by adding a new set for all pods and modifying the `IsCached` method.
- Improved the pod caching mechanism in the RuleManager with the introduction of mutexes to prevent race conditions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Implement Worker Channels for Event Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Added worker channels for handling events in a non-blocking manner.<br> <li> Initialized worker channels in <code>CreateIGContainerWatcher</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dns.go</strong><dd><code>Use Channels for DNS Event Processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/dns.go
<li>Replaced direct worker pool invocation with channel-based event <br>handling.<br> <li> Added a goroutine to process DNS events from the channel.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-cbd9798476031eee0f2a08ae4df4033ac6ab9560b6637465e59075d395b7542b">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>exec.go</strong><dd><code>Use Channels for Exec Event Processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/exec.go
<li>Replaced direct worker pool invocation with channel-based event <br>handling for exec events.<br> <li> Added a goroutine to process exec events from the channel.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-95bba503637ab3f7e32434d1cb37b47e08ccd06907135350e6404febddf55f0e">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network.go</strong><dd><code>Use Channels for Network Event Processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/network.go
<li>Replaced direct worker pool invocation with channel-based event <br>handling for network events.<br> <li> Added a goroutine to process network events from the channel.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-7c522b60112dd344d811a511fd95baef6f518f918dfeb3d08f44eeb598f3c387">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>open.go</strong><dd><code>Use Channels for Open Event Processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/open.go
<li>Replaced direct worker pool invocation with channel-based event <br>handling for open events.<br> <li> Added a goroutine to process open events from the channel.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-62176d3b35342542f601e9e5c91593ff16fcbd9f948bf566af9a4d25b46cfd86">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>randomx.go</strong><dd><code>Use Channels for Randomx Event Processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/randomx.go
<li>Replaced direct worker pool invocation with channel-based event <br>handling for randomx events.<br> <li> Added a goroutine to process randomx events from the channel.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-68d1c0781235514dc017012a6dda1124d4079ad3ff0ecd3762d7eac6026c4bc2">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Enhance Pod Tracking in RuleBinding Cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Added a new mapset for all pods to track pods without rules.<br> <li> Modified <code>IsCached</code> method to check against all pods.<br> <li> Added pods to the allPods set after processing in <code>addPod</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Improve Pod Caching Mechanism with Mutexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Added mutexes for pod caching to prevent race conditions.<br> <li> Modified <code>isCached</code> method to use read and write locks for pod caching.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/219/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+24/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

