### PR TITLE
Fixing r1000

### DIFF
--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -71,10 +71,10 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 	// is memory mapped file
 
 	// The assumption here is that the event path is absolute!
-	p := filepath.Dir(getExecPathFromEvent(execEvent))
+	execPath := filepath.Dir(getExecPathFromEvent(execEvent))
 	for _, maliciousExecPathPrefix := range maliciousExecPathPrefixes {
 		// if the exec path or the current dir is from a malicious source
-		if strings.HasPrefix(p, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.Cwd, maliciousExecPathPrefix) {
+		if strings.HasPrefix(execPath, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.Cwd, maliciousExecPathPrefix) {
 			isPartOfImage := !execEvent.UpperLayer
 			ruleFailure := GenericRuleFailure{
 				BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
@@ -94,7 +94,7 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 				TriggerEvent: execEvent.Event,
 				RuleAlert: apitypes.RuleAlert{
 					RuleID:          rule.ID(),
-					RuleDescription: fmt.Sprintf("exec call \"%s\" is from a malicious source \"%s\"", p, maliciousExecPathPrefix),
+					RuleDescription: fmt.Sprintf("exec call \"%s\" is from a malicious source \"%s\"", execPath, maliciousExecPathPrefix),
 				},
 				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
 			}

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
@@ -41,63 +41,11 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 	if ruleResult == nil {
 		t.Errorf("Expected ruleResult since exec is malicious")
 	}
+
+	e.Comm = "/run.sh"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since exec is not malicious")
+	}
 }
-
-// func TestProcessEvent(t *testing.T) {
-//     rule := &R1000ExecFromMaliciousSource{}
-
-//     tests := []struct {
-//         name     string
-//         eventType utils.EventType
-//         event    *tracerexectype.Event
-//         expected ruleengine.RuleFailure
-//     }{
-//         {
-//             name:     "Test with non-ExecveEventType",
-//             eventType: utils.OtherEventType,
-//             event:    &tracerexectype.Event{},
-//             expected: nil,
-//         },
-//         {
-//             name:     "Test with ExecveEventType and non-malicious source",
-//             eventType: utils.ExecveEventType,
-//             event: &tracerexectype.Event{
-//                 Event: tracerexectype.Event{
-//                     Cwd: "/home/user",
-//                 },
-//             },
-//             expected: nil,
-//         },
-//         {
-//             name:     "Test with ExecveEventType and malicious source",
-//             eventType: utils.ExecveEventType,
-//             event: &tracerexectype.Event{
-//                 Event: tracerexectype.Event{
-//                     Cwd: "/run_amit.sh",
-//                 },
-//             },
-//             expected: &GenericRuleFailure{
-//                 // Fill in expected GenericRuleFailure fields here
-//             },
-//         },
-// 		{
-//             name:     "Test with ExecveEventType and malicious source",
-//             eventType: utils.ExecveEventType,
-//             event: &tracerexectype.Event{
-//                 Event: tracerexectype.Event{
-//                     Cwd: "/run/amit.sh",
-//                 },
-//             },
-//             expected: &GenericRuleFailure{
-//                 // Fill in expected GenericRuleFailure fields here
-//             },
-//         },
-//     }
-
-//     for _, tt := range tests {
-//         t.Run(tt.name, func(t *testing.T) {
-//             result := rule.ProcessEvent(tt.eventType, tt.event, nil)
-//             assert.Equal(t, tt.expected, result)
-//         })
-//     }
-// }

--- a/pkg/ruleengine/v1/r1007_crypto_miners.go
+++ b/pkg/ruleengine/v1/r1007_crypto_miners.go
@@ -176,9 +176,11 @@ func (rule *R1007CryptoMiners) ProcessEvent(eventType utils.EventType, event int
 	}
 
 	if randomXEvent, ok := event.(*tracerrandomxtype.Event); ok {
+		isPartOfImage := !randomXEvent.UpperLayer
 		ruleFailure := GenericRuleFailure{
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
+				IsPartOfImage:  &isPartOfImage,
 				FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",
 				Severity:       R1007CryptoMinersRuleDescriptor.Priority,
 				PPID:           &randomXEvent.PPid,


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix, tests


___

## **Description**
- Improved variable naming within the malicious source execution rule for better readability.
- Updated the rule failure message to include the execution path for clearer alert descriptions.
- Cleaned up the test file by removing commented-out code.
- Added a new test case to ensure non-malicious execution paths are correctly handled.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source.go</strong><dd><code>Improve Clarity and Alert Descriptions in Malicious Source Execution </code><br><code>Rule</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
<li>Improved variable naming for clarity (<code>p</code> to <code>execPath</code>).<br> <li> Enhanced rule description to include the <code>execPath</code> in the alert <br>message.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/235/files#diff-00351ce4b75a85e267a68663f357265bbcc7721c2e461fa6112363fdfb2150c5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source_test.go</strong><dd><code>Cleanup and Extend Tests for Malicious Source Execution Rule</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
<li>Removed commented-out test code.<br> <li> Added a test case to verify non-malicious execution paths do not <br>trigger a rule alert.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/235/files#diff-0335c2abb82667ee7c0f955f8a4f1ab795958d30e89dc3965de2d67c6b610b00">+6/-58</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

