### PR TITLE
Moved syscalls to application profile, stop relevancy manager for pre-running containers

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -4,6 +4,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     branches:
       - 'main'
+      - 'rule-manager'
     paths-ignore:
       - '*.md'
       - '*.yaml'

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -224,6 +224,10 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 
 	// application activity
 	// get syscalls from IG
+
+	var syscalls []string
+	var newSyscalls []string
+
 	if am.syscallPeekFunc != nil {
 		observedSyscalls, err := am.syscallPeekFunc(watchedContainer.NsMntId)
 		if err != nil {
@@ -237,36 +241,8 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		savedSyscalls := am.savedSyscalls.Get(watchedContainer.K8sContainerID)
 		toSaveSyscalls := mapset.NewSet[string](observedSyscalls...).Difference(savedSyscalls)
 		if !toSaveSyscalls.IsEmpty() {
-			newActivity := &v1beta1.ApplicationActivity{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: slug,
-					Annotations: map[string]string{
-						helpersv1.WlidMetadataKey:       watchedContainer.Wlid,
-						helpersv1.CompletionMetadataKey: string(watchedContainer.GetCompletionStatus()),
-						helpersv1.StatusMetadataKey:     string(watchedContainer.GetStatus()),
-					},
-					Labels: utils.GetLabels(watchedContainer, true),
-				},
-			}
-			// add syscalls
-			newActivity.Spec.Syscalls = observedSyscalls
-			// save application activity
-			if err := am.storageClient.CreateApplicationActivity(newActivity, namespace); err != nil {
-				logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to save application activity", helpers.Error(err),
-					helpers.String("slug", slug),
-					helpers.Int("container index", watchedContainer.ContainerIndex),
-					helpers.String("container ID", watchedContainer.ContainerID),
-					helpers.String("k8s workload", watchedContainer.K8sContainerID))
-			} else {
-				// record saved syscalls
-				am.savedSyscalls.Get(watchedContainer.K8sContainerID).Append(toSaveSyscalls.ToSlice()...)
-				logger.L().Debug("ApplicationProfileManager - saved application activity",
-					helpers.Int("syscalls", toSaveSyscalls.Cardinality()),
-					helpers.String("slug", slug),
-					helpers.Int("container index", watchedContainer.ContainerIndex),
-					helpers.String("container ID", watchedContainer.ContainerID),
-					helpers.String("k8s workload", watchedContainer.K8sContainerID))
-			}
+			syscalls = observedSyscalls
+			newSyscalls = toSaveSyscalls.ToSlice()
 		}
 	} else {
 		logger.L().Ctx(ctx).Error("ApplicationProfileManager - syscall peek function is nil", helpers.String("slug", slug))
@@ -322,9 +298,9 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 	// 3a. the profile is missing Containers or InitContainers - ADD one with the container profile at the right index
 	// 3b. the profile is missing the container profile - ADD the container profile at the right index
 	// 3c. default - patch the container ourselves and REPLACE it at the right index
-	if len(capabilities) > 0 || len(execs) > 0 || len(opens) > 0 || watchedContainer.StatusUpdated() {
+	if len(capabilities) > 0 || len(execs) > 0 || len(opens) > 0 || len(syscalls) > 0 || watchedContainer.StatusUpdated() {
 		// calculate patch
-		profileOperations := utils.CreateCapabilitiesPatchOperations(capabilities, execs, opens, watchedContainer.ContainerType.String(), watchedContainer.ContainerIndex)
+		profileOperations := utils.CreateCapabilitiesPatchOperations(capabilities, syscalls, execs, opens, watchedContainer.ContainerType.String(), watchedContainer.ContainerIndex)
 		profileOperations = utils.AppendStatusAnnotationPatchOperations(profileOperations, watchedContainer)
 
 		patch, err := json.Marshal(profileOperations)
@@ -356,7 +332,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 				newProfileContainer := &v1beta1.ApplicationProfileContainer{
 					Name: watchedContainer.InstanceID.GetContainerName(),
 				}
-				utils.EnrichProfileContainer(newProfileContainer, capabilities, execs, opens)
+				utils.EnrichProfileContainer(newProfileContainer, capabilities, syscalls, execs, opens)
 				// insert application profile container
 				utils.InsertApplicationProfileContainer(newProfile, watchedContainer.ContainerType, watchedContainer.ContainerIndex, newProfileContainer)
 				// try to create application profile
@@ -395,7 +371,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 						addProfileContainer = true
 					}
 					// update it
-					utils.EnrichProfileContainer(existingProfileContainer, capabilities, execs, opens)
+					utils.EnrichProfileContainer(existingProfileContainer, capabilities, syscalls, execs, opens)
 					// get existing containers
 					var existingContainers []v1beta1.ApplicationProfileContainer
 					if watchedContainer.ContainerType == utils.Container {
@@ -468,6 +444,8 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 			// for status updates to be tracked, we reset the update flag
 			watchedContainer.ResetStatusUpdatedFlag()
 
+			// record saved syscalls
+			am.savedSyscalls.Get(watchedContainer.K8sContainerID).Append(newSyscalls...)
 			// record saved capabilities
 			am.savedCapabilities.Get(watchedContainer.K8sContainerID).Append(capabilities...)
 			// record saved execs

--- a/pkg/containerwatcher/v1/container_watcher.go
+++ b/pkg/containerwatcher/v1/container_watcher.go
@@ -153,7 +153,7 @@ func CreateIGContainerWatcher(cfg config.Config, applicationProfileManager appli
 		}
 		metrics.ReportEvent(utils.ExecveEventType)
 		applicationProfileManager.ReportFileExec(k8sContainerID, path, event.Args)
-		relevancyManager.ReportFileExec(k8sContainerID, path)
+		relevancyManager.ReportFileExec(event.Runtime.ContainerID, k8sContainerID, path)
 		ruleManager.ReportFileExec(k8sContainerID, event)
 		malwareManager.ReportFileExec(k8sContainerID, event)
 	})
@@ -181,7 +181,7 @@ func CreateIGContainerWatcher(cfg config.Config, applicationProfileManager appli
 		}
 		metrics.ReportEvent(utils.OpenEventType)
 		applicationProfileManager.ReportFileOpen(k8sContainerID, path, event.Flags)
-		relevancyManager.ReportFileExec(k8sContainerID, path)
+		relevancyManager.ReportFileOpen(event.Runtime.ContainerID, k8sContainerID, path)
 		ruleManager.ReportFileOpen(k8sContainerID, event)
 		malwareManager.ReportFileOpen(k8sContainerID, event)
 	})

