### PR TITLE
watch running containers

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,13 +19,15 @@ import (
 	metricsmanager "node-agent/pkg/metricsmanager"
 	metricprometheus "node-agent/pkg/metricsmanager/prometheus"
 	"node-agent/pkg/networkmanager"
+	"node-agent/pkg/objectcache"
 	"node-agent/pkg/objectcache/applicationprofilecache"
 	"node-agent/pkg/objectcache/k8scache"
 	"node-agent/pkg/objectcache/networkneighborscache"
-	"node-agent/pkg/objectcache/v1"
+	objectcachev1 "node-agent/pkg/objectcache/v1"
 	"node-agent/pkg/relevancymanager"
 	relevancymanagerv1 "node-agent/pkg/relevancymanager/v1"
-	rulebindingcache "node-agent/pkg/rulebindingmanager/cache"
+	rulebinding "node-agent/pkg/rulebindingmanager"
+	rulebindingcachev1 "node-agent/pkg/rulebindingmanager/cache"
 	"node-agent/pkg/rulemanager"
 	"node-agent/pkg/rulemanager/exporters"
 	rulemanagerv1 "node-agent/pkg/rulemanager/v1"
@@ -153,12 +155,17 @@ func main() {
 
 	var ruleManager rulemanager.RuleManagerClient
 	var malwareManager malwaremanager.MalwareManagerClient
+	var objCache objectcache.ObjectCache
+	var ruleBindingNotify chan rulebinding.RuleBindingNotify
 
 	if cfg.EnableRuntimeDetection {
 
 		// create ruleBinding cache
-		ruleBindingCache := rulebindingcache.NewCache(nodeName, k8sClient)
+		ruleBindingCache := rulebindingcachev1.NewCache(nodeName, k8sClient)
 		dWatcher.AddAdaptor(ruleBindingCache)
+
+		ruleBindingNotify = make(chan rulebinding.RuleBindingNotify, 100)
+		ruleBindingCache.AddNotifier(&ruleBindingNotify)
 
 		apc := applicationprofilecache.NewApplicationProfileCache(nodeName, k8sClient)
 		dWatcher.AddAdaptor(apc)
@@ -167,7 +174,7 @@ func main() {
 		dWatcher.AddAdaptor(nnc)
 
 		// create object cache
-		objCache := objectcache.NewObjectCache(k8sObjectCache, apc, nnc)
+		objCache = objectcachev1.NewObjectCache(k8sObjectCache, apc, nnc)
 
 		// create exporter
 		exporter := exporters.InitExporters(cfg.Exporters)
@@ -201,6 +208,8 @@ func main() {
 	} else {
 		ruleManager = rulemanager.CreateRuleManagerMock()
 		malwareManager = malwaremanager.CreateMalwareManagerMock()
+		objCache = objectcache.NewObjectCacheMock()
+		ruleBindingNotify = make(chan rulebinding.RuleBindingNotify, 1)
 	}
 
 	// Create the network and DNS managers
@@ -216,16 +225,13 @@ func main() {
 	}
 
 	// Create the container handler
-	mainHandler, err := containerwatcher.CreateIGContainerWatcher(cfg, applicationProfileManager, k8sClient, relevancyManager, networkManagerClient, dnsManagerClient, prometheusExporter, ruleManager, malwareManager, preRunningContainersIDs)
+	mainHandler, err := containerwatcher.CreateIGContainerWatcher(cfg, applicationProfileManager, k8sClient, relevancyManager, networkManagerClient, dnsManagerClient, prometheusExporter, ruleManager, malwareManager, preRunningContainersIDs, &ruleBindingNotify)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("error creating the container watcher", helpers.Error(err))
 	}
 
 	// Start the prometheusExporter
 	prometheusExporter.Start()
-
-	// start watching
-	dWatcher.Start(ctx)
 
 	// Start the container handler
 	err = mainHandler.Start(ctx)
@@ -241,6 +247,10 @@ func main() {
 		}
 	}
 	defer mainHandler.Stop()
+
+	// start watching
+	dWatcher.Start(ctx)
+	defer dWatcher.Stop(ctx)
 
 	// Wait for shutdown signal
 	shutdown := make(chan os.Signal, 1)

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -11,6 +11,7 @@ import (
 	"node-agent/pkg/objectcache"
 	"node-agent/pkg/storage"
 	"node-agent/pkg/utils"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -41,6 +42,7 @@ type ApplicationProfileManager struct {
 	ctx                      context.Context
 	containerMutexes         storageUtils.MapMutex[string]                                   // key is k8sContainerID
 	trackedContainers        mapset.Set[string]                                              // key is k8sContainerID
+	removedContainers        mapset.Set[string]                                              // key is k8sContainerID
 	savedCapabilities        maps.SafeMap[string, mapset.Set[string]]                        // key is k8sContainerID
 	savedExecs               maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]] // key is k8sContainerID
 	droppedEvents            maps.SafeMap[string, bool]                                      // key is k8sContainerID
@@ -69,6 +71,7 @@ func CreateApplicationProfileManager(ctx context.Context, cfg config.Config, clu
 		storageClient:          storageClient,
 		containerMutexes:       storageUtils.NewMapMutex[string](),
 		trackedContainers:      mapset.NewSet[string](),
+		removedContainers:      mapset.NewSet[string](),
 		preRunningContainerIDs: preRunningContainerIDs,
 	}, nil
 }
@@ -126,6 +129,7 @@ func (am *ApplicationProfileManager) deleteResources(watchedContainer *utils.Wat
 	// make sure we don't run deleteResources and saveProfile at the same time
 	am.containerMutexes.Lock(watchedContainer.K8sContainerID)
 	defer am.containerMutexes.Unlock(watchedContainer.K8sContainerID)
+	am.removedContainers.Add(watchedContainer.K8sContainerID)
 	// delete resources
 	watchedContainer.UpdateDataTicker.Stop()
 	am.trackedContainers.Remove(watchedContainer.K8sContainerID)
@@ -230,7 +234,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 
 	if am.syscallPeekFunc != nil {
 		observedSyscalls, err = am.syscallPeekFunc(watchedContainer.NsMntId)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "no syscall found") {
 			logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to get syscalls", helpers.Error(err),
 				helpers.String("slug", slug),
 				helpers.Int("container index", watchedContainer.ContainerIndex),
@@ -243,8 +247,6 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		if !toSaveSyscallsSet.IsEmpty() {
 			toSaveSyscalls = toSaveSyscallsSet.ToSlice()
 		}
-	} else {
-		logger.L().Ctx(ctx).Error("ApplicationProfileManager - syscall peek function is nil", helpers.String("slug", slug))
 	}
 
 	// application profile
@@ -517,6 +519,9 @@ func (am *ApplicationProfileManager) startApplicationProfiling(ctx context.Conte
 }
 
 func (am *ApplicationProfileManager) waitForContainer(k8sContainerID string) error {
+	if am.removedContainers.Contains(k8sContainerID) {
+		return fmt.Errorf("container %s has been removed", k8sContainerID)
+	}
 	return backoff.Retry(func() error {
 		if am.trackedContainers.Contains(k8sContainerID) {
 			return nil
@@ -546,6 +551,7 @@ func (am *ApplicationProfileManager) ContainerCallback(notif containercollection
 		am.toSaveCapabilities.Set(k8sContainerID, mapset.NewSet[string]())
 		am.toSaveExecs.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
 		am.toSaveOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
+		am.removedContainers.Remove(k8sContainerID) // make sure container is not in the removed list
 		am.trackedContainers.Add(k8sContainerID)
 		go am.startApplicationProfiling(ctx, notif.Container, k8sContainerID)
 

--- a/pkg/containerwatcher/v1/open_test.go
+++ b/pkg/containerwatcher/v1/open_test.go
@@ -22,7 +22,7 @@ func BenchmarkIGContainerWatcher_openEventCallback(b *testing.B) {
 	assert.NoError(b, err)
 	mockExporter := metricsmanager.NewMetricsMock()
 
-	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, mockExporter, nil, nil, nil)
+	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, mockExporter, nil, nil, nil, nil)
 	assert.NoError(b, err)
 	event := &traceropentype.Event{
 		Event: types.Event{

--- a/pkg/objectcache/applicationprofilecache/applicationprofilecache_test.go
+++ b/pkg/objectcache/applicationprofilecache/applicationprofilecache_test.go
@@ -252,7 +252,7 @@ func Test_deleteApplicationProfile(t *testing.T) {
 			if tt.shouldDelete {
 				assert.Equal(t, len(tt.slugs)-1, ap.allProfiles.Cardinality())
 				assert.False(t, ap.slugToAppProfile.Has(tt.slug))
-				assert.False(t, ap.slugToPods.Has(tt.slug))
+				assert.True(t, ap.slugToPods.Has(tt.slug)) // this field should not be deleted
 			} else {
 				assert.Equal(t, len(tt.slugs), ap.allProfiles.Cardinality())
 				assert.True(t, ap.slugToAppProfile.Has(tt.slug))
@@ -496,6 +496,7 @@ func Test_addApplicationProfile_existing(t *testing.T) {
 			// add pods
 			for i := range tt.pods {
 				ap.podToSlug.Set(tt.pods[i].podName, tt.pods[i].slug)
+				ap.slugToPods.Set(tt.pods[i].slug, mapset.NewSet(tt.pods[i].podName))
 			}
 
 			ap.addApplicationProfile(context.Background(), tt.obj1)

--- a/pkg/objectcache/k8scache/k8scache.go
+++ b/pkg/objectcache/k8scache/k8scache.go
@@ -32,6 +32,7 @@ func NewK8sObjectCache(nodeName string, k8sClient k8sclient.K8sClientInterface) 
 	k := &K8sObjectCacheImpl{
 		k8sClient: k8sClient,
 		nodeName:  nodeName,
+		podSpec:   maps.SafeMap[string, *corev1.PodSpec]{},
 	}
 
 	if err := k.setApiServerIpAddress(); err != nil {

--- a/pkg/objectcache/networkneighborscache/networkneighborscache_test.go
+++ b/pkg/objectcache/networkneighborscache/networkneighborscache_test.go
@@ -277,7 +277,7 @@ func Test_deleteNetworkNeighbors(t *testing.T) {
 			if tt.shouldDelete {
 				assert.Equal(t, len(tt.slugs)-1, nn.allNeighbors.Cardinality())
 				assert.False(t, nn.slugToNetworkNeighbor.Has(tt.slug))
-				assert.False(t, nn.slugToPods.Has(tt.slug))
+				assert.True(t, nn.slugToPods.Has(tt.slug))
 			} else {
 				assert.Equal(t, len(tt.slugs), nn.allNeighbors.Cardinality())
 				assert.True(t, nn.slugToNetworkNeighbor.Has(tt.slug))
@@ -522,6 +522,7 @@ func Test_addNetworkNeighbor_existing(t *testing.T) {
 			// add pods
 			for i := range tt.pods {
 				nn.podToSlug.Set(tt.pods[i].podName, tt.pods[i].slug)
+				nn.slugToPods.Set(tt.pods[i].slug, mapset.NewSet(tt.pods[i].podName))
 			}
 
 			nn.addNetworkNeighbor(context.Background(), tt.obj1)

--- a/pkg/objectcache/objectcache_interface.go
+++ b/pkg/objectcache/objectcache_interface.go
@@ -12,6 +12,9 @@ var _ ObjectCache = (*ObjectCacheMock)(nil)
 type ObjectCacheMock struct {
 }
 
+func NewObjectCacheMock() *ObjectCacheMock {
+	return &ObjectCacheMock{}
+}
 func (om *ObjectCacheMock) K8sObjectCache() K8sObjectCache {
 	return &K8sObjectCacheMock{}
 }

--- a/pkg/rulebindingmanager/cache/helpers.go
+++ b/pkg/rulebindingmanager/cache/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	typesv1 "node-agent/pkg/rulebindingmanager/types/v1"
 	"node-agent/pkg/watcher"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+func uniqueNameToName(n string) (string, string) {
+	if str := strings.Split(n, "/"); len(str) == 2 {
+		return str[0], str[1]
+	}
+	return "", ""
+}
 func uniqueName(namespace, name string) string {
 	return fmt.Sprintf("%s/%s", namespace, name)
 }

--- a/pkg/rulebindingmanager/notifier.go
+++ b/pkg/rulebindingmanager/notifier.go
@@ -1,0 +1,46 @@
+package rulebindingmanager
+
+import (
+	"context"
+	"node-agent/pkg/k8sclient"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Actions int
+
+const (
+	Added   Actions = 0
+	Removed Actions = 1
+)
+
+type RuleBindingNotify struct {
+	Pod    corev1.Pod
+	Action Actions
+}
+
+func NewRuleBindingNotifierImpl(action Actions, pod corev1.Pod) RuleBindingNotify {
+	return RuleBindingNotify{
+		Pod:    pod,
+		Action: action,
+	}
+}
+func RuleBindingNotifierImplWithK8s(k8sClient k8sclient.K8sClientInterface, action Actions, namespace, name string) (RuleBindingNotify, error) {
+	pod, err := k8sClient.GetKubernetesClient().CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return RuleBindingNotify{}, err
+	}
+	return RuleBindingNotify{
+		Pod:    *pod,
+		Action: action,
+	}, nil
+}
+
+func (r *RuleBindingNotify) GetPod() *corev1.Pod {
+	return &r.Pod
+}
+func (r *RuleBindingNotify) GetAction() Actions {
+	return r.Action
+}

--- a/pkg/rulebindingmanager/rulebindingmanager_interface.go
+++ b/pkg/rulebindingmanager/rulebindingmanager_interface.go
@@ -1,8 +1,11 @@
 package rulebindingmanager
 
-import "node-agent/pkg/ruleengine"
+import (
+	"node-agent/pkg/ruleengine"
+)
 
 type RuleBindingCache interface {
 	IsCached(kind, namespace, name string) bool
 	ListRulesForPod(namespace, name string) []ruleengine.RuleEvaluator
+	AddNotifier(*chan RuleBindingNotify)
 }

--- a/pkg/rulebindingmanager/rulebindingmanager_mock.go
+++ b/pkg/rulebindingmanager/rulebindingmanager_mock.go
@@ -7,9 +7,14 @@ var _ RuleBindingCache = (*RuleBindingCacheMock)(nil)
 type RuleBindingCacheMock struct {
 }
 
+func NewRuleBindingCacheMock() *RuleBindingCacheMock {
+	return &RuleBindingCacheMock{}
+}
 func (r *RuleBindingCacheMock) ListRulesForPod(namespace, name string) []ruleengine.RuleEvaluator {
 	return []ruleengine.RuleEvaluator{}
 }
 func (r *RuleBindingCacheMock) IsCached(kind, namespace, name string) bool {
-	return false
+	return true
+}
+func (r *RuleBindingCacheMock) AddNotifier(_ *chan RuleBindingNotify) {
 }

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -415,12 +415,12 @@ func (rm *RuleManager) isCached(namespace, name string) bool {
 
 	// wait for pod to be cached
 	if err := backoff.Retry(func() error {
-		if !rm.objectCache.IsCached("Pod", namespace, name) {
-			return fmt.Errorf("pod %s/%s not found in objectCache", namespace, name)
+		if !rm.objectCache.K8sObjectCache().IsCached("Pod", namespace, name) {
+			return fmt.Errorf("pod %s/%s not found in K8sObjectCache", namespace, name)
 		}
-		if !rm.ruleBindingCache.IsCached("Pod", namespace, name) {
-			return fmt.Errorf("pod %s/%s not found in ruleBindingCache", namespace, name)
-		}
+		// if !rm.ruleBindingCache.IsCached("Pod", namespace, name) {
+		// 	return fmt.Errorf("pod %s/%s not found in ruleBindingCache", namespace, name)
+		// }
 		return nil
 	}, backoff.NewExponentialBackOff()); err != nil {
 		return false

--- a/pkg/watcher/dynamicwatcher/watch.go
+++ b/pkg/watcher/dynamicwatcher/watch.go
@@ -61,7 +61,7 @@ func (wh *WatchHandler) AddAdaptor(adaptor watcher.Adaptor) {
 	}
 }
 
-func (wh *WatchHandler) Start(ctx context.Context) error {
+func (wh *WatchHandler) Start(ctx context.Context) {
 
 	for k, v := range wh.resources {
 		go func(r string, w watcher.WatchResource) {
@@ -70,7 +70,6 @@ func (wh *WatchHandler) Start(ctx context.Context) error {
 			}
 		}(k, v)
 	}
-	return nil
 }
 
 func (wh *WatchHandler) watch(ctx context.Context, resource watcher.WatchResource, eventQueue *cooldownqueue.CooldownQueue) error {
@@ -177,9 +176,12 @@ func (wh *WatchHandler) getExistingStorageObjects(ctx context.Context, res schem
 	if err != nil {
 		return "", fmt.Errorf("list resources: %w", err)
 	}
+	logger.L().Info("got existing objects from storage", helpers.String("resource", res.Resource), helpers.Int("count", len(list.Items)))
 	for i := range list.Items {
 		for _, handler := range wh.handlers {
-			handler.AddHandler(ctx, &list.Items[i])
+			var l unstructured.Unstructured
+			l = list.Items[i]
+			handler.AddHandler(ctx, &l)
 		}
 	}
 	// set resource version to watch from


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Enhanced object and rule binding cache management for improved performance and reliability.
- Introduced rule binding notifications to dynamically manage container monitoring based on rule bindings.
- Optimized application profile and network neighbors caching logic.
- Improved container lifecycle management in various components.
- Fixed dynamic watcher start method and storage object handling to prevent data races.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Enhance Object and Rule Binding Cache Management and Shutdown </code><br><code>Procedure</code></dd></summary>
<hr>

main.go
<li>Introduced <code>objectcachev1</code> and <code>rulebindingcachev1</code> for enhanced cache <br>management.<br> <li> Added <code>ruleBindingNotify</code> channel to manage rule binding notifications.<br> <li> Integrated <code>ruleBindingNotify</code> with <code>containerwatcher</code> to observe <br>container events based on rule bindings.<br> <li> Ensured <code>dWatcher</code> stops upon application shutdown.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+18/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Improve Application Profile Manager with Better Error Handling and </code><br><code>Container Tracking</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Added tracking for removed containers to prevent race conditions <br>during delete operations.<br> <li> Improved error handling for syscall retrieval to ignore "no syscall <br>found" errors.<br> <li> Removed unnecessary logging for nil syscall peek function.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Refactor Container Watcher to Support Rule-based Container Monitoring</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Added <code>ruleBindingPodNotify</code> to manage container monitoring based on <br>rule bindings.<br> <li> Introduced <code>timeBasedContainers</code> and <code>ruleManagedContainers</code> sets for <br>container tracking.<br> <li> Adjusted container monitoring logic to differentiate between <br>time-based and rule-managed containers.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+16/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher_private.go</strong><dd><code>Enhance Container Callback and Monitoring Logic for Rule-based </code><br><code>Operations</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher_private.go
<li>Enhanced container callback to support rule-based container <br>monitoring.<br> <li> Implemented <code>addRunningContainers</code> to monitor containers based on rule <br>bindings.<br> <li> Adjusted container unregister logic to consider rule-managed <br>containers.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-6f95b4caa6090a17da5aed1923600fd049392d228e0fba99cc212f48111f3ffe">+68/-29</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Improve Network Manager with Enhanced Container Tracking</code>&nbsp; </dd></summary>
<hr>

pkg/networkmanager/network_manager.go
<li>Introduced <code>removedContainers</code> and <code>trackedContainers</code> sets for better <br>container lifecycle management.<br> <li> Improved <code>waitForContainer</code> method to handle removed containers.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-cbcd69c2d2fb59b909f8b3cec3ff32348a1ddb4f1d465ece79ead0fa0ba7168b">+29/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofilecache.go</strong><dd><code>Optimize Application Profile Caching Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectcache/applicationprofilecache/applicationprofilecache.go
<li>Optimized application profile caching logic for added and deleted <br>pods.<br> <li> Ensured application profiles are properly cached and cleaned up.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-7033af70203ec0c7cabfa58ce543eee2aa32baea58ae8904c87db7c406b51f9b">+16/-31</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>k8scache.go</strong><dd><code>Initialize PodSpec Map in Kubernetes Object Cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectcache/k8scache/k8scache.go
<li>Initialized <code>podSpec</code> map to store Kubernetes object specifications.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-94e97b801b804ff969fe331c2781d7d7bd6b0eff78492f428ee9c7de05ce4327">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkneighborscache.go</strong><dd><code>Optimize Network Neighbors Caching Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectcache/networkneighborscache/networkneighborscache.go
<li>Optimized network neighbors caching logic for added and deleted pods.<br> <li> Ensured network neighbors are properly cached and cleaned up.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-ec7eda3c7e1d7fe827159ee9e8067c2ce6278ecaf78d39aef6bc5b6210689c28">+14/-25</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>objectcache_interface.go</strong><dd><code>Introduce NewObjectCacheMock Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectcache/objectcache_interface.go
<li>Introduced <code>NewObjectCacheMock</code> function to create a mock object cache.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-f4e5fb31aacce84b5afe8e50e89c5657459a436fd0d807e213f4a55d0f41fcf6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager.go</strong><dd><code>Improve Relevancy Manager with Better Container Lifecycle Management</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager.go
<li>Added tracking for removed containers to prevent race conditions.<br> <li> Improved container callback to handle container removal more <br>gracefully.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-f665b80e0e8d6552b56e677f5579b3b90cb7cd78999a4bec61d41522469393a3">+13/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Enhance Rule Binding Cache with Notification Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Added support for notifying about rule binding changes.<br> <li> Enhanced rule binding and pod association logic.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+32/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helpers.go</strong><dd><code>Add Helper Function for Name Conversion in Rule Binding Cache</code></dd></summary>
<hr>

pkg/rulebindingmanager/cache/helpers.go
<li>Added helper function to convert unique names to namespace and name.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-3dcb9670e6a598e25f8f7b6bfeff52c586e61b3c4f38d6a00e6eb17fedac5fa1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>notifier.go</strong><dd><code>Introduce Rule Binding Notification Mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/notifier.go
<li>Introduced <code>RuleBindingNotify</code> structure and related functions to manage <br>rule binding notifications.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-c8fbb60780f2adc0d246684085c73ecfcfe548f4010a5c5bcb31eafa61edf115">+46/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rulebindingmanager_interface.go</strong><dd><code>Add Notifier Method to RuleBindingCache Interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/rulebindingmanager_interface.go
- Added `AddNotifier` method to the `RuleBindingCache` interface.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-cc00734db7b0aca47227aaca8561a769295cc137fac90f868261c8e020b0ec4e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rulebindingmanager_mock.go</strong><dd><code>Introduce NewRuleBindingCacheMock Function and Fix Mock Behavior</code></dd></summary>
<hr>

pkg/rulebindingmanager/rulebindingmanager_mock.go
<li>Introduced <code>NewRuleBindingCacheMock</code> function.<br> <li> Fixed <code>IsCached</code> method to return true for better mock behavior.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-53b9c80f1773bebd60a7e49a60a44cfd21a0a929d34897c4ac1ff8fced7b908d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Adjust Rule Manager Caching Check for Efficiency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Adjusted caching check to use <code>K8sObjectCache</code> directly.<br> <li> Commented out redundant rule binding cache check.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>open_test.go</strong><dd><code>Fix Container Watcher Test Initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/open_test.go
<li>Fixed the <code>CreateIGContainerWatcher</code> call in tests by adding the missing <br><code>ruleBindingPodNotify</code> parameter.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-108b6c5c8056d52d17a43bba61a908715238d3bc3a2919f6332ca926509d2ec2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Bug_fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>watch.go</strong><dd><code>Adjust Dynamic Watcher Start Method and Fix Storage Object Handling</code></dd></summary>
<hr>

pkg/watcher/dynamicwatcher/watch.go
<li>Adjusted <code>Start</code> method to not return an error.<br> <li> Fixed handling of existing storage objects to prevent data races.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/229/files#diff-f29578a7352bf2f04d5b87fd277128222fa7ce282adc7d71a9d628c9880a5722">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

