### PR TITLE
adding ruleManager.ContainerCallback

### DIFF
--- a/pkg/rulebindingmanager/cache/cache_test.go
+++ b/pkg/rulebindingmanager/cache/cache_test.go
@@ -22,7 +22,6 @@ func NewCacheMock(nodeName string) *RBCache {
 		allPods:          mapset.NewSet[string](),
 		k8sClient:        &k8sclient.K8sClientMock{},
 		ruleCreator:      &ruleengine.RuleCreatorMock{},
-		globalRBNames:    mapset.NewSet[string](),
 		podToRBNames:     maps.SafeMap[string, mapset.Set[string]]{},
 		rbNameToPodNames: maps.SafeMap[string, mapset.Set[string]]{},
 	}
@@ -384,19 +383,15 @@ func TestDeleteHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &RBCache{
-				allPods:       mapset.NewSet[string](tt.expected.pod),
-				globalRBNames: mapset.NewSet[string](tt.expected.rule),
+				allPods: mapset.NewSet[string](tt.expected.pod),
 			}
 			c.DeleteHandler(context.Background(), tt.obj)
 			if tt.obj.GetKind() == "Pod" {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
-				assert.True(t, c.globalRBNames.Contains(tt.expected.rule))
 			} else if tt.obj.GetKind() == "RuntimeRuleAlertBinding" {
 				assert.True(t, c.allPods.Contains(tt.expected.pod))
-				assert.False(t, c.globalRBNames.Contains(tt.expected.rule))
 			} else {
 				assert.True(t, c.allPods.Contains(tt.expected.pod))
-				assert.True(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 		})
 	}
@@ -503,15 +498,12 @@ func TestModifyHandler(t *testing.T) {
 
 			if tt.addedPod {
 				assert.True(t, c.allPods.Contains(tt.expected.pod))
-				assert.False(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 			if tt.addedRB {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
-				assert.True(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 			if !tt.addedPod && !tt.addedRB {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
-				assert.False(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 		})
 	}
@@ -618,15 +610,12 @@ func TestAddHandler(t *testing.T) {
 
 			if tt.addedPod {
 				assert.True(t, c.allPods.Contains(tt.expected.pod))
-				assert.False(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 			if tt.addedRB {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
-				assert.True(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 			if !tt.addedPod && !tt.addedRB {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
-				assert.False(t, c.globalRBNames.Contains(tt.expected.rule))
 			}
 		})
 	}

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -243,16 +243,6 @@ func (rm *RuleManager) deleteResources(watchedContainer *utils.WatchedContainerD
 	rm.watchedContainerChannels.Delete(watchedContainer.ContainerID)
 }
 
-// This function is not used in the current implementation (Might be used in the future).
-// func (rm *RuleManager) waitForContainer(k8sContainerID string) error {
-// 	return backoff.Retry(func() error {
-// 		if rm.trackedContainers.Contains(k8sContainerID) {
-// 			return nil
-// 		}
-// 		return fmt.Errorf("container %s not found", k8sContainerID)
-// 	}, backoff.NewExponentialBackOff())
-// }
-
 func (rm *RuleManager) ContainerCallback(notif containercollection.PubSubEvent) {
 	k8sContainerID := utils.CreateK8sContainerID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName, notif.Container.K8s.ContainerName)
 
@@ -433,6 +423,8 @@ func (rm *RuleManager) processEvent(eventType utils.EventType, event interface{}
 }
 
 func (rm *RuleManager) isCached(namespace, name string) bool {
+	return true
+
 	podName := fmt.Sprintf("%s/%s", namespace, name)
 
 	// this will prevent multiple goroutines from waiting for the same pod to be cached


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Integrated `ruleManager.ContainerCallback` into the container watcher to handle container events.
- Cleaned up unused code and simplified logic in container watcher and rule manager.
- Improved rule binding cache logic for handling pod and namespace selector mismatches.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>container_watcher_private.go</strong><dd><code>Integration of RuleManager Container Callback and Code Cleanup</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher_private.go
<li>Added <code>ruleManager.ContainerCallback</code> to the list of container <br>callbacks.<br> <li> Removed unused <code>getContainerRuntimeConfig</code> function.<br> <li> Simplified <code>traceForever</code> function.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/234/files#diff-6f95b4caa6090a17da5aed1923600fd049392d228e0fba99cc212f48111f3ffe">+1/-23</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Improved Logic and Clarity in RuleBinding Cache Operations</code></dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Fixed logic to continue instead of return when pod or namespace <br>selectors do not match.<br> <li> Adjusted logging and error handling for clearer operation flow.<br> <li> Enhanced the <code>addPod</code> function to ensure notifications are sent <br>correctly.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/234/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+13/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Implementation of Container Callback and Code Cleanup in RuleManager</code></dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Implemented <code>ContainerCallback</code> function for handling container events.<br> <li> Removed unused code and comments related to future use.<br> <li> Added a dummy <code>isCached</code> function to always return true for now.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/234/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+2/-10</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

