### PR TITLE
Bugfix/rules

### DIFF
--- a/pkg/ruleengine/v1/factory.go
+++ b/pkg/ruleengine/v1/factory.go
@@ -13,7 +13,7 @@ func NewRuleCreator() *RuleCreatorImpl {
 		ruleDescriptions: []RuleDescriptor{
 			R0001UnexpectedProcessLaunchedRuleDescriptor,
 			R0002UnexpectedFileAccessRuleDescriptor,
-			// R0003UnexpectedSystemCallRuleDescriptor,
+			R0003UnexpectedSystemCallRuleDescriptor,
 			R0004UnexpectedCapabilityUsedRuleDescriptor,
 			R0005UnexpectedDomainRequestRuleDescriptor,
 			R0006UnexpectedServiceAccountTokenAccessRuleDescriptor,

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -71,7 +71,13 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 	// is memory mapped file
 
 	// The assumption here is that the event path is absolute!
-	execPath := filepath.Dir(getExecPathFromEvent(execEvent))
+	execPath := getExecPathFromEvent(execEvent)
+	if strings.HasPrefix(execPath, "./") || strings.HasPrefix(execPath, "../") {
+		execPath = filepath.Join(execEvent.Cwd, execPath)
+	} else if !strings.HasPrefix(execPath, "/") {
+		execPath = "/" + execPath
+	}
+	execPath = filepath.Dir(execPath)
 	for _, maliciousExecPathPrefix := range maliciousExecPathPrefixes {
 		// if the exec path or the current dir is from a malicious source
 		if strings.HasPrefix(execPath, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.Cwd, maliciousExecPathPrefix) {

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
@@ -42,10 +42,33 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 		t.Errorf("Expected ruleResult since exec is malicious")
 	}
 
+	e.Cwd = "/"
+
 	e.Comm = "/run.sh"
 
 	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
 	if ruleResult != nil {
 		t.Errorf("Expected ruleResult to be nil since exec is not malicious")
+	}
+
+	e.Comm = "./run.sh"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since exec is not malicious")
+	}
+
+	e.Comm = "/run/run.sh"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is malicious")
+	}
+
+	e.Comm = "./run/run.sh"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is malicious")
 	}
 }

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
@@ -79,4 +79,11 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 	if ruleResult == nil {
 		t.Errorf("Expected ruleResult since exec is malicious")
 	}
+
+	e.Comm = "./run.sh -al"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is malicious")
+	}
 }

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
@@ -71,4 +71,12 @@ func TestR1000ExecFromMaliciousSource(t *testing.T) {
 	if ruleResult == nil {
 		t.Errorf("Expected ruleResult since exec is malicious")
 	}
+
+	e.Cwd = "/run"
+	e.Comm = "./run.sh"
+
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &RuleObjectCacheMock{})
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult since exec is malicious")
+	}
 }

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -148,10 +148,10 @@ func (rm *RuleManager) monitorContainer(ctx context.Context, container *containe
 					WithMountNsID: eventtypes.WithMountNsID{
 						MountNsID: watchedContainer.NsMntId,
 					},
-					Pid: container.Pid,
-					// Uid:         container.OciConfig.Process.User.UID, TODO: Figure why OciConfig is nil.
-					// Gid:         container.OciConfig.Process.User.GID, TODO: Figure why OciConfig is nil.
-					// Comm:        container.OciConfig.Process.Args[0], TODO: Figure why OciConfig is nil.
+					Pid:         container.Pid,
+					Uid:         container.OciConfig.Process.User.UID,
+					Gid:         container.OciConfig.Process.User.GID,
+					Comm:        container.OciConfig.Process.Args[0],
 					SyscallName: syscall,
 				}
 


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix, tests, enhancement


___

## **Description**
- Enabled `R0003UnexpectedSystemCallRuleDescriptor` in the rule factory, enhancing rule coverage.
- Fixed executable path handling in malicious source detection to ensure paths are absolute, addressing potential false negatives.
- Added extensive tests for malicious source execution detection, improving reliability and coverage.
- Resolved an issue where `nil` OCI config resulted in missing process information in events, enhancing event detail accuracy.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>factory.go</strong><dd><code>Enable Unexpected System Call Rule Descriptor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/factory.go
<li>Enabled <code>R0003UnexpectedSystemCallRuleDescriptor</code> in the rule factory.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/237/files#diff-f871dffe7fa2bf85f011c358809241217e9f4bda1100e94e76ac799e47f51646">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source.go</strong><dd><code>Fix Executable Path Handling for Malicious Source Detection</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
<li>Fixed the handling of executable paths to always be absolute.<br> <li> Adjusted path resolution to handle relative paths correctly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/237/files#diff-00351ce4b75a85e267a68663f357265bbcc7721c2e461fa6112363fdfb2150c5">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Fix Nil OCI Config Issue in Event Population</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Fixed <code>nil</code> OCI config issue to correctly populate process information <br>in events.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/237/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source_test.go</strong><dd><code>Add Tests for Malicious Source Execution Detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source_test.go
<li>Added comprehensive tests for malicious source execution detection <br>with various path scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/237/files#diff-0335c2abb82667ee7c0f955f8a4f1ab795958d30e89dc3965de2d67c6b610b00">+38/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

