### PR TITLE
renamed storage_no_cache, fix NN patch

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	// Create clients
 	k8sClient := k8sinterface.NewKubernetesApi()
-	storageClient, err := storage.CreateStorageNoCache(clusterData.Namespace)
+	storageClient, err := storage.CreateStorage(clusterData.Namespace)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("error creating the storage client", helpers.Error(err))
 	}

--- a/pkg/storage/v1/storage.go
+++ b/pkg/storage/v1/storage.go
@@ -25,15 +25,15 @@ const (
 	KubeConfig                       = "KUBECONFIG"
 )
 
-type StorageNoCache struct {
+type Storage struct {
 	StorageClient             spdxv1beta1.SpdxV1beta1Interface
 	maxApplicationProfileSize int
 	namespace                 string
 }
 
-var _ storage.StorageClient = (*StorageNoCache)(nil)
+var _ storage.StorageClient = (*Storage)(nil)
 
-func CreateStorageNoCache(namespace string) (*StorageNoCache, error) {
+func CreateStorage(namespace string) (*Storage, error) {
 	var config *rest.Config
 	kubeconfig := os.Getenv(KubeConfig)
 	// use the current context in kubeconfig
@@ -55,21 +55,21 @@ func CreateStorageNoCache(namespace string) (*StorageNoCache, error) {
 		maxApplicationProfileSize = DefaultMaxApplicationProfileSize
 	}
 
-	return &StorageNoCache{
+	return &Storage{
 		StorageClient:             clientset.SpdxV1beta1(),
 		maxApplicationProfileSize: maxApplicationProfileSize,
 		namespace:                 namespace,
 	}, nil
 }
 
-func CreateFakeStorageNoCache(namespace string) (*StorageNoCache, error) {
-	return &StorageNoCache{
+func CreateFakeStorage(namespace string) (*Storage, error) {
+	return &Storage{
 		StorageClient: fake.NewSimpleClientset().SpdxV1beta1(),
 		namespace:     namespace,
 	}, nil
 }
 
-func (sc StorageNoCache) CreateNetworkNeighbors(networkNeighbors *v1beta1.NetworkNeighbors, namespace string) error {
+func (sc Storage) CreateNetworkNeighbors(networkNeighbors *v1beta1.NetworkNeighbors, namespace string) error {
 	_, err := sc.StorageClient.NetworkNeighborses(namespace).Create(context.Background(), networkNeighbors, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -77,11 +77,11 @@ func (sc StorageNoCache) CreateNetworkNeighbors(networkNeighbors *v1beta1.Networ
 	return nil
 }
 
-func (sc StorageNoCache) GetNetworkNeighbors(namespace, name string) (*v1beta1.NetworkNeighbors, error) {
+func (sc Storage) GetNetworkNeighbors(namespace, name string) (*v1beta1.NetworkNeighbors, error) {
 	return sc.StorageClient.NetworkNeighborses(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (sc StorageNoCache) PatchNetworkNeighborsIngressAndEgress(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error {
+func (sc Storage) PatchNetworkNeighborsIngressAndEgress(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error {
 	bytes, err := json.Marshal(networkNeighbors)
 	if err != nil {
 		return err
@@ -95,13 +95,13 @@ func (sc StorageNoCache) PatchNetworkNeighborsIngressAndEgress(name, namespace s
 	return nil
 }
 
-func (sc StorageNoCache) PatchNetworkNeighborsMatchLabels(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error {
+func (sc Storage) PatchNetworkNeighborsMatchLabels(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error {
 	_, err := sc.StorageClient.NetworkNeighborses(namespace).Update(context.Background(), networkNeighbors, metav1.UpdateOptions{})
 
 	return err
 }
 
-func (sc StorageNoCache) CreateApplicationActivity(activity *v1beta1.ApplicationActivity, namespace string) error {
+func (sc Storage) CreateApplicationActivity(activity *v1beta1.ApplicationActivity, namespace string) error {
 	_, err := sc.StorageClient.ApplicationActivities(namespace).Create(context.Background(), activity, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -109,11 +109,11 @@ func (sc StorageNoCache) CreateApplicationActivity(activity *v1beta1.Application
 	return nil
 }
 
-func (sc StorageNoCache) GetApplicationActivity(namespace, name string) (*v1beta1.ApplicationActivity, error) {
+func (sc Storage) GetApplicationActivity(namespace, name string) (*v1beta1.ApplicationActivity, error) {
 	return sc.StorageClient.ApplicationActivities(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (sc StorageNoCache) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error {
+func (sc Storage) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error {
 	// unset resourceVersion
 	profile.ResourceVersion = ""
 	_, err := sc.StorageClient.ApplicationProfiles(namespace).Create(context.Background(), profile, metav1.CreateOptions{})
@@ -123,7 +123,7 @@ func (sc StorageNoCache) CreateApplicationProfile(profile *v1beta1.ApplicationPr
 	return nil
 }
 
-func (sc StorageNoCache) PatchApplicationProfile(name, namespace string, patch []byte, channel chan error) error {
+func (sc Storage) PatchApplicationProfile(name, namespace string, patch []byte, channel chan error) error {
 	profile, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, patch, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("patch application profile: %w", err)
@@ -168,11 +168,11 @@ func (sc StorageNoCache) PatchApplicationProfile(name, namespace string, patch [
 	return nil
 }
 
-func (sc StorageNoCache) GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error) {
+func (sc Storage) GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error) {
 	return sc.StorageClient.ApplicationProfiles(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (sc StorageNoCache) CreateApplicationProfileSummary(profile *v1beta1.ApplicationProfileSummary, namespace string) error {
+func (sc Storage) CreateApplicationProfileSummary(profile *v1beta1.ApplicationProfileSummary, namespace string) error {
 	_, err := sc.StorageClient.ApplicationProfileSummaries(namespace).Create(context.Background(), profile, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func (sc StorageNoCache) CreateApplicationProfileSummary(profile *v1beta1.Applic
 	return nil
 }
 
-func (sc StorageNoCache) CreateFilteredSBOM(SBOM *v1beta1.SBOMSyftFiltered) error {
+func (sc Storage) CreateFilteredSBOM(SBOM *v1beta1.SBOMSyftFiltered) error {
 	_, err := sc.StorageClient.SBOMSyftFiltereds(sc.namespace).Create(context.Background(), SBOM, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -188,15 +188,15 @@ func (sc StorageNoCache) CreateFilteredSBOM(SBOM *v1beta1.SBOMSyftFiltered) erro
 	return nil
 }
 
-func (sc StorageNoCache) GetFilteredSBOM(name string) (*v1beta1.SBOMSyftFiltered, error) {
+func (sc Storage) GetFilteredSBOM(name string) (*v1beta1.SBOMSyftFiltered, error) {
 	return sc.StorageClient.SBOMSyftFiltereds(sc.namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (sc StorageNoCache) GetSBOM(name string) (*v1beta1.SBOMSyft, error) {
+func (sc Storage) GetSBOM(name string) (*v1beta1.SBOMSyft, error) {
 	return sc.StorageClient.SBOMSyfts(sc.namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
-func (sc StorageNoCache) PatchFilteredSBOM(name string, SBOM *v1beta1.SBOMSyftFiltered) error {
+func (sc Storage) PatchFilteredSBOM(name string, SBOM *v1beta1.SBOMSyftFiltered) error {
 	bytes, err := json.Marshal(SBOM)
 	if err != nil {
 		return err
@@ -208,10 +208,10 @@ func (sc StorageNoCache) PatchFilteredSBOM(name string, SBOM *v1beta1.SBOMSyftFi
 	return nil
 }
 
-func (sc StorageNoCache) IncrementImageUse(_ string) {
+func (sc Storage) IncrementImageUse(_ string) {
 	// noop
 }
 
-func (sc StorageNoCache) DecrementImageUse(_ string) {
+func (sc Storage) DecrementImageUse(_ string) {
 	// noop
 }

--- a/pkg/storage/v1/storage_test.go
+++ b/pkg/storage/v1/storage_test.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestStorageNoCache_CreateFilteredSBOM(t *testing.T) {
+func TestStorage_CreateFilteredSBOM(t *testing.T) {
 	type args struct {
 		SBOM *v1beta1.SBOMSyftFiltered
 	}
@@ -33,7 +33,7 @@ func TestStorageNoCache_CreateFilteredSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache("kubescape")
+			sc, _ := CreateFakeStorage("kubescape")
 			if err := sc.CreateFilteredSBOM(tt.args.SBOM); (err != nil) != tt.wantErr {
 				t.Errorf("CreateFilteredSBOM() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -41,7 +41,7 @@ func TestStorageNoCache_CreateFilteredSBOM(t *testing.T) {
 	}
 }
 
-func TestStorageNoCache_GetSBOM(t *testing.T) {
+func TestStorage_GetSBOM(t *testing.T) {
 	type args struct {
 		name string
 	}
@@ -75,7 +75,7 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache("kubescape")
+			sc, _ := CreateFakeStorage("kubescape")
 			if tt.createSBOM {
 				_, _ = sc.StorageClient.SBOMSyfts("kubescape").Create(context.Background(), tt.want, v1.CreateOptions{})
 			}
@@ -89,7 +89,7 @@ func TestStorageNoCache_GetSBOM(t *testing.T) {
 	}
 }
 
-func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
+func TestStorage_PatchFilteredSBOM(t *testing.T) {
 	type args struct {
 		name string
 		SBOM *v1beta1.SBOMSyftFiltered
@@ -126,7 +126,7 @@ func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache("kubescape")
+			sc, _ := CreateFakeStorage("kubescape")
 			filteredSBOM := &v1beta1.SBOMSyftFiltered{
 				ObjectMeta: v1.ObjectMeta{
 					Name: tt.args.name,
@@ -147,7 +147,7 @@ func TestStorageNoCache_PatchFilteredSBOM(t *testing.T) {
 	}
 }
 
-func TestStorageNoCache_PatchNetworkNeighbors(t *testing.T) {
+func TestStorage_PatchNetworkNeighbors(t *testing.T) {
 	type args struct {
 		name      string
 		neighbors *v1beta1.NetworkNeighbors
@@ -178,7 +178,7 @@ func TestStorageNoCache_PatchNetworkNeighbors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache("kubescape")
+			sc, _ := CreateFakeStorage("kubescape")
 			existingProfile := &v1beta1.NetworkNeighbors{
 				ObjectMeta: v1.ObjectMeta{
 					Name: tt.args.name,
@@ -205,7 +205,7 @@ func TestStorageNoCache_PatchNetworkNeighbors(t *testing.T) {
 	}
 }
 
-func TestStorageNoCache_PatchApplicationProfile(t *testing.T) {
+func TestStorage_PatchApplicationProfile(t *testing.T) {
 	type args struct {
 		name  string
 		patch []byte
@@ -311,7 +311,7 @@ func TestStorageNoCache_PatchApplicationProfile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc, _ := CreateFakeStorageNoCache("kubescape")
+			sc, _ := CreateFakeStorage("kubescape")
 			existingProfile := &v1beta1.ApplicationProfile{
 				ObjectMeta: v1.ObjectMeta{
 					Name: tt.args.name,


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, tests


___

## **Description**
- Added new methods in `RuleManager` for handling various types of events (capability, file exec, file open, network event, DNS event, randomx event), ensuring comprehensive event processing.
- Enhanced `ApplicationProfileManager` with improved container monitoring, including handling for dropped events and status updates, to better manage application profiles.
- Introduced comprehensive tests for `DynamicWatcher` functionality, covering scenarios like listing, watching, modifying, and deleting Kubernetes resources to ensure robustness.
- Implemented tests for `RuleBindingManager` cache operations, validating the correct behavior for adding, deleting, and listing rule bindings and their associations with pods.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Extend RuleManager with Event Handling and Resource Management</code></dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Added new methods for handling various event reports (capability, file <br>exec, file open, network event, DNS event, randomx event).<br> <li> Implemented a method to ensure instance ID is set for a container.<br> <li> Added logic to start rule manager for a container and handle its <br>lifecycle events.<br> <li> Introduced logic to delete resources associated with a container upon <br>termination.<br> <li> Added a method to process events and evaluate them against defined <br>rules.<br> <li> Included a utility method to check if a pod is cached before <br>processing events for it.<br> <li> Added a method to determine if an event is relevant to a rule based on <br>its requirements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/225/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+441/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Enhance ApplicationProfileManager with Improved Monitoring and Status </code><br><code>Handling</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Updated constructor to include preRunningContainerIDs and <br>k8sObjectCache parameters.<br> <li> Added logic to handle container lifecycle events and manage <br>application profiles.<br> <li> Implemented methods to monitor containers and save profiles <br>periodically.<br> <li> Introduced logic to delete resources associated with a container upon <br>termination.<br> <li> Added handling for dropped events and status updates in application <br>profiles.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/225/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+108/-68</a></td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>watch_test.go</strong><dd><code>Add DynamicWatcher Functionality Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/watcher/dynamicwatcher/watch_test.go
<li>Added comprehensive tests for dynamic watcher functionality, covering <br>listing, watching, modifying, and deleting Kubernetes resources.<br> <li> Implemented test setup to initialize resources, create, modify, and <br>delete objects, and verify watcher responses.<br> <li> Utilized wait groups to synchronize operations and ensure all expected <br>events are processed.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/225/files#diff-8525263cede41a0e7d889a99209e61d1af95ea64fde3e921f5a1a5aaadc61faa">+294/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache_test.go</strong><dd><code>Implement Tests for RuleBindingManager Cache Operations</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache_test.go
<li>Introduced tests for rule binding cache operations, including adding, <br>deleting, and listing rule bindings.<br> <li> Tested cache behavior for handling pods and rule bindings, ensuring <br>correct associations and updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/225/files#diff-387cbffbe5655030d0bb5dff8e6b40070c87fc8aa5447a5f7762ec6016a41912">+633/-0</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

