### PR TITLE
fixed rule

### DIFF
--- a/pkg/rulebindingmanager/cache/cache.go
+++ b/pkg/rulebindingmanager/cache/cache.go
@@ -182,7 +182,7 @@ func (c *RBCache) addRuleBinding(ruleBinding *typesv1.RuntimeAlertRuleBinding) {
 	// if the rule binding is global, add it to the global rules
 	if len(nsSelectorStr) == 0 && len(podSelectorStr) == 0 {
 		c.globalRBNames.Add(rbUniqueName(ruleBinding))
-		logger.L().Debug("AddRuleBinding", helpers.String("ruleBinding", rbName), helpers.String("global", "true"))
+		logger.L().Info("AddRuleBinding", helpers.String("ruleBinding", rbName), helpers.String("global", "true"))
 		return
 	}
 

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -5,6 +5,7 @@ import (
 	"node-agent/pkg/objectcache"
 	"node-agent/pkg/ruleengine"
 	"node-agent/pkg/utils"
+	"path/filepath"
 	"strings"
 
 	apitypes "github.com/armosec/armoapi-go/armotypes"
@@ -70,7 +71,7 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 	// is memory mapped file
 
 	// The assumption here is that the event path is absolute!
-	p := getExecPathFromEvent(execEvent)
+	p := filepath.Dir(getExecPathFromEvent(execEvent))
 	for _, maliciousExecPathPrefix := range maliciousExecPathPrefixes {
 		// if the exec path or the current dir is from a malicious source
 		if strings.HasPrefix(p, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.Cwd, maliciousExecPathPrefix) {

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
@@ -42,3 +42,62 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 		t.Errorf("Expected ruleResult since exec is malicious")
 	}
 }
+
+// func TestProcessEvent(t *testing.T) {
+//     rule := &R1000ExecFromMaliciousSource{}
+
+//     tests := []struct {
+//         name     string
+//         eventType utils.EventType
+//         event    *tracerexectype.Event
+//         expected ruleengine.RuleFailure
+//     }{
+//         {
+//             name:     "Test with non-ExecveEventType",
+//             eventType: utils.OtherEventType,
+//             event:    &tracerexectype.Event{},
+//             expected: nil,
+//         },
+//         {
+//             name:     "Test with ExecveEventType and non-malicious source",
+//             eventType: utils.ExecveEventType,
+//             event: &tracerexectype.Event{
+//                 Event: tracerexectype.Event{
+//                     Cwd: "/home/user",
+//                 },
+//             },
+//             expected: nil,
+//         },
+//         {
+//             name:     "Test with ExecveEventType and malicious source",
+//             eventType: utils.ExecveEventType,
+//             event: &tracerexectype.Event{
+//                 Event: tracerexectype.Event{
+//                     Cwd: "/run_amit.sh",
+//                 },
+//             },
+//             expected: &GenericRuleFailure{
+//                 // Fill in expected GenericRuleFailure fields here
+//             },
+//         },
+// 		{
+//             name:     "Test with ExecveEventType and malicious source",
+//             eventType: utils.ExecveEventType,
+//             event: &tracerexectype.Event{
+//                 Event: tracerexectype.Event{
+//                     Cwd: "/run/amit.sh",
+//                 },
+//             },
+//             expected: &GenericRuleFailure{
+//                 // Fill in expected GenericRuleFailure fields here
+//             },
+//         },
+//     }
+
+//     for _, tt := range tests {
+//         t.Run(tt.name, func(t *testing.T) {
+//             result := rule.ProcessEvent(tt.eventType, tt.event, nil)
+//             assert.Equal(t, tt.expected, result)
+//         })
+//     }
+// }

--- a/pkg/watcher/dynamicwatcher/watch.go
+++ b/pkg/watcher/dynamicwatcher/watch.go
@@ -85,9 +85,7 @@ func (wh *WatchHandler) watch(ctx context.Context, resource watcher.WatchResourc
 			opt.ResourceVersion, err = wh.getExistingStorageObjects(ctx, res, opt)
 			return err
 		}, newBackOff(), func(err error, d time.Duration) {
-			logger.L().Ctx(ctx).Warning("get existing storage objects", helpers.Error(err),
-				helpers.String("resource", res.Resource),
-				helpers.String("retry in", d.String()))
+			// filed to list resources, will retry
 		}); err != nil {
 			return fmt.Errorf("giving up get existing storage objects: %w", err)
 		}


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced logging for the addition of global rule bindings by changing the log level from Debug to Info.
- Improved malicious source detection in rule R1000 by checking the directory path instead of the exact path.
- Extended test coverage for rule R1000 to include scenarios with non-ExecveEventType, non-malicious sources, and malicious sources.
- Removed a warning log in the dynamic watcher to adopt a silent retry mechanism on failure to list resources.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Enhance Logging for Global Rule Binding Addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Changed log level from Debug to Info when adding a global rule <br>binding.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/233/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source.go</strong><dd><code>Improve Malicious Source Detection Logic in Rule R1000</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
<li>Imported <code>filepath</code> package for path manipulation.<br> <li> Modified the path check to use directory path instead of exact path in <br>malicious source detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/233/files#diff-00351ce4b75a85e267a68663f357265bbcc7721c2e461fa6112363fdfb2150c5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source_test.go</strong><dd><code>Extend Test Coverage for Rule R1000 Malicious Source Detection</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
<li>Added new test cases for <code>ProcessEvent</code> function in rule R1000 to cover <br>various scenarios including non-ExecveEventType, non-malicious source, <br>and malicious source.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/233/files#diff-0335c2abb82667ee7c0f955f8a4f1ab795958d30e89dc3965de2d67c6b610b00">+59/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>watch.go</strong><dd><code>Remove Warning Log on Resource Listing Failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/watcher/dynamicwatcher/watch.go
<li>Removed warning log when failing to list resources, opting for a <br>silent retry mechanism.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/233/files#diff-f29578a7352bf2f04d5b87fd277128222fa7ce282adc7d71a9d628c9880a5722">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

