### PR TITLE
fix units

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -2,9 +2,6 @@ name: pull_request_created
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    branches:
-      - 'main'
-      - 'rule-manager'
     paths-ignore:
       - '*.md'
       - '*.yaml'

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -103,6 +103,14 @@ func CheckPrerequisites() error {
 	if nodeName := os.Getenv(config.NodeNameEnvVar); nodeName == "" {
 		return fmt.Errorf("%s environment variable not set", config.NodeNameEnvVar)
 	}
+	logger.L().Debug("checking pod name")
+	if nodeName := os.Getenv(config.PodNameEnvVar); nodeName == "" {
+		return fmt.Errorf("%s environment variable not set", config.NodeNameEnvVar)
+	}
+	logger.L().Debug("checking namespace name")
+	if nodeName := os.Getenv(config.NamespaceEnvVar); nodeName == "" {
+		return fmt.Errorf("%s environment variable not set", config.NodeNameEnvVar)
+	}
 	// Ensure all filesystems are mounted
 	logger.L().Debug("checking mounts")
 	if err := workaroundMounts(); err != nil {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -87,6 +87,8 @@ func TestCheckPrerequisites(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setEnv {
 				t.Setenv(config.NodeNameEnvVar, "testNode")
+				t.Setenv(config.NamespaceEnvVar, "namespace")
+				t.Setenv(config.PodNameEnvVar, "pod")
 			}
 			if err := CheckPrerequisites(); (err != nil) != tt.wantErr {
 				t.Errorf("CheckPrerequisites() error = %v, wantErr %v", err, tt.wantErr)

--- a/mocks/readfiles.go
+++ b/mocks/readfiles.go
@@ -14,6 +14,7 @@ import (
 )
 
 type TestKinds string
+type TestName string
 
 const (
 	TestKindPod    TestKinds = "Pod"
@@ -23,8 +24,6 @@ const (
 	TestKindAA     TestKinds = "ApplicationActivity"
 	TestKindNN     TestKinds = "NetworkNeighbors"
 )
-
-type TestName string
 
 const (
 	TestNginx      TestName = "nginx"
@@ -48,6 +47,8 @@ const (
 	collectionNetworkNeighborsBytes    = "testdata/collection_networkneighbors.json"
 )
 
+var NAMESPACE = ""
+
 func readFile(p string) []byte {
 	_, filename, _, _ := runtime.Caller(0)
 	dir := path.Join(path.Dir(filename), "..")
@@ -64,7 +65,12 @@ func readFile(p string) []byte {
 }
 
 func UnstructuredToRuntime(u *unstructured.Unstructured) k8sruntime.Object {
-
+	if NAMESPACE != "" {
+		u.SetNamespace(NAMESPACE)
+	}
+	if ns := os.Getenv("TEST_NAMESPACE"); ns != "" {
+		u.SetNamespace(ns)
+	}
 	switch TestKinds(u.GetKind()) {
 	case TestKindPod:
 		pod := &corev1.Pod{}
@@ -111,7 +117,12 @@ func GetUnstructured(kind TestKinds, name TestName) *unstructured.Unstructured {
 	if err := u.UnmarshalJSON(b); err != nil {
 		panic(err)
 	}
-
+	if NAMESPACE != "" {
+		u.SetNamespace(NAMESPACE)
+	}
+	if ns := os.Getenv("TEST_NAMESPACE"); ns != "" {
+		u.SetNamespace(ns)
+	}
 	return u
 }
 

--- a/mocks/testdata/collection_rs.json
+++ b/mocks/testdata/collection_rs.json
@@ -18,7 +18,8 @@
                 "apiVersion": "apps/v1",
                 "blockOwnerDeletion": true,
                 "controller": true,
-                "kind": "Deployment"
+                "kind": "Deployment",
+                "name": "collection"
             }
         ]
     },

--- a/mocks/testdata/nginx_networkneighbors.json
+++ b/mocks/testdata/nginx_networkneighbors.json
@@ -3,7 +3,6 @@
     "kind": "NetworkNeighbors",
     "metadata": {
         "annotations": {
-            "kubescape.io/status": "complete"
         },
         "creationTimestamp": "2024-03-19T09:24:57Z",
         "labels": {

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -548,7 +548,6 @@ func (am *ApplicationProfileManager) ContainerCallback(notif containercollection
 		am.toSaveOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
 		am.trackedContainers.Add(k8sContainerID)
 		go am.startApplicationProfiling(ctx, notif.Container, k8sContainerID)
-		logger.L().Info("start monitor on container", helpers.String("container ID", notif.Container.Runtime.ContainerID), helpers.String("k8s workload", k8sContainerID))
 
 		// stop monitoring after MaxSniffingTime
 		time.AfterFunc(am.cfg.MaxSniffingTime, func() {

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -92,6 +92,8 @@ func (ch *IGContainerWatcher) startContainerCollection(ctx context.Context) erro
 				ch.containerCollection.RemoveContainer(container.Runtime.ContainerID)
 				continue
 			}
+			// TODO: wait for pod to be cached
+
 			ch.preRunningContainersIDs.Add(container.Runtime.ContainerID)
 		}
 	}

--- a/pkg/objectcache/networkneighborscache/networkneighborscache_test.go
+++ b/pkg/objectcache/networkneighborscache/networkneighborscache_test.go
@@ -8,7 +8,9 @@ import (
 	"node-agent/pkg/watcher"
 	"testing"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,7 +18,6 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 
-	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,9 +27,27 @@ import (
 func init() {
 	v1beta1.AddToScheme(scheme.Scheme)
 	corev1.AddToScheme(scheme.Scheme)
+	appsv1.AddToScheme(scheme.Scheme)
 }
 
 func Test_AddHandlers(t *testing.T) {
+	k8sClient := k8sinterface.NewKubernetesApiMock()
+	var r []runtime.Object
+	namespace := "default"
+	mocks.NAMESPACE = namespace
+	defer func() {
+		mocks.NAMESPACE = ""
+	}()
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindDeploy, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindDeploy, mocks.TestNginx))
+	r = append(r, mocks.GetRuntime(mocks.TestKindRS, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindRS, mocks.TestNginx))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	d := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, r...)
+	k8sClient.DynamicClient = d
 
 	tests := []struct {
 		f      func(nn *NetworkNeighborsCacheImp, ctx context.Context, obj *unstructured.Unstructured)
@@ -77,7 +96,6 @@ func Test_AddHandlers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.obj.SetNamespace("default")
 
-			k8sClient := k8sinterface.NewKubernetesApiMock()
 			nn := NewNetworkNeighborsCache("", k8sClient)
 
 			tt.f(nn, context.Background(), tt.obj)
@@ -100,7 +118,7 @@ func Test_addNetworkNeighbor(t *testing.T) {
 		name           string
 		annotations    map[string]string
 		preCreatedPods []*unstructured.Unstructured // pre created pods
-		preCreatedAP   []*unstructured.Unstructured // pre created network neighborss
+		preCreatedNN   []*unstructured.Unstructured // pre created network neighborss
 		shouldAdd      bool
 		shouldAddToPod bool
 	}{
@@ -113,7 +131,7 @@ func Test_addNetworkNeighbor(t *testing.T) {
 			name: "add network neighbors with complete annotation",
 			obj:  mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
 			annotations: map[string]string{
-				helpersv1.CompletionMetadataKey: helpersv1.Complete,
+				"kubescape.io/status": "completed",
 			},
 			shouldAdd: true,
 		},
@@ -121,7 +139,7 @@ func Test_addNetworkNeighbor(t *testing.T) {
 			name: "ignore single network neighbors with incomplete annotation",
 			obj:  mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
 			annotations: map[string]string{
-				helpersv1.CompletionMetadataKey: helpersv1.Ready,
+				"kubescape.io/status": "ready",
 			},
 			shouldAdd: false,
 		},
@@ -130,7 +148,7 @@ func Test_addNetworkNeighbor(t *testing.T) {
 			obj:            mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
 			preCreatedPods: []*unstructured.Unstructured{mocks.GetUnstructured(mocks.TestKindPod, mocks.TestCollection)},
 			annotations: map[string]string{
-				helpersv1.CompletionMetadataKey: helpersv1.Complete,
+				"kubescape.io/status": "completed",
 			},
 			shouldAdd:      true,
 			shouldAddToPod: true,
@@ -140,7 +158,7 @@ func Test_addNetworkNeighbor(t *testing.T) {
 			obj:            mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
 			preCreatedPods: []*unstructured.Unstructured{mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx)},
 			annotations: map[string]string{
-				helpersv1.CompletionMetadataKey: helpersv1.Complete,
+				"kubescape.io/status": "completed",
 			},
 			shouldAdd:      true,
 			shouldAddToPod: false,
@@ -152,19 +170,25 @@ func Test_addNetworkNeighbor(t *testing.T) {
 				tt.obj.SetAnnotations(tt.annotations)
 			}
 			namespace := fmt.Sprintf("default-%d", i)
-			k8sClient := k8sinterface.NewKubernetesApiMock()
-
+			mocks.NAMESPACE = namespace
+			defer func() {
+				mocks.NAMESPACE = ""
+			}()
 			var runtimeObjs []runtime.Object
 			tt.obj.SetNamespace(namespace)
-			runtimeObjs = append(runtimeObjs, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
 
+			k8sClient := k8sinterface.NewKubernetesApiMock()
+
+			runtimeObjs = append(runtimeObjs, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+			runtimeObjs = append(runtimeObjs, mocks.GetRuntime(mocks.TestKindDeploy, mocks.TestCollection))
+			runtimeObjs = append(runtimeObjs, mocks.GetRuntime(mocks.TestKindDeploy, mocks.TestNginx))
+			runtimeObjs = append(runtimeObjs, mocks.GetRuntime(mocks.TestKindRS, mocks.TestCollection))
+			runtimeObjs = append(runtimeObjs, mocks.GetRuntime(mocks.TestKindRS, mocks.TestNginx))
 			for i := range tt.preCreatedPods {
-				tt.preCreatedPods[i].SetNamespace(namespace)
 				runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.preCreatedPods[i]))
 			}
-			for i := range tt.preCreatedAP {
-				tt.preCreatedAP[i].SetNamespace(namespace)
-				runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.preCreatedAP[i]))
+			for i := range tt.preCreatedNN {
+				runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.preCreatedNN[i]))
 			}
 
 			runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.obj))
@@ -176,29 +200,29 @@ func Test_addNetworkNeighbor(t *testing.T) {
 			for i := range tt.preCreatedPods {
 				nn.addPod(tt.preCreatedPods[i])
 			}
-			for i := range tt.preCreatedAP {
-				nn.addNetworkNeighbor(context.Background(), tt.preCreatedAP[i])
+			for i := range tt.preCreatedNN {
+				nn.addNetworkNeighbor(context.Background(), tt.preCreatedNN[i])
 			}
 
 			nn.addNetworkNeighbor(context.Background(), tt.obj)
 
 			// test if the network neighbors is added to the cache
-			apName := objectcache.UnstructuredUniqueName(tt.obj)
+			nName := objectcache.UnstructuredUniqueName(tt.obj)
 			if tt.shouldAdd {
 				assert.Equal(t, 1, nn.allNeighbors.Cardinality())
-				assert.True(t, nn.slugToNetworkNeighbor.Has(apName))
 			} else {
 				assert.Equal(t, 0, nn.allNeighbors.Cardinality())
-				assert.False(t, nn.slugToNetworkNeighbor.Has(apName))
 			}
 
 			if tt.shouldAddToPod {
-				assert.True(t, nn.slugToPods.Has(apName))
+				assert.True(t, nn.slugToPods.Has(nName))
+				assert.True(t, nn.slugToNetworkNeighbor.Has(nName))
 				for i := range tt.preCreatedPods {
 					assert.NotNil(t, nn.GetNetworkNeighbors(namespace, tt.preCreatedPods[i].GetName()))
 				}
 			} else {
-				assert.False(t, nn.slugToPods.Has(apName))
+				assert.False(t, nn.slugToPods.Has(nName))
+				assert.False(t, nn.slugToNetworkNeighbor.Has(nName))
 				for i := range tt.preCreatedPods {
 					assert.Nil(t, nn.GetNetworkNeighbors(namespace, tt.preCreatedPods[i].GetName()))
 				}
@@ -207,294 +231,314 @@ func Test_addNetworkNeighbor(t *testing.T) {
 	}
 }
 
-// func Test_deleteNetworkNeighbors(t *testing.T) {
+func Test_deleteNetworkNeighbors(t *testing.T) {
 
-// 	tests := []struct {
-// 		obj          *unstructured.Unstructured
-// 		name         string
-// 		slug         string
-// 		slugs        []string
-// 		shouldDelete bool
-// 	}{
-// 		{
-// 			name:         "delete network neighbors nginx",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			slug:         "/replicaset-nginx-77b4fdf86c",
-// 			slugs:        []string{"/replicaset-nginx-77b4fdf86c"},
-// 			shouldDelete: true,
-// 		},
-// 		{
-// 			name:         "delete network neighbors from many",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			slug:         "/replicaset-nginx-77b4fdf86c",
-// 			slugs:        []string{"/replicaset-nginx-11111", "/replicaset-nginx-77b4fdf86c", "/replicaset-nginx-22222"},
-// 			shouldDelete: true,
-// 		},
-// 		{
-// 			name:         "ignore delete network neighbors nginx",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
-// 			slug:         "/replicaset-nginx-77b4fdf86c",
-// 			slugs:        []string{"/replicaset-nginx-77b4fdf86c"},
-// 			shouldDelete: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			nn := NewNetworkNeighborsCache("", nil)
+	tests := []struct {
+		obj          *unstructured.Unstructured
+		name         string
+		slug         string
+		slugs        []string
+		shouldDelete bool
+	}{
+		{
+			name:         "delete network neighbors nginx",
+			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			slug:         "/deployment-nginx",
+			slugs:        []string{"/deployment-nginx"},
+			shouldDelete: true,
+		},
+		{
+			name:         "delete network neighbors from many",
+			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			slug:         "/deployment-nginx",
+			slugs:        []string{"/deployment-collection", "/deployment-bla", "/deployment-nginx"},
+			shouldDelete: true,
+		},
+		{
+			name:         "ignore delete network neighbors nginx",
+			obj:          mocks.GetUnstructured(mocks.TestKindNN, mocks.TestCollection),
+			slug:         "/deployment-nginx",
+			slugs:        []string{"/deployment-nginx"},
+			shouldDelete: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nn := NewNetworkNeighborsCache("", nil)
 
-// 			nn.allNeighbors.Append(tt.slugs...)
-// 			for _, i := range tt.slugs {
-// 				nn.slugToNetworkNeighbor.Set(i, &v1beta1.NetworkNeighbors{})
-// 				nn.slugToPods.Set(i, nil)
-// 			}
+			nn.allNeighbors.Append(tt.slugs...)
+			for _, i := range tt.slugs {
+				nn.slugToNetworkNeighbor.Set(i, &v1beta1.NetworkNeighbors{})
+				nn.slugToPods.Set(i, nil)
+			}
 
-// 			nn.deleteNetworkNeighbors(tt.obj)
+			nn.deleteNetworkNeighbor(tt.obj)
 
-// 			if tt.shouldDelete {
-// 				assert.Equal(t, len(tt.slugs)-1, nn.allNeighbors.Cardinality())
-// 				assert.False(t, nn.slugToNetworkNeighbor.Has(tt.slug))
-// 				assert.False(t, nn.slugToPods.Has(tt.slug))
-// 			} else {
-// 				assert.Equal(t, len(tt.slugs), nn.allNeighbors.Cardinality())
-// 				assert.True(t, nn.slugToNetworkNeighbor.Has(tt.slug))
-// 				assert.True(t, nn.slugToPods.Has(tt.slug))
-// 			}
-// 		})
-// 	}
-// }
+			if tt.shouldDelete {
+				assert.Equal(t, len(tt.slugs)-1, nn.allNeighbors.Cardinality())
+				assert.False(t, nn.slugToNetworkNeighbor.Has(tt.slug))
+				assert.False(t, nn.slugToPods.Has(tt.slug))
+			} else {
+				assert.Equal(t, len(tt.slugs), nn.allNeighbors.Cardinality())
+				assert.True(t, nn.slugToNetworkNeighbor.Has(tt.slug))
+				assert.True(t, nn.slugToPods.Has(tt.slug))
+			}
+		})
+	}
+}
 
-// func Test_deletePod(t *testing.T) {
+func Test_deletePod(t *testing.T) {
 
-// 	tests := []struct {
-// 		obj          *unstructured.Unstructured
-// 		name         string
-// 		podName      string
-// 		slug         string
-// 		otherSlugs   []string
-// 		shouldDelete bool
-// 	}{
-// 		{
-// 			name:         "delete pod",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
-// 			podName:      "/nginx-77b4fdf86c-hp4x5",
-// 			shouldDelete: true,
-// 		},
-// 		{
-// 			name:         "pod not deleted",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
-// 			podName:      "blabla",
-// 			shouldDelete: false,
-// 		},
-// 		{
-// 			name:         "delete pod with slug",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
-// 			podName:      "/nginx-77b4fdf86c-hp4x5",
-// 			slug:         "/replicaset-nginx-77b4fdf86c",
-// 			otherSlugs:   []string{"1111111", "222222"},
-// 			shouldDelete: true,
-// 		},
-// 		{
-// 			name:         "delete pod with slug",
-// 			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
-// 			podName:      "/nginx-77b4fdf86c-hp4x5",
-// 			slug:         "/replicaset-nginx-77b4fdf86c",
-// 			shouldDelete: true,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			nn := NewNetworkNeighborsCache("", nil)
-// 			for _, i := range tt.otherSlugs {
-// 				nn.slugToPods.Set(i, mapset.NewSet[string]())
-// 				nn.slugToNetworkNeighbor.Set(i, &v1beta1.NetworkNeighbors{})
-// 			}
-// 			if tt.slug != "" {
-// 				nn.slugToPods.Set(tt.slug, mapset.NewSet[string](tt.podName))
-// 				nn.slugToNetworkNeighbor.Set(tt.slug, &v1beta1.NetworkNeighbors{})
-// 			}
+	tests := []struct {
+		obj          *unstructured.Unstructured
+		name         string
+		podName      string
+		slug         string
+		otherSlugs   []string
+		shouldDelete bool
+	}{
+		{
+			name:         "delete pod",
+			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
+			podName:      "/nginx-77b4fdf86c-hp4x5",
+			shouldDelete: true,
+		},
+		{
+			name:         "pod not deleted",
+			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
+			podName:      "blabla",
+			shouldDelete: false,
+		},
+		{
+			name:         "delete pod with slug",
+			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
+			podName:      "/nginx-77b4fdf86c-hp4x5",
+			slug:         "/deployment-nginx",
+			otherSlugs:   []string{"1111111", "222222"},
+			shouldDelete: true,
+		},
+		{
+			name:         "delete pod with slug",
+			obj:          mocks.GetUnstructured(mocks.TestKindPod, mocks.TestNginx),
+			podName:      "/nginx-77b4fdf86c-hp4x5",
+			slug:         "/deployment-nginx",
+			shouldDelete: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nn := NewNetworkNeighborsCache("", nil)
+			for _, i := range tt.otherSlugs {
+				nn.slugToPods.Set(i, mapset.NewSet[string]())
+				nn.slugToNetworkNeighbor.Set(i, &v1beta1.NetworkNeighbors{})
+			}
+			if tt.slug != "" {
+				nn.slugToPods.Set(tt.slug, mapset.NewSet[string](tt.podName))
+				nn.slugToNetworkNeighbor.Set(tt.slug, &v1beta1.NetworkNeighbors{})
+			}
 
-// 			nn.podToSlug.Set(tt.podName, tt.slug)
+			nn.podToSlug.Set(tt.podName, tt.slug)
 
-// 			nn.deletePod(tt.obj)
+			nn.deletePod(tt.obj)
 
-// 			if tt.shouldDelete {
-// 				assert.False(t, nn.podToSlug.Has(tt.podName))
-// 			} else {
-// 				assert.True(t, nn.podToSlug.Has(tt.podName))
-// 			}
+			if tt.shouldDelete {
+				assert.False(t, nn.podToSlug.Has(tt.podName))
+			} else {
+				assert.True(t, nn.podToSlug.Has(tt.podName))
+			}
 
-// 			if tt.slug != "" {
-// 				assert.False(t, nn.slugToPods.Has(tt.slug))
-// 				assert.Equal(t, len(tt.otherSlugs), nn.slugToPods.Len())
-// 				assert.Equal(t, len(tt.otherSlugs), nn.slugToNetworkNeighbor.Len())
+			if tt.slug != "" {
+				assert.False(t, nn.slugToPods.Has(tt.slug))
+				assert.Equal(t, len(tt.otherSlugs), nn.slugToPods.Len())
+				assert.Equal(t, len(tt.otherSlugs), nn.slugToNetworkNeighbor.Len())
 
-// 				if len(tt.otherSlugs) == 0 {
-// 					assert.False(t, nn.slugToPods.Has(tt.slug))
-// 					assert.False(t, nn.slugToNetworkNeighbor.Has(tt.slug))
-// 				}
-// 			}
-// 		})
-// 	}
-// }
-// func Test_GetNetworkNeighbors(t *testing.T) {
-// 	type args struct {
-// 		name      string
-// 		namespace string
-// 		slug      string
-// 	}
-// 	tests := []struct {
-// 		get      args
-// 		name     string
-// 		pods     []args
-// 		expected bool
-// 	}{
-// 		{
-// 			name: "network neighbors found",
-// 			pods: []args{
-// 				{
-// 					name:      "nginx",
-// 					namespace: "default",
-// 					slug:      "default/replicaset-nginx-1234",
-// 				},
-// 				{
-// 					name:      "collection",
-// 					namespace: "default",
-// 					slug:      "default/replicaset-collection-1234",
-// 				},
-// 			},
-// 			get: args{
-// 				name:      "nginx",
-// 				namespace: "default",
-// 			},
-// 			expected: true,
-// 		},
-// 		{
-// 			name: "network neighbors not found",
-// 			pods: []args{
-// 				{
-// 					name:      "nginx",
-// 					namespace: "default",
-// 					slug:      "default/replicaset-nginx-1234",
-// 				},
-// 				{
-// 					name:      "collection",
-// 					namespace: "default",
-// 					slug:      "default/replicaset-collection-1234",
-// 				},
-// 			},
-// 			get: args{
-// 				name:      "nginx",
-// 				namespace: "collection",
-// 			},
-// 			expected: false,
-// 		},
-// 		{
-// 			name: "pod exists but network neighbors is not",
-// 			pods: []args{
-// 				{
-// 					name:      "nginx",
-// 					namespace: "default",
-// 					slug:      "default/replicaset-nginx-1234",
-// 				},
-// 				{
-// 					name:      "collection",
-// 					namespace: "default",
-// 					slug:      "",
-// 				},
-// 			},
-// 			get: args{
-// 				name:      "collection",
-// 				namespace: "default",
-// 			},
-// 			expected: false,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			nn := NewNetworkNeighborsCache("", k8sinterface.NewKubernetesApiMock())
+				if len(tt.otherSlugs) == 0 {
+					assert.False(t, nn.slugToPods.Has(tt.slug))
+					assert.False(t, nn.slugToNetworkNeighbor.Has(tt.slug))
+				}
+			}
+		})
+	}
+}
 
-// 			for _, c := range tt.pods {
-// 				n := objectcache.UniqueName(c.namespace, c.name)
-// 				nn.podToSlug.Set(n, c.slug)
-// 				if c.slug != "" {
-// 					nn.slugToNetworkNeighbor.Set(c.slug, &v1beta1.NetworkNeighbors{})
-// 				}
-// 			}
+func Test_GetNetworkNeighbors(t *testing.T) {
+	type args struct {
+		name      string
+		namespace string
+		slug      string
+	}
+	tests := []struct {
+		get      args
+		name     string
+		pods     []args
+		expected bool
+	}{
+		{
+			name: "network neighbors found",
+			pods: []args{
+				{
+					name:      "nginx",
+					namespace: "default",
+					slug:      "default/replicaset-nginx-1234",
+				},
+				{
+					name:      "collection",
+					namespace: "default",
+					slug:      "default/replicaset-collection-1234",
+				},
+			},
+			get: args{
+				name:      "nginx",
+				namespace: "default",
+			},
+			expected: true,
+		},
+		{
+			name: "network neighbors not found",
+			pods: []args{
+				{
+					name:      "nginx",
+					namespace: "default",
+					slug:      "default/deployment-nginx",
+				},
+				{
+					name:      "collection",
+					namespace: "default",
+					slug:      "default/deployment-collection",
+				},
+			},
+			get: args{
+				name:      "nginx",
+				namespace: "collection",
+			},
+			expected: false,
+		},
+		{
+			name: "pod exists but network neighbors is not",
+			pods: []args{
+				{
+					name:      "nginx",
+					namespace: "default",
+					slug:      "default/deployment-nginx",
+				},
+				{
+					name:      "collection",
+					namespace: "default",
+					slug:      "",
+				},
+			},
+			get: args{
+				name:      "collection",
+				namespace: "default",
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nn := NewNetworkNeighborsCache("", k8sinterface.NewKubernetesApiMock())
 
-// 			p := nn.GetNetworkNeighbors(tt.get.namespace, tt.get.name)
-// 			if tt.expected {
-// 				assert.NotNil(t, p)
-// 			} else {
-// 				assert.Nil(t, p)
-// 			}
-// 		})
-// 	}
-// }
-// func Test_addNetworkNeighbor_existing(t *testing.T) {
+			for _, c := range tt.pods {
+				n := objectcache.UniqueName(c.namespace, c.name)
+				nn.podToSlug.Set(n, c.slug)
+				if c.slug != "" {
+					nn.slugToNetworkNeighbor.Set(c.slug, &v1beta1.NetworkNeighbors{})
+				}
+			}
 
-// 	// add single network neighbors
-// 	tests := []struct {
-// 		obj1         *unstructured.Unstructured
-// 		obj2         *unstructured.Unstructured
-// 		annotations1 map[string]string
-// 		annotations2 map[string]string
-// 		name         string
-// 		storeInCache bool
-// 	}{
-// 		{
-// 			name:         "network neighbors already exists",
-// 			obj1:         mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			obj2:         mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			storeInCache: true,
-// 		},
-// 		{
-// 			name: "remove network neighbors",
-// 			obj1: mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			obj2: mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
-// 			annotations1: map[string]string{
-// 				helpersv1.CompletionMetadataKey: helpersv1.Complete,
-// 			},
-// 			annotations2: map[string]string{
-// 				helpersv1.CompletionMetadataKey: helpersv1.Ready,
-// 			},
-// 			storeInCache: false,
-// 		},
-// 	}
-// 	for i, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			if len(tt.annotations1) != 0 {
-// 				tt.obj1.SetAnnotations(tt.annotations1)
-// 			}
-// 			if len(tt.annotations2) != 0 {
-// 				tt.obj2.SetAnnotations(tt.annotations2)
-// 			}
-// 			namespace := fmt.Sprintf("default-%d", i)
-// 			k8sClient := k8sinterface.NewKubernetesApiMock()
+			p := nn.GetNetworkNeighbors(tt.get.namespace, tt.get.name)
+			if tt.expected {
+				assert.NotNil(t, p)
+			} else {
+				assert.Nil(t, p)
+			}
+		})
+	}
+}
 
-// 			var runtimeObjs []runtime.Object
-// 			runtimeObjs = append(runtimeObjs, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+func Test_addNetworkNeighbor_existing(t *testing.T) {
+	type podToSlug struct {
+		podName string
+		slug    string
+	}
+	// add single network neighbors
+	tests := []struct {
+		obj1         *unstructured.Unstructured
+		obj2         *unstructured.Unstructured
+		annotations1 map[string]string
+		annotations2 map[string]string
+		name         string
+		pods         []podToSlug
+		storeInCache bool
+	}{
+		{
+			name:         "network neighbors already exists",
+			obj1:         mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			obj2:         mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			storeInCache: true,
+			pods: []podToSlug{
+				{
+					podName: "nginx-77b4fdf86c",
+					slug:    "/deployment-nginx",
+				},
+			},
+		},
+		{
+			name: "remove network neighbors",
+			obj1: mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			obj2: mocks.GetUnstructured(mocks.TestKindNN, mocks.TestNginx),
+			pods: []podToSlug{
+				{
+					podName: "nginx-77b4fdf86c",
+					slug:    "/deployment-nginx",
+				},
+			},
+			annotations1: map[string]string{
+				"kubescape.io/status": "completed",
+			},
+			annotations2: map[string]string{
+				"kubescape.io/status": "ready",
+			},
+			storeInCache: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.annotations1) != 0 {
+				tt.obj1.SetAnnotations(tt.annotations1)
+			}
+			if len(tt.annotations2) != 0 {
+				tt.obj2.SetAnnotations(tt.annotations2)
+			}
+			k8sClient := k8sinterface.NewKubernetesApiMock()
 
-// 			runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.obj1))
+			var runtimeObjs []runtime.Object
 
-// 			k8sClient.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, runtimeObjs...)
+			runtimeObjs = append(runtimeObjs, mocks.UnstructuredToRuntime(tt.obj1))
 
-// 			nn := NewNetworkNeighborsCache("", k8sClient)
+			k8sClient.DynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, runtimeObjs...)
 
-// 			nn.addNetworkNeighbor(context.Background(), tt.obj1)
-// 			nn.addNetworkNeighbor(context.Background(), tt.obj2)
+			nn := NewNetworkNeighborsCache("", k8sClient)
+			// add pods
+			for i := range tt.pods {
+				nn.podToSlug.Set(tt.pods[i].podName, tt.pods[i].slug)
+			}
 
-// 			// test if the network neighbors is added to the cache
-// 			apName := objectcache.UnstructuredUniqueName(tt.obj1)
-// 			if tt.storeInCache {
-// 				assert.Equal(t, 1, nn.allNeighbors.Cardinality())
-// 				assert.True(t, nn.slugToNetworkNeighbor.Has(apName))
-// 			} else {
-// 				assert.Equal(t, 0, nn.allNeighbors.Cardinality())
-// 				assert.False(t, nn.slugToNetworkNeighbor.Has(apName))
-// 			}
-// 		})
-// 	}
-// }
+			nn.addNetworkNeighbor(context.Background(), tt.obj1)
+			nn.addNetworkNeighbor(context.Background(), tt.obj2)
+
+			// test if the network neighbors is added to the cache
+			nName := objectcache.UnstructuredUniqueName(tt.obj1)
+			if tt.storeInCache {
+				assert.Equal(t, 1, nn.allNeighbors.Cardinality())
+				assert.True(t, nn.slugToNetworkNeighbor.Has(nName))
+			} else {
+				assert.Equal(t, 0, nn.allNeighbors.Cardinality())
+				assert.False(t, nn.slugToNetworkNeighbor.Has(nName))
+			}
+		})
+	}
+}
 
 func Test_unstructuredToNetworkNeighbors(t *testing.T) {
 

--- a/pkg/relevancymanager/v1/relevancy_manager_test.go
+++ b/pkg/relevancymanager/v1/relevancy_manager_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"testing"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 
 	"time"
@@ -30,7 +31,7 @@ func BenchmarkRelevancyManager_ReportFileExec(b *testing.B) {
 	ctx := context.TODO()
 	fileHandler, err := filehandler.CreateInMemoryFileHandler()
 	assert.NoError(b, err)
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil, nil)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, nil, nil, mapset.NewSet[string]())
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		relevancyManager.ReportFileExec("ns", "ns", "file")
@@ -61,7 +62,7 @@ func TestRelevancyManager(t *testing.T) {
 	storageClient := storage.CreateSyftSBOMStorageHttpClientMock(syftDoc)
 	sbomHandler := syfthandler.CreateSyftSBOMHandler(storageClient)
 
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, nil)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, mapset.NewSet[string]())
 	assert.NoError(t, err)
 	// report container started
 	container := &containercollection.Container{
@@ -164,7 +165,7 @@ func TestRelevancyManagerIncompleteSBOM(t *testing.T) {
 
 	storageClient := storage.CreateSyftSBOMStorageHttpClientMock(syftDoc)
 	sbomHandler := syfthandler.CreateSyftSBOMHandler(storageClient)
-	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, nil)
+	relevancyManager, err := CreateRelevancyManager(ctx, cfg, "cluster", fileHandler, k8sClient, sbomHandler, mapset.NewSet[string]())
 	assert.NoError(t, err)
 
 	// report container started

--- a/pkg/rulemanager/exporters/http_exporter_test.go
+++ b/pkg/rulemanager/exporters/http_exporter_test.go
@@ -249,7 +249,7 @@ func TestValidateHTTPExporterConfig(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "POST", exp.config.Method)
-	assert.Equal(t, 1, exp.config.TimeoutSeconds)
+	assert.Equal(t, 5, exp.config.TimeoutSeconds)
 	assert.Equal(t, 10000, exp.config.MaxAlertsPerMinute)
 	assert.Equal(t, map[string]string{}, exp.config.Headers)
 


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Added checks for `PodNameEnvVar` and `NamespaceEnvVar` in `internal/validator/validator.go`.
- Introduced dynamic namespace handling in test mocks for improved flexibility.
- Refactored slug generation in application profile cache for better maintainability.
- Updated various tests to reflect new logic and parameter changes.
- Removed redundant logging and updated configuration in application profile manager.
- Adjusted HTTP exporter config validation to use a new default timeout.
- Removed branch restrictions from GitHub pull request workflow.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>validator.go</strong><dd><code>Add missing environment variable checks and improve error messages</code></dd></summary>
<hr>

internal/validator/validator.go
<li>Added checks for <code>PodNameEnvVar</code> and <code>NamespaceEnvVar</code> environment <br>variables.<br> <li> Improved error messages to be more descriptive.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-0cadd4fb8124512a91a24bdf4a1f812adb0b6a0d542b0bc51fa952b36d8f8328">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Remove redundant logging in application profile manager</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Removed redundant logging statement in <code>ContainerCallback</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher_private.go</strong><dd><code>Add TODO for pod caching in container watcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher_private.go
- Added a TODO comment regarding waiting for pod to be cached.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-6f95b4caa6090a17da5aed1923600fd049392d228e0fba99cc212f48111f3ffe">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofilecache.go</strong><dd><code>Refactor slug generation in application profile cache</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectcache/applicationprofilecache/applicationprofilecache.go
<li>Refactored <code>addPod</code> function to use <code>getSlug</code> for slug generation.<br> <li> Added <code>getSlug</code> function to streamline slug generation from pod <br>unstructured object.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-7033af70203ec0c7cabfa58ce543eee2aa32baea58ae8904c87db7c406b51f9b">+30/-23</a>&nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>validator_test.go</strong><dd><code>Update tests to include new environment variable checks</code>&nbsp; &nbsp; </dd></summary>
<hr>

internal/validator/validator_test.go
<li>Added environment variables setup for <code>NamespaceEnvVar</code> and <br><code>PodNameEnvVar</code> in tests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-8347160e1327b6417e38ea56be79df684bcffaddeb1db5f4e3bce00c552d1e7c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>readfiles.go</strong><dd><code>Add dynamic namespace handling in test mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mocks/readfiles.go
<li>Introduced <code>NAMESPACE</code> variable to dynamically set namespace in tests.<br> <li> Added logic to set namespace in <code>UnstructuredToRuntime</code> and <br><code>GetUnstructured</code> functions based on <code>NAMESPACE</code> or <code>TEST_NAMESPACE</code> <br>environment variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-294251308c1fa7931e8f5c16c3592d2f94e96f9810a66dafc382944c6879748f">+15/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go</strong><dd><code>Update application profile manager tests for new parameter and </code><br><code>assertions</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
<li>Adjusted <code>CreateApplicationProfileManager</code> call to include a new <br>parameter.<br> <li> Updated assertions to reflect changes in application profile and <br>summaries handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofilecache_test.go</strong><dd><code>Add tests for new slug generation logic and update existing tests</code></dd></summary>
<hr>

pkg/objectcache/applicationprofilecache/applicationprofilecache_test.go
<li>Added tests for <code>getSlug</code> function.<br> <li> Modified existing tests to use a new <code>podToSlug</code> struct for setup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-ef0ce4fe7f355464391d42b1390135ce300029d467b04a1f9bbfa8b13c14d937">+82/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkneighborscache_test.go</strong><dd><code>Update network neighbors cache tests with new dependencies and logic</code></dd></summary>
<hr>

pkg/objectcache/networkneighborscache/networkneighborscache_test.go
<li>Introduced <code>mapset</code> for set operations and <code>appsv1</code> for Kubernetes apps <br>API.<br> <li> Updated tests to reflect changes in network neighbors cache handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-004f968b33a4341ec7fa233ab9dcb17f89cd67085f3e20736a419a703ea15d22">+353/-309</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_test.go</strong><dd><code>Update relevancy manager tests for new parameter inclusion</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager_test.go
<li>Adjusted <code>CreateRelevancyManager</code> calls to include a new parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-03d056dd81b53a3e65816a06b634ac3b332d230d23c5ca3ade4376fafb39143a">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>collection_rs.json</strong><dd><code>Add missing `name` field in test data for collection replica set</code></dd></summary>
<hr>

mocks/testdata/collection_rs.json
- Added `name` field to owner references in test data.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-94c77b9db58761902ca425454adfae9d59618280496333ff00059bce31c78773">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nginx_networkneighbors.json</strong><dd><code>Remove status annotation from nginx network neighbors test data</code></dd></summary>
<hr>

mocks/testdata/nginx_networkneighbors.json
- Removed `kubescape.io/status` annotation from test data.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-8cfdaf8103da242a013f1ad379f43a19ea86c57d9ad296351e65ab2bcddc9a7d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter_test.go</strong><dd><code>Update HTTP exporter config validation test for default timeout</code></dd></summary>
<hr>

pkg/rulemanager/exporters/http_exporter_test.go
<li>Updated default timeout seconds in HTTP exporter config validation <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-98e48a2325cf731bb30673b3f67f1df0da60ad9d649e63717234aac4b3d790fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-created.yaml</strong><dd><code>Remove branch restrictions from pull request workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-created.yaml
- Removed branch restrictions for pull request workflow triggers.



</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/226/files#diff-5ffea07c9148d15428f777e9a5ebf1e757b90eb09c229cb374a0567caeb5b202">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