--- a/pkg/relevancymanager/relevancy_manager_interface.go
+++ b/pkg/relevancymanager/relevancy_manager_interface.go
@@ -6,5 +6,6 @@ import (
 
 type RelevancyManagerClient interface {
 	ContainerCallback(notif containercollection.PubSubEvent)
-	ReportFileExec(k8sContainerID, file string)
+	ReportFileExec(containerID, k8sContainerID, file string)
+	ReportFileOpen(containerID, k8sContainerID, file string)
 }

--- a/pkg/relevancymanager/relevancy_manager_mock.go
+++ b/pkg/relevancymanager/relevancy_manager_mock.go
@@ -15,6 +15,10 @@ func (r RelevancyManagerMock) ContainerCallback(_ containercollection.PubSubEven
 	// noop
 }
 
-func (r RelevancyManagerMock) ReportFileExec(_, _ string) {
+func (r RelevancyManagerMock) ReportFileExec(_, _, _ string) {
+	// noop
+}
+
+func (r RelevancyManagerMock) ReportFileOpen(_, _, _ string) {
 	// noop
 }

--- a/pkg/relevancymanager/v1/relevancy_manager_test.go
+++ b/pkg/relevancymanager/v1/relevancy_manager_test.go
@@ -33,7 +33,7 @@ func BenchmarkRelevancyManager_ReportFileExec(b *testing.B) {
 	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil, nil)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
-		relevancyManager.ReportFileExec("ns", "file")
+		relevancyManager.ReportFileExec("ns", "ns", "file")
 	}
 	b.ReportAllocs()
 }
@@ -91,13 +91,13 @@ func TestRelevancyManager(t *testing.T) {
 	}
 
 	for _, file := range files {
-		relevancyManager.ReportFileExec("ns/pod/cont", file)
+		relevancyManager.ReportFileExec("ns/pod/cont", "ns/pod/cont", file)
 	}
 
 	// let it run for a while
 	time.Sleep(5 * time.Second)
 	// report a same file again, should do noop
-	relevancyManager.ReportFileExec("ns/pod/cont", "/usr/sbin/deluser")
+	relevancyManager.ReportFileExec("ns/pod/cont", "ns/pod/cont", "/usr/sbin/deluser")
 	// let it run for a while
 	time.Sleep(5 * time.Second)
 	// verify files are reported and we have only 1 filtered SBOM
