### PR TITLE
adding tests

### DIFF
--- a/pkg/rulebindingmanager/cache/cache_test.go
+++ b/pkg/rulebindingmanager/cache/cache_test.go
@@ -2,16 +2,24 @@ package cache
 
 import (
 	"context"
-	"node-agent/pkg/k8sclient"
+	"node-agent/mocks"
+	"node-agent/pkg/rulebindingmanager"
 	typesv1 "node-agent/pkg/rulebindingmanager/types/v1"
 	"node-agent/pkg/ruleengine"
+	"slices"
+	"sync"
 	"testing"
+	"time"
+
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/goradd/maps"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -20,7 +28,7 @@ func NewCacheMock(nodeName string) *RBCache {
 	return &RBCache{
 		nodeName:         nodeName,
 		allPods:          mapset.NewSet[string](),
-		k8sClient:        &k8sclient.K8sClientMock{},
+		k8sClient:        k8sinterface.NewKubernetesApiMock(),
 		ruleCreator:      &ruleengine.RuleCreatorMock{},
 		podToRBNames:     maps.SafeMap[string, mapset.Set[string]]{},
 		rbNameToPodNames: maps.SafeMap[string, mapset.Set[string]]{},
@@ -160,7 +168,6 @@ func TestRuntimeObjAddHandler(t *testing.T) {
 			},
 			expectedRules: []rules{},
 		},
-		// TODO: test namespace selector
 	}
 
 	for _, tt := range tests {
@@ -617,6 +624,507 @@ func TestAddHandler(t *testing.T) {
 			if !tt.addedPod && !tt.addedRB {
 				assert.False(t, c.allPods.Contains(tt.expected.pod))
 			}
+		})
+	}
+}
+func TestDeleteRuleBinding(t *testing.T) {
+
+	tests := []struct {
+		podToRBNames         map[string][]string
+		expectedPodToRBNames map[string][]string
+		name                 string
+		uniqueName           string
+	}{
+		{
+			name:                 "Test with valid unique name without pods",
+			uniqueName:           "test-unique-name",
+			podToRBNames:         map[string][]string{},
+			expectedPodToRBNames: map[string][]string{},
+		},
+		{
+			name:       "Test with valid unique name one pod",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/pod-1": {"test-unique-name"},
+			},
+			expectedPodToRBNames: map[string][]string{},
+		},
+		{
+			name:       "Delete all pods with the same unique name",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/pod-1": {"test-unique-name"},
+				"default/pod-2": {"test-unique-name"},
+				"default/pod-3": {"test-unique-name"},
+			},
+			expectedPodToRBNames: map[string][]string{},
+		},
+		{
+			name:       "Delete one pod with the same unique name",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/pod-1": {"test-unique-name"},
+				"default/pod-2": {"test-unique-name", "test-unique-name-2", "test-unique-name-3"},
+				"default/pod-3": {"test-unique-name-2", "test-unique-name-3"},
+			},
+			expectedPodToRBNames: map[string][]string{
+				"default/pod-2": {"test-unique-name-2", "test-unique-name-3"},
+				"default/pod-3": {"test-unique-name-2", "test-unique-name-3"},
+			},
+		},
+		{
+			name:       "Do not delete any",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/pod-2": {"test-unique-name-2", "test-unique-name-3"},
+				"default/pod-3": {"test-unique-name-2", "test-unique-name-3"},
+			},
+			expectedPodToRBNames: map[string][]string{
+				"default/pod-2": {"test-unique-name-2", "test-unique-name-3"},
+				"default/pod-3": {"test-unique-name-2", "test-unique-name-3"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCacheMock("")
+
+			for k, v := range tt.podToRBNames {
+				for _, s := range v {
+					c.rbNameToRB.Set(s, typesv1.RuntimeAlertRuleBinding{})
+					c.rbNameToRules.Set(s, []ruleengine.RuleEvaluator{&ruleengine.RuleMock{}})
+
+					if !c.rbNameToPodNames.Has(s) {
+						c.rbNameToPodNames.Set(s, mapset.NewSet[string]())
+					}
+					c.rbNameToPodNames.Get(s).Add(k)
+
+					if !c.podToRBNames.Has(k) {
+						c.podToRBNames.Set(k, mapset.NewSet[string]())
+					}
+					c.podToRBNames.Get(k).Add(s)
+				}
+
+			}
+
+			c.deleteRuleBinding(tt.uniqueName)
+
+			assert.False(t, c.rbNameToPodNames.Has(tt.uniqueName))
+			assert.False(t, c.rbNameToRB.Has(tt.uniqueName))
+			assert.False(t, c.rbNameToRules.Has(tt.uniqueName))
+			for k, v := range tt.expectedPodToRBNames {
+				assert.Equal(t, 0, slices.Compare(v, c.podToRBNames.Get(k).ToSlice()))
+			}
+		})
+	}
+}
+
+func TestDeleteRuleBindingWithNotify(t *testing.T) {
+
+	defer func() {
+		mocks.NAMESPACE = ""
+	}()
+
+	k8sClient := k8sinterface.NewKubernetesApiMock()
+	var r []runtime.Object
+	mocks.NAMESPACE = "default"
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mocks.NAMESPACE}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	mocks.NAMESPACE = "other"
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mocks.NAMESPACE}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	k8sClient.KubernetesClient = k8sfake.NewSimpleClientset(r...)
+
+	tests := []struct {
+		podToRBNames         map[string][]string
+		name                 string
+		uniqueName           string
+		expectedNotifiedPods []string
+	}{
+		{
+			name:       "Test notify",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/collection-94c495554-z8s5k": {"test-unique-name"},
+				"default/nginx-77b4fdf86c-hp4x5":     {"test-unique-name"},
+			},
+			expectedNotifiedPods: []string{"default/collection-94c495554-z8s5k", "default/nginx-77b4fdf86c-hp4x5"},
+		},
+		{
+			name:       "Test notify different namespaces",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/collection-94c495554-z8s5k": {"test-unique-name"},
+				"other/nginx-77b4fdf86c-hp4x5":       {"test-unique-name"},
+			},
+			expectedNotifiedPods: []string{"default/collection-94c495554-z8s5k", "other/nginx-77b4fdf86c-hp4x5"},
+		},
+		{
+			name:       "Test notify only one pod",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/collection-94c495554-z8s5k": {"test-unique-name"},
+				"other/collection-94c495554-z8s5k":   {"test-unique-name"},
+				"default/nginx-77b4fdf86c-hp4x5":     {"test-unique-name", "test-unique-name-2"},
+			},
+			expectedNotifiedPods: []string{"default/collection-94c495554-z8s5k", "other/collection-94c495554-z8s5k"},
+		},
+		{
+			name:       "Test do not notify",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"default/collection-94c495554-z8s5k": {"test-unique-name", "test-unique-name-2"},
+				"default/nginx-77b4fdf86c-hp4x5":     {"test-unique-name", "test-unique-name-2"},
+			},
+			expectedNotifiedPods: []string{},
+		},
+		{
+			name:       "Test do not notify, pod not found",
+			uniqueName: "test-unique-name",
+			podToRBNames: map[string][]string{
+				"bla/collection-94c495554-z8s5k": {"test-unique-name"},
+			},
+			expectedNotifiedPods: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCacheMock("")
+			c.k8sClient = k8sClient
+
+			for k, v := range tt.podToRBNames {
+				for _, s := range v {
+					c.rbNameToRB.Set(s, typesv1.RuntimeAlertRuleBinding{})
+					c.rbNameToRules.Set(s, []ruleengine.RuleEvaluator{&ruleengine.RuleMock{}})
+
+					if !c.rbNameToPodNames.Has(s) {
+						c.rbNameToPodNames.Set(s, mapset.NewSet[string]())
+					}
+					c.rbNameToPodNames.Get(s).Add(k)
+
+					if !c.podToRBNames.Has(k) {
+						c.podToRBNames.Set(k, mapset.NewSet[string]())
+					}
+					c.podToRBNames.Get(k).Add(s)
+				}
+
+			}
+
+			notifyChan := make(chan rulebindingmanager.RuleBindingNotify)
+			received := []string{}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(len(tt.expectedNotifiedPods))
+
+			go func() {
+				for {
+					n := <-notifyChan
+					assert.Equal(t, n.Action, rulebindingmanager.Removed)
+					received = append(received, n.Pod.GetNamespace()+"/"+n.Pod.GetName())
+					wg.Done()
+				}
+			}()
+
+			c.AddNotifier(&notifyChan)
+
+			c.deleteRuleBinding(tt.uniqueName)
+
+			// wait for notified resources
+			wg.Wait()
+
+			// some resources should not be notify, so we wait to make sure they were not notified
+			time.Sleep(2 * time.Second)
+
+			slices.Sort(received)
+			slices.Sort(tt.expectedNotifiedPods)
+			assert.Equal(t, tt.expectedNotifiedPods, received)
+
+		})
+	}
+}
+
+func TestAddRuleBinding(t *testing.T) {
+
+	defer func() {
+		mocks.NAMESPACE = ""
+	}()
+
+	k8sClient := k8sinterface.NewKubernetesApiMock()
+	var r []runtime.Object
+	mocks.NAMESPACE = "default"
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mocks.NAMESPACE, Labels: map[string]string{"app": mocks.NAMESPACE}}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	mocks.NAMESPACE = "other"
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mocks.NAMESPACE, Labels: map[string]string{"app": mocks.NAMESPACE}}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	mocks.NAMESPACE = "test"
+	r = append(r, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: mocks.NAMESPACE, Labels: map[string]string{"app": mocks.NAMESPACE}}})
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestCollection))
+	r = append(r, mocks.GetRuntime(mocks.TestKindPod, mocks.TestNginx))
+
+	k8sClient.KubernetesClient = k8sfake.NewSimpleClientset(r...)
+
+	tests := []struct {
+		rb                   *typesv1.RuntimeAlertRuleBinding
+		name                 string
+		expectedNotifiedPods []string
+		invalidRB            bool
+	}{
+		{
+			name: "Add roleBinding",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{
+				"default/collection-94c495554-z8s5k",
+				"default/nginx-77b4fdf86c-hp4x5",
+				"other/collection-94c495554-z8s5k",
+				"other/nginx-77b4fdf86c-hp4x5",
+				"test/collection-94c495554-z8s5k",
+				"test/nginx-77b4fdf86c-hp4x5",
+			},
+		},
+		{
+			name: "Add roleBinding namespace 'other'",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+						{
+							RuleID: "R0002",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{
+				"other/collection-94c495554-z8s5k",
+				"other/nginx-77b4fdf86c-hp4x5",
+			},
+		},
+		{
+			name: "Add roleBinding exclude namespace 'other'",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+						{
+							RuleID: "R0002",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{
+				"default/collection-94c495554-z8s5k",
+				"default/nginx-77b4fdf86c-hp4x5",
+				"test/collection-94c495554-z8s5k",
+				"test/nginx-77b4fdf86c-hp4x5",
+			},
+		},
+		{
+			name: "Add roleBinding MatchLabels",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "collection",
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+						{
+							RuleID: "R0002",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{
+				"test/collection-94c495554-z8s5k",
+			},
+		},
+		{
+			name: "Namespace does not exists",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "bla",
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{},
+		},
+		{
+			name: "Invalid ns selector",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOperator("invalid"),
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+					},
+				},
+			},
+			invalidRB:            true,
+			expectedNotifiedPods: []string{},
+		},
+		{
+			name: "Invalid label selector",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rb1",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					PodSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOperator("invalid"),
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+					},
+				},
+			},
+			invalidRB:            true,
+			expectedNotifiedPods: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewCacheMock("")
+			c.k8sClient = k8sClient
+
+			notifyChan := make(chan rulebindingmanager.RuleBindingNotify)
+			received := []string{}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(len(tt.expectedNotifiedPods))
+
+			go func() {
+				for {
+					n := <-notifyChan
+					assert.Equal(t, n.Action, rulebindingmanager.Added)
+					received = append(received, n.Pod.GetNamespace()+"/"+n.Pod.GetName())
+					wg.Done()
+				}
+			}()
+
+			c.AddNotifier(&notifyChan)
+
+			c.addRuleBinding(tt.rb)
+
+			// wait for notified resources
+			wg.Wait()
+
+			// some resources should not be notify, so we wait to make sure they were not notified
+			time.Sleep(2 * time.Second)
+
+			slices.Sort(received)
+			slices.Sort(tt.expectedNotifiedPods)
+			assert.Equal(t, tt.expectedNotifiedPods, received)
+
+			rbName := rbUniqueName(tt.rb)
+
+			if tt.invalidRB {
+				assert.False(t, c.rbNameToPodNames.Has(rbName))
+				assert.False(t, c.rbNameToRB.Has(rbName))
+				assert.False(t, c.rbNameToRules.Has(rbName))
+				return
+			}
+
+			assert.True(t, c.rbNameToPodNames.Has(rbName))
+			assert.True(t, c.rbNameToRB.Has(rbName))
+			assert.True(t, c.rbNameToRules.Has(rbName))
+
+			for _, pod := range tt.expectedNotifiedPods {
+				assert.True(t, c.podToRBNames.Has(pod))
+				assert.True(t, c.podToRBNames.Get(pod).Contains(rbName))
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, tests


___

## **Description**
- Refactored `addRuleBinding` method to use a new implementation for creating notifiers, improving code readability and maintainability.
- Modified `deleteRuleBinding` to enhance consistency in handling pod deletions and adjusted logging level for notifier creation failures.
- Significantly expanded unit tests for the rule binding cache, covering new scenarios for adding and deleting rule bindings, including comprehensive checks for notifier functionality.
- Employed mock objects for Kubernetes API interactions in tests, enhancing test reliability and isolation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Refactor Rule Binding Cache Implementation and Logging</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Refactored <code>addRuleBinding</code> to use <code>NewRuleBindingNotifierImpl</code> instead of <br><code>RuleBindingNotifierImplWithK8s</code>.<br> <li> In <code>deleteRuleBinding</code>, moved <code>podToRBNames.Delete(podName)</code> inside the <br>condition checking for empty notifiers for consistency.<br> <li> Changed log level from <code>Error</code> to <code>Warning</code> when failing to create a <br>notifier in <code>deleteRuleBinding</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/236/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache_test.go</strong><dd><code>Extend Unit Tests for Rule Binding Cache Operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache_test.go
<li>Added new unit tests for <code>deleteRuleBinding</code> with various scenarios <br>including valid unique names, pods with multiple bindings, and <br>notification checks.<br> <li> Introduced tests for <code>addRuleBinding</code> covering scenarios like adding <br>rule bindings with namespace and pod selectors, handling invalid <br>selectors, and ensuring notifications are sent correctly.<br> <li> Utilized <code>k8sinterface.NewKubernetesApiMock</code> and other mock objects for <br>testing instead of the previous mock implementations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/236/files#diff-387cbffbe5655030d0bb5dff8e6b40070c87fc8aa5447a5f7762ec6016a41912">+511/-3</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