@@ -107,7 +107,7 @@ func TestRelevancyManager(t *testing.T) {
 	assert.Equal(t, "/usr/sbin/deluser", storageClient.FilteredSyftSBOMs[0].Spec.Syft.Files[0].Location.RealPath)
 
 	// add one more vulnerable file
-	relevancyManager.ReportFileExec("ns/pod/cont", "/etc/deluser.conf")
+	relevancyManager.ReportFileExec("ns/pod/cont", "ns/pod/cont", "/etc/deluser.conf")
 	time.Sleep(1 * time.Second)
 	// report container stopped
 	relevancyManager.ContainerCallback(containercollection.PubSubEvent{
@@ -187,7 +187,7 @@ func TestRelevancyManagerIncompleteSBOM(t *testing.T) {
 		Container: container,
 	})
 	// report file access
-	relevancyManager.ReportFileExec("ns/pod/cont", "/usr/sbin/deluser")
+	relevancyManager.ReportFileExec("ns/pod/cont", "ns/pod/cont", "/usr/sbin/deluser")
 	// let it run for a while
 	time.Sleep(10 * time.Second)
 	// report container stopped

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -305,13 +305,13 @@ func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsC
 	return 0
 }
 
-func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
+func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities, observedSyscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
 	// add capabilities
 	sort.Strings(observedCapabilities)
 	newProfileContainer.Capabilities = observedCapabilities
 	// add syscalls
-	sort.Strings(syscalls)
-	newProfileContainer.Syscalls = syscalls
+	sort.Strings(observedSyscalls)
+	newProfileContainer.Syscalls = observedSyscalls
 	// add execs
 	newProfileContainer.Execs = make([]v1beta1.ExecCalls, 0)
 	for path, exec := range execs {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -305,10 +305,13 @@ func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsC
 	return 0
 }
 
-func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
+func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
 	// add capabilities
 	sort.Strings(observedCapabilities)
 	newProfileContainer.Capabilities = observedCapabilities
+	// add syscalls
+	sort.Strings(syscalls)
+	newProfileContainer.Syscalls = syscalls
 	// add execs
 	newProfileContainer.Execs = make([]v1beta1.ExecCalls, 0)
 	for path, exec := range execs {
@@ -345,7 +348,7 @@ func EscapeJSONPointerElement(s string) string {
 	return s
 }
 
-func CreateCapabilitiesPatchOperations(capabilities []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
+func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
 	var profileOperations []PatchOperation
 	// add capabilities
 	sort.Strings(capabilities)
@@ -357,6 +360,17 @@ func CreateCapabilitiesPatchOperations(capabilities []string, execs map[string]m
 			Value: capability,
 		})
 	}
+	// add syscalls
+	sort.Strings(syscalls)
+	sysCallsPath := fmt.Sprintf("/spec/%s/%d/syscalls/-", containerType, containerIndex)
+	for _, syscall := range syscalls {
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:    "add",
+			Path:  sysCallsPath,
+			Value: syscall,
+		})
+	}
+
 	// add execs
 	execsPath := fmt.Sprintf("/spec/%s/%d/execs/-", containerType, containerIndex)
 	for path, exec := range execs {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Refactored syscall collection and saving logic in `applicationprofile_manager.go` for efficiency and clarity.
- Updated `container_watcher.go` to pass container ID to relevancy manager methods, enhancing traceability.
- Extended the `RelevancyManagerClient` interface to include `ReportFileOpen` and updated `ReportFileExec` to require container ID.
- Implemented the new interface methods in `RelevancyManagerMock` and `RelevancyManager`, with additional logic to handle pre-running containers.
- Updated utility functions in `utils.go` to support syscall data in profile containers and patch operations.
- Adjusted relevancy manager tests to accommodate new method signatures and logic.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Refactor Syscall Collection and Enhance Profile Patching</code>&nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Refactored syscall collection and saving logic.<br> <li> Enhanced profile patching to include syscall data.<br> <li> Optimized syscall saving by using sets for uniqueness and checking <br>before saving.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+14/-37</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Update Container Watcher to Include Container ID in Relevancy Manager </code><br><code>Calls</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Updated <code>ReportFileExec</code> and <code>ReportFileOpen</code> methods to include container <br>ID in relevancy manager calls.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_interface.go</strong><dd><code>Extend Relevancy Manager Interface with File Open Reporting</code></dd></summary>
<hr>

pkg/relevancymanager/relevancy_manager_interface.go
<li>Added <code>ReportFileOpen</code> method to the <code>RelevancyManagerClient</code> interface.<br> <li> Updated <code>ReportFileExec</code> method signature to include container ID.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-15761e78a5217b4c8e272a8a33389c153ff9e9744a6fac9e008eff354858041c">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_mock.go</strong><dd><code>Implement New Interface Methods in Relevancy Manager Mock</code></dd></summary>
<hr>

pkg/relevancymanager/relevancy_manager_mock.go
<li>Implemented <code>ReportFileOpen</code> method in <code>RelevancyManagerMock</code>.<br> <li> Updated <code>ReportFileExec</code> method in <code>RelevancyManagerMock</code> to match <br>interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-62a84f3a30d5aef360919a77b6f637666155db4d9b33204417ebf9f57dbc8fb8">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager.go</strong><dd><code>Enhance Relevancy Manager with Pre-Running Container Checks and New </code><br><code>Reporting Methods</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager.go
<li>Implemented logic to ignore pre-running containers in relevancy <br>checks.<br> <li> Added handling for <code>ReportFileExec</code> and <code>ReportFileOpen</code> including <br>pre-running container checks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-f665b80e0e8d6552b56e677f5579b3b90cb7cd78999a4bec61d41522469393a3">+27/-9</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Enhance Utility Functions to Support Syscall Data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils.go
<li>Enhanced <code>EnrichProfileContainer</code> and <code>CreateCapabilitiesPatchOperations</code> <br>to include syscalls.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+16/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_test.go</strong><dd><code>Update Relevancy Manager Tests for New Logic and Methods</code>&nbsp; </dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager_test.go
<li>Updated tests to reflect new method signatures and logic in relevancy <br>manager.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/223/files#diff-03d056dd81b53a3e65816a06b634ac3b332d230d23c5ca3ade4376fafb39143a">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

