### PR TITLE
add support for NetworkNeighborhood generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/kubescape/backend v0.0.16
 	github.com/kubescape/go-logger v0.0.22
 	github.com/kubescape/k8s-interface v0.0.165
-	github.com/kubescape/storage v0.0.79
+	github.com/kubescape/storage v0.0.80-0.20240412125709-82a0123c5163
 	github.com/panjf2000/ants/v2 v2.9.0
 	github.com/prometheus/alertmanager v0.27.0
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/kubescape/go-logger v0.0.22 h1:gle7wH6emOiGv9ljdpVi82pWLQ3jGucrUucvil
 github.com/kubescape/go-logger v0.0.22/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
 github.com/kubescape/k8s-interface v0.0.165 h1:Tq1ZMnO6gI8gIrml6RSnt4XdlCJxRUJHNheAeh/i7xw=
 github.com/kubescape/k8s-interface v0.0.165/go.mod h1:oF+Yxug3Kpfu9Yr2j63wy7gwswrKXpiqI0mLk/7gF/s=
-github.com/kubescape/storage v0.0.79 h1:APvBd00/OYjNMvMgOhdiiIFSUzy/wUyLzb92xjcmuqw=
-github.com/kubescape/storage v0.0.79/go.mod h1:ttwWSuxDyckuB014uPHBs23zSdFZx6TMD0MZHlwuw+0=
+github.com/kubescape/storage v0.0.80-0.20240412125709-82a0123c5163 h1:tBXnnwsVNWdLcO56nDABOmg5ebdYwPnOzv4X8yrG8H8=
+github.com/kubescape/storage v0.0.80-0.20240412125709-82a0123c5163/go.mod h1:ttwWSuxDyckuB014uPHBs23zSdFZx6TMD0MZHlwuw+0=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=

--- a/main.go
+++ b/main.go
@@ -16,9 +16,11 @@ import (
 	"node-agent/pkg/filehandler/v1"
 	"node-agent/pkg/malwaremanager"
 	malwaremanagerv1 "node-agent/pkg/malwaremanager/v1"
-	metricsmanager "node-agent/pkg/metricsmanager"
+	"node-agent/pkg/metricsmanager"
 	metricprometheus "node-agent/pkg/metricsmanager/prometheus"
 	"node-agent/pkg/networkmanager"
+	networkmanagerv1 "node-agent/pkg/networkmanager/v1"
+	networkmanagerv2 "node-agent/pkg/networkmanager/v2"
 	"node-agent/pkg/objectcache"
 	"node-agent/pkg/objectcache/applicationprofilecache"
 	"node-agent/pkg/objectcache/k8scache"
@@ -202,19 +204,22 @@ func main() {
 	}
 
 	// Create the network and DNS managers
+	var networkManagerv1Client networkmanagerv1.NetworkManagerClient
 	var networkManagerClient networkmanager.NetworkManagerClient
 	var dnsManagerClient dnsmanager.DNSManagerClient
 	if cfg.EnableNetworkTracing {
 		dnsManager := dnsmanager.CreateDNSManager()
 		dnsManagerClient = dnsManager
-		networkManagerClient = networkmanager.CreateNetworkManager(ctx, cfg, k8sClient, storageClient, clusterData.ClusterName, dnsManager, preRunningContainersIDs, k8sObjectCache)
+		networkManagerv1Client = networkmanagerv1.CreateNetworkManager(ctx, cfg, k8sClient, storageClient, clusterData.ClusterName, dnsManager, preRunningContainersIDs, k8sObjectCache)
+		networkManagerClient = networkmanagerv2.CreateNetworkManager(ctx, cfg, clusterData.ClusterName, k8sClient, storageClient, dnsManager, preRunningContainersIDs, k8sObjectCache)
 	} else {
+		networkManagerv1Client = networkmanagerv1.CreateNetworkManagerMock()
 		networkManagerClient = networkmanager.CreateNetworkManagerMock()
 		dnsManagerClient = dnsmanager.CreateDNSManagerMock()
 	}
 
 	// Create the container handler
-	mainHandler, err := containerwatcher.CreateIGContainerWatcher(cfg, applicationProfileManager, k8sClient, relevancyManager, networkManagerClient, dnsManagerClient, prometheusExporter, ruleManager, malwareManager, preRunningContainersIDs, &ruleBindingNotify)
+	mainHandler, err := containerwatcher.CreateIGContainerWatcher(cfg, applicationProfileManager, k8sClient, relevancyManager, networkManagerv1Client, networkManagerClient, dnsManagerClient, prometheusExporter, ruleManager, malwareManager, preRunningContainersIDs, &ruleBindingNotify)
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal("error creating the container watcher", helpers.Error(err))
 	}

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -52,6 +52,7 @@ func (ch *IGContainerWatcher) startContainerCollection(ctx context.Context) erro
 		ch.containerCallback,
 		ch.applicationProfileManager.ContainerCallback,
 		ch.relevancyManager.ContainerCallback,
+		ch.networkManagerv1.ContainerCallback,
 		ch.networkManager.ContainerCallback,
 		ch.malwareManager.ContainerCallback,
 		ch.ruleManager.ContainerCallback,

--- a/pkg/containerwatcher/v1/open_test.go
+++ b/pkg/containerwatcher/v1/open_test.go
@@ -22,7 +22,7 @@ func BenchmarkIGContainerWatcher_openEventCallback(b *testing.B) {
 	assert.NoError(b, err)
 	mockExporter := metricsmanager.NewMetricsMock()
 
-	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, mockExporter, nil, nil, nil, nil)
+	mainHandler, err := CreateIGContainerWatcher(cfg, nil, nil, relevancyManager, nil, nil, nil, mockExporter, nil, nil, nil, nil)
 	assert.NoError(b, err)
 	event := &traceropentype.Event{
 		Event: types.Event{

--- a/pkg/networkmanager/network_event.go
+++ b/pkg/networkmanager/network_event.go
@@ -24,11 +24,18 @@ type Destination struct {
 
 type EndpointKind string
 
-var defaultLabelsToIgnore = map[string]struct{}{
+var DefaultLabelsToIgnore = map[string]struct{}{
 	"controller-revision-hash": {},
 	"pod-template-generation":  {},
 	"pod-template-hash":        {},
 }
+
+const (
+	InternalTrafficType = "internal"
+	ExternalTrafficType = "external"
+	HostPktType         = "HOST"
+	OutgoingPktType     = "OUTGOING"
+)
 
 const (
 	EndpointKindPod     EndpointKind = "pod"
@@ -86,4 +93,12 @@ func generatePodLabels(podLabels map[string]string) string {
 	}
 
 	return podLabelsString
+}
+
+func GeneratePortIdentifierFromEvent(networkEvent NetworkEvent) string {
+	return GeneratePortIdentifier(networkEvent.Protocol, int32(networkEvent.Port))
+}
+
+func GeneratePortIdentifier(protocol string, port int32) string {
+	return fmt.Sprintf("%s-%d", protocol, port)
 }

--- a/pkg/networkmanager/network_neighbors.go
+++ b/pkg/networkmanager/network_neighbors.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func generateNetworkNeighborsCRD(parentWorkload k8sinterface.IWorkload, parentWorkloadSelector *metav1.LabelSelector, clusterName string) *v1beta1.NetworkNeighbors {
+func GenerateNetworkNeighborsCRD(parentWorkload k8sinterface.IWorkload, parentWorkloadSelector *metav1.LabelSelector, clusterName string) *v1beta1.NetworkNeighbors {
 	if parentWorkloadSelector.MatchLabels == nil && parentWorkloadSelector.MatchExpressions == nil {
 		parentWorkloadSelector.MatchLabels = parentWorkload.GetLabels()
 	}
@@ -44,7 +44,7 @@ func generateNetworkNeighborsNameFromWorkload(workload k8sinterface.IWorkload) s
 	return fmt.Sprintf("%s-%s", strings.ToLower(workload.GetKind()), workload.GetName())
 }
 
-func generateNetworkNeighborsNameFromWlid(parentWlid string) string {
+func GenerateNetworkNeighborsNameFromWlid(parentWlid string) string {
 	return fmt.Sprintf("%s-%s", strings.ToLower(wlid.GetKindFromWlid(parentWlid)), wlid.GetNameFromWlid(parentWlid))
 }
 
@@ -68,12 +68,12 @@ func generateNetworkNeighborsLabels(workload k8sinterface.IWorkload) map[string]
 	}
 }
 
-// filterLabels filters out labels that are not relevant for the network neighbor
-func filterLabels(labels map[string]string) map[string]string {
+// FilterLabels filters out labels that are not relevant for the network neighbor
+func FilterLabels(labels map[string]string) map[string]string {
 	filteredLabels := make(map[string]string)
 
 	for i := range labels {
-		if _, ok := defaultLabelsToIgnore[i]; ok {
+		if _, ok := DefaultLabelsToIgnore[i]; ok {
 			continue
 		}
 		filteredLabels[i] = labels[i]

--- a/pkg/networkmanager/network_neighbors_test.go
+++ b/pkg/networkmanager/network_neighbors_test.go
@@ -1,6 +1,7 @@
 package networkmanager
 
 import (
+	"node-agent/pkg/networkmanager/testdata"
 	"testing"
 
 	_ "embed"
@@ -12,18 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//go:embed testdata/cronjob.json
-var cronjobJson []byte
-
-//go:embed testdata/deployment.json
-var deploymentJson []byte
-
-//go:embed testdata/daemonset.json
-var daemonsetJson []byte
-
-//go:embed testdata/pod.json
-var podJson []byte
-
 func TestGenerateNetworkNeighborsCRD(t *testing.T) {
 	tests := []struct {
 		name                     string
@@ -33,7 +22,7 @@ func TestGenerateNetworkNeighborsCRD(t *testing.T) {
 	}{
 		{
 			name:           "deployment",
-			parentWorkload: deploymentJson,
+			parentWorkload: testdata.DeploymentJson,
 			parentWorkloadLabels: map[string]string{
 				"app": "nginx",
 			},
@@ -69,7 +58,7 @@ func TestGenerateNetworkNeighborsCRD(t *testing.T) {
 		},
 		{
 			name:           "daemonset",
-			parentWorkload: daemonsetJson,
+			parentWorkload: testdata.DaemonsetJson,
 			parentWorkloadLabels: map[string]string{
 				"match": "fluentd-elasticsearch",
 			},
@@ -105,7 +94,7 @@ func TestGenerateNetworkNeighborsCRD(t *testing.T) {
 		},
 		{
 			name:           "pod",
-			parentWorkload: podJson,
+			parentWorkload: testdata.PodJson,
 			parentWorkloadLabels: map[string]string{
 				"match": "test",
 			},
@@ -149,7 +138,7 @@ func TestGenerateNetworkNeighborsCRD(t *testing.T) {
 			selector, err := wl.GetSelector()
 			assert.Nil(t, err)
 
-			actualNetworkNeighbors := generateNetworkNeighborsCRD(wl, selector, "minikube")
+			actualNetworkNeighbors := GenerateNetworkNeighborsCRD(wl, selector, "minikube")
 			assert.Equal(t, test.expectedNetworkNeighbors, actualNetworkNeighbors)
 		})
 	}
@@ -163,17 +152,17 @@ func TestGenerateNetworkNeighborsNameFromWorkload(t *testing.T) {
 	}{
 		{
 			name:         "deployment",
-			workload:     deploymentJson,
+			workload:     testdata.DeploymentJson,
 			expectedName: "deployment-nginx-deployment",
 		},
 		{
 			name:         "daemonset",
-			workload:     daemonsetJson,
+			workload:     testdata.DaemonsetJson,
 			expectedName: "daemonset-fluentd-elasticsearch",
 		},
 		{
 			name:         "pod",
-			workload:     podJson,
+			workload:     testdata.PodJson,
 			expectedName: "pod-nginx-deployment-fcc867f7-dgjrg",
 		},
 	}
@@ -216,7 +205,7 @@ func TestGenerateNetworkNeighborsNameFromWlid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualName := generateNetworkNeighborsNameFromWlid(test.parentWlid)
+			actualName := GenerateNetworkNeighborsNameFromWlid(test.parentWlid)
 			if actualName != test.expectedName {
 				t.Errorf("expected name %s, got %s", test.expectedName, actualName)
 			}
@@ -232,7 +221,7 @@ func TestGenerateNetworkNeighborsLabels(t *testing.T) {
 	}{
 		{
 			name:     "deployment",
-			workload: deploymentJson,
+			workload: testdata.DeploymentJson,
 			expectedLabels: map[string]string{
 				"kubescape.io/workload-api-group":        "apps",
 				"kubescape.io/workload-api-version":      "v1",
@@ -245,7 +234,7 @@ func TestGenerateNetworkNeighborsLabels(t *testing.T) {
 
 		{
 			name:     "daemonset",
-			workload: daemonsetJson,
+			workload: testdata.DaemonsetJson,
 			expectedLabels: map[string]string{
 				"kubescape.io/workload-api-group":        "apps",
 				"kubescape.io/workload-api-version":      "v1",
@@ -258,7 +247,7 @@ func TestGenerateNetworkNeighborsLabels(t *testing.T) {
 
 		{
 			name:     "pod",
-			workload: podJson,
+			workload: testdata.PodJson,
 			expectedLabels: map[string]string{
 				"kubescape.io/workload-api-group":        "",
 				"kubescape.io/workload-api-version":      "v1",
@@ -349,7 +338,7 @@ func TestFilterLabels(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualLabels := filterLabels(test.labels)
+			actualLabels := FilterLabels(test.labels)
 			if len(actualLabels) != len(test.expectedLabels) {
 				t.Errorf("expected %d labels, got %d", len(test.expectedLabels), len(actualLabels))
 			}

--- a/pkg/networkmanager/testdata/testdata.go
+++ b/pkg/networkmanager/testdata/testdata.go
@@ -1,0 +1,15 @@
+package testdata
+
+import _ "embed"
+
+//go:embed cronjob.json
+var CronjobJson []byte
+
+//go:embed deployment.json
+var DeploymentJson []byte
+
+//go:embed daemonset.json
+var DaemonsetJson []byte
+
+//go:embed pod.json
+var PodJson []byte

--- a/pkg/networkmanager/v1/network_manager_interface.go
+++ b/pkg/networkmanager/v1/network_manager_interface.go
@@ -1,4 +1,4 @@
-package networkmanager
+package v1
 
 import (
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
@@ -7,6 +7,6 @@ import (
 
 type NetworkManagerClient interface {
 	ContainerCallback(notif containercollection.PubSubEvent)
-	ReportNetworkEvent(k8sContainerID string, event tracernetworktype.Event)
-	ReportDroppedEvent(k8sContainerID string)
+	ReportNetworkEvent(containerID string, event tracernetworktype.Event)
+	ReportDroppedEvent(containerID string, event tracernetworktype.Event)
 }

--- a/pkg/networkmanager/v1/network_manager_mock.go
+++ b/pkg/networkmanager/v1/network_manager_mock.go
@@ -1,4 +1,4 @@
-package networkmanager
+package v1
 
 import (
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
@@ -22,6 +22,6 @@ func (am *NetworkManagerMock) ReportNetworkEvent(_ string, _ tracernetworktype.E
 	// noop
 }
 
-func (am *NetworkManagerMock) ReportDroppedEvent(_ string) {
+func (am *NetworkManagerMock) ReportDroppedEvent(_ string, _ tracernetworktype.Event) {
 	// noop
 }

--- a/pkg/networkmanager/v2/network_manager_test.go
+++ b/pkg/networkmanager/v2/network_manager_test.go
@@ -1,0 +1,346 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	mapset "github.com/deckarep/golang-set/v2"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	tracernetworktype "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/network/types"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"node-agent/pkg/config"
+	"node-agent/pkg/dnsmanager"
+	"node-agent/pkg/k8sclient"
+	"node-agent/pkg/networkmanager"
+	"node-agent/pkg/objectcache"
+	"node-agent/pkg/storage"
+	"testing"
+	"time"
+)
+
+func TestCreateNetworkManager(t *testing.T) {
+	cfg := config.Config{
+		InitialDelay:     1 * time.Second,
+		MaxSniffingTime:  5 * time.Minute,
+		UpdateDataPeriod: 1 * time.Second,
+	}
+	ctx := context.TODO()
+	k8sClient := &k8sclient.K8sClientMock{}
+	storageClient := &storage.StorageHttpClientMock{}
+	dnsManager := &dnsmanager.DNSManagerMock{}
+	k8sObjectCacheMock := &objectcache.K8sObjectCacheMock{}
+	am := CreateNetworkManager(ctx, cfg, "cluster", k8sClient, storageClient, dnsManager, mapset.NewSet[string](), k8sObjectCacheMock)
+	// prepare container
+	container := &containercollection.Container{
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: types.BasicK8sMetadata{
+				Namespace:     "ns",
+				PodName:       "pod",
+				ContainerName: "cont",
+			},
+		},
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+				ContainerID: "5fff6a395ce4e6984a9447cc6cfb09f473eaf278498243963fcc944889bc8400",
+			},
+		},
+	}
+	// report network event
+	go am.ReportNetworkEvent("ns/pod/cont", tracernetworktype.Event{
+		Port:      80,
+		PktType:   "HOST",
+		Proto:     "TCP",
+		PodLabels: map[string]string{"app": "nginx"},
+		DstEndpoint: types.L3Endpoint{
+			Namespace: "kubescape",
+			Name:      "nginx-deployment-cbdccf466-csh9c",
+			Kind:      "pod",
+			Addr:      "1.2.3.4",
+			PodLabels: map[string]string{"app": "destination", "controller-revision-hash": "hash"},
+		},
+	})
+	// report container started (race condition with reports)
+	am.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+	// let it run for a while
+	time.Sleep(15 * time.Second)
+	// more events
+	go am.ReportNetworkEvent("ns/pod/cont", tracernetworktype.Event{
+		Port:      443,
+		PktType:   "OUTGOING",
+		Proto:     "TCP",
+		PodLabels: map[string]string{"app": "nginx"},
+		DstEndpoint: types.L3Endpoint{
+			Namespace: "kubescape",
+			Name:      "nginx-deployment-cbdccf466-csh9c",
+			Kind:      "pod",
+			Addr:      "1.2.3.4",
+			PodLabels: map[string]string{"app": "destination", "controller-revision-hash": "hash"},
+		},
+	})
+	// sleep more
+	time.Sleep(2 * time.Second)
+	// report container stopped
+	am.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+	// let it stop
+	time.Sleep(2 * time.Second)
+	// verify generated CRDs
+	assert.Equal(t, 2, len(storageClient.NetworkNeighborhoods))
+	// check the first neighborhood
+	assert.Equal(t, v1beta1.NetworkNeighbor{
+		Identifier:        "c86024d63c2bfddde96a258c3005e963e06fb9d8ee941a6de3003d6eae5dd7cc",
+		Type:              "internal",
+		Ports:             []v1beta1.NetworkPort{{Name: "TCP-80", Protocol: "TCP", Port: ptr.To(int32(80))}},
+		PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "destination"}},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kubescape"}},
+	}, storageClient.NetworkNeighborhoods[0].Spec.Containers[1].Ingress[0])
+	assert.Equal(t, 0, len(storageClient.NetworkNeighborhoods[0].Spec.Containers[1].Egress))
+	// check the second neighborhood - this is a patch for execs and opens
+	assert.Equal(t, v1beta1.NetworkNeighbor{
+		Identifier:        "c86024d63c2bfddde96a258c3005e963e06fb9d8ee941a6de3003d6eae5dd7cc",
+		Type:              "internal",
+		Ports:             []v1beta1.NetworkPort{{Name: "TCP-80", Protocol: "TCP", Port: ptr.To(int32(80))}},
+		PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "destination"}},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kubescape"}},
+	}, storageClient.NetworkNeighborhoods[1].Spec.Containers[1].Ingress[0])
+	assert.Equal(t, v1beta1.NetworkNeighbor{
+		Identifier:        "c86024d63c2bfddde96a258c3005e963e06fb9d8ee941a6de3003d6eae5dd7cc",
+		Type:              "internal",
+		Ports:             []v1beta1.NetworkPort{{Name: "TCP-443", Protocol: "TCP", Port: ptr.To(int32(443))}},
+		PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "destination"}},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kubescape"}},
+	}, storageClient.NetworkNeighborhoods[1].Spec.Containers[1].Egress[0])
+}
+
+func TestIsValidEvent(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    tracernetworktype.Event
+		expected bool
+	}{
+		{
+			name: "invalid pkt type",
+			event: tracernetworktype.Event{
+				PktType: "INVALID",
+			},
+			expected: false,
+		},
+		{
+			name: "pkt to itself",
+			event: tracernetworktype.Event{
+				PktType:   "HOST",
+				PodHostIP: "1.2.3.4",
+				DstEndpoint: types.L3Endpoint{
+					Addr: "1.2.3.4",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "host network",
+			event: tracernetworktype.Event{
+				Event: types.Event{
+					CommonData: types.CommonData{
+						K8s: types.K8sMetadata{
+							HostNetwork: true,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "localhost IP",
+			event: tracernetworktype.Event{
+				DstEndpoint: types.L3Endpoint{
+					Addr: "169.254.169.254",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "valid event",
+			event: tracernetworktype.Event{
+				Port:      80,
+				PktType:   "HOST",
+				Proto:     "tcp",
+				PodLabels: map[string]string{"app": "nginx"},
+				DstEndpoint: types.L3Endpoint{
+					Namespace: "default",
+					Name:      "nginx-deployment-cbdccf466-csh9c",
+					Kind:      "pod",
+					PodLabels: map[string]string{"app": "nginx2"},
+					Addr:      "19.64.52.5",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	am := &NetworkManager{}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("Input: %s", tc.name), func(t *testing.T) {
+			result := am.isValidEvent(tc.event)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+type dnsResolverMock struct{}
+
+func (d *dnsResolverMock) ResolveIPAddress(ipAddr string) (string, bool) {
+	if ipAddr == "1.2.3.4" {
+		return "domain.com", true
+	}
+	return "", false
+}
+
+func TestNetworkManager_createNetworkNeighbor(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		networkEvent networkmanager.NetworkEvent
+		want         *v1beta1.NetworkNeighbor
+	}{
+		{
+			name:      "empty",
+			namespace: "default",
+			want: &v1beta1.NetworkNeighbor{
+				Type:       "external",
+				Ports:      []v1beta1.NetworkPort{{Name: "-0", Protocol: "", Port: ptr.To(int32(0))}},
+				Identifier: "1db1cf596388ac2f0d5eecbe6bcc9b57199beaa7d87e53a049ae18744dd62045",
+			},
+		},
+		{
+			name:      "pod from same namespace egress - should not have namespace selector",
+			namespace: "kubescape",
+			networkEvent: networkmanager.NetworkEvent{
+				Port:      80,
+				PktType:   "OUTGOING",
+				Protocol:  "TCP",
+				PodLabels: "app=nginx",
+				Destination: networkmanager.Destination{
+					Namespace: "kubescape",
+					Name:      "nginx-deployment-cbdccf466-csh9c",
+					Kind:      networkmanager.EndpointKindPod,
+					PodLabels: "app=destination,controller-revision-hash=hash",
+					IPAddress: "",
+				},
+			},
+			want: &v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "",
+				Ports:             []v1beta1.NetworkPort{{Name: "TCP-80", Protocol: "TCP", Port: ptr.To(int32(80))}},
+				PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "destination"}},
+				NamespaceSelector: nil,
+				IPAddress:         "",
+				Identifier:        "0d13d659ca4ba62f02f78781a15e1bfb4f88b29761d06c1b90cfa8834d9845c7",
+			},
+		},
+		{
+			name:      "pod from another namespace - should have namespace selector",
+			namespace: "default",
+			networkEvent: networkmanager.NetworkEvent{
+				Port:      80,
+				PktType:   "OUTGOING",
+				Protocol:  "TCP",
+				PodLabels: "app=nginx",
+				Destination: networkmanager.Destination{
+					Namespace: "kubescape",
+					Name:      "nginx-deployment-cbdccf466-csh9c",
+					Kind:      networkmanager.EndpointKindPod,
+					PodLabels: "app=destination,pod-template-hash=test",
+					IPAddress: "",
+				},
+			},
+			want: &v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "",
+				Ports:             []v1beta1.NetworkPort{{Name: "TCP-80", Protocol: "TCP", Port: ptr.To(int32(80))}},
+				PodSelector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "destination"}},
+				NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kubescape"}},
+				IPAddress:         "",
+				Identifier:        "c86024d63c2bfddde96a258c3005e963e06fb9d8ee941a6de3003d6eae5dd7cc",
+			},
+		},
+		{
+			name:      "raw IP",
+			namespace: "default",
+			networkEvent: networkmanager.NetworkEvent{
+				Port:     80,
+				PktType:  "OUTGOING",
+				Protocol: "UDP",
+				Destination: networkmanager.Destination{
+					Kind:      networkmanager.EndpointKindRaw,
+					IPAddress: "143.54.53.21",
+				},
+			},
+			want: &v1beta1.NetworkNeighbor{
+				Type:       "external",
+				DNS:        "",
+				Ports:      []v1beta1.NetworkPort{{Name: "UDP-80", Protocol: "UDP", Port: ptr.To(int32(80))}},
+				IPAddress:  "143.54.53.21",
+				Identifier: "3bbd32606a8516f97e7e3c11b0e914744c56cd6b8a2cadf010dd5fc648285535",
+			},
+		},
+		{
+			name:      "raw IP localhost - should be ignored",
+			namespace: "default",
+			networkEvent: networkmanager.NetworkEvent{
+				Port:     80,
+				PktType:  "OUTGOING",
+				Protocol: "TCP",
+				Destination: networkmanager.Destination{
+					Kind:      networkmanager.EndpointKindRaw,
+					IPAddress: "127.0.0.1",
+				},
+			},
+			want: nil,
+		},
+		{
+			name:      "IP is resolved - DNS is enriched",
+			namespace: "kubescape",
+			networkEvent: networkmanager.NetworkEvent{
+				Port:     1,
+				PktType:  "HOST",
+				Protocol: "TCP",
+				Destination: networkmanager.Destination{
+					Kind:      networkmanager.EndpointKindRaw,
+					IPAddress: "1.2.3.4",
+				},
+			},
+			want: &v1beta1.NetworkNeighbor{
+				Type:     "external",
+				DNS:      "domain.com",
+				DNSNames: []string{"domain.com"},
+				Ports: []v1beta1.NetworkPort{
+					{
+						Name:     "TCP-1",
+						Protocol: "TCP",
+						Port:     ptr.To(int32(1)),
+					},
+				},
+				IPAddress:  "1.2.3.4",
+				Identifier: "12f9a2d88f8ca830047d7b6324e9ded773a803e42b50a01a36009fc447fc6fb0",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			am := &NetworkManager{
+				dnsResolverClient: &dnsResolverMock{},
+			}
+			got := am.createNetworkNeighbor(tt.networkEvent, tt.namespace)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -199,7 +199,6 @@ func (rm *RuleManager) ensureInstanceID(container *containercollection.Container
 		watchedContainer.SetContainerInfo(pod, container.K8s.ContainerName)
 	}
 
-	// FIXME ephemeralContainers are not supported yet
 	return nil
 }
 

--- a/pkg/storage/applicationprofile.go
+++ b/pkg/storage/applicationprofile.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/evanphx/json-patch"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (sc *StorageHttpClientMock) GetApplicationProfile(_, _ string) (*v1beta1.ApplicationProfile, error) {
+	if len(sc.ApplicationProfiles) == 0 {
+		return &v1beta1.ApplicationProfile{
+			Spec: v1beta1.ApplicationProfileSpec{
+				Containers: []v1beta1.ApplicationProfileContainer{
+					{Capabilities: []string{"SYS_ADMIN"}},
+					{Capabilities: []string{"NET_BROADCAST"}},
+				},
+			},
+		}, nil
+	}
+	return sc.ApplicationProfiles[len(sc.ApplicationProfiles)-1], nil
+}
+
+func (sc *StorageHttpClientMock) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, _ string) error {
+	if !sc.failedOnce {
+		sc.failedOnce = true
+		return errors.New("first time fail")
+	}
+	sc.ApplicationProfiles = append(sc.ApplicationProfiles, profile)
+	return nil
+}
+
+func (sc *StorageHttpClientMock) PatchApplicationProfile(name, _ string, patchJSON []byte, _ chan error) error {
+	if len(sc.ApplicationProfiles) == 0 {
+		return errors2.NewNotFound(v1beta1.Resource("applicationprofile"), name)
+	}
+	// get last profile
+	lastProfile, err := json.Marshal(sc.ApplicationProfiles[len(sc.ApplicationProfiles)-1])
+	if err != nil {
+		return fmt.Errorf("marshal last profile: %w", err)
+	}
+	patch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return fmt.Errorf("decode patch: %w", err)
+	}
+	patchedProfile, err := patch.Apply(lastProfile)
+	if err != nil {
+		return fmt.Errorf("apply patch: %w", err)
+	}
+	profile := &v1beta1.ApplicationProfile{}
+	if err := json.Unmarshal(patchedProfile, profile); err != nil {
+		return fmt.Errorf("unmarshal patched profile: %w", err)
+	}
+	sc.ApplicationProfiles = append(sc.ApplicationProfiles, profile)
+	return nil
+}

--- a/pkg/storage/network.go
+++ b/pkg/storage/network.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/evanphx/json-patch"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	errors2 "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (sc *StorageHttpClientMock) GetNetworkNeighborhood(_, _ string) (*v1beta1.NetworkNeighborhood, error) {
+	if len(sc.NetworkNeighborhoods) == 0 {
+		return &v1beta1.NetworkNeighborhood{
+			Spec: v1beta1.NetworkNeighborhoodSpec{
+				Containers: []v1beta1.NetworkNeighborhoodContainer{
+					// FIXME add stuff
+				},
+			},
+		}, nil
+	}
+	return sc.NetworkNeighborhoods[len(sc.NetworkNeighborhoods)-1], nil
+}
+
+func (sc *StorageHttpClientMock) CreateNetworkNeighborhood(neighborhood *v1beta1.NetworkNeighborhood, _ string) error {
+	if !sc.failedOnce {
+		sc.failedOnce = true
+		return errors.New("first time fail")
+	}
+	for i := range neighborhood.Spec.Containers {
+		if neighborhood.Spec.Containers[i].Ingress == nil {
+			neighborhood.Spec.Containers[i].Ingress = []v1beta1.NetworkNeighbor{}
+		}
+		if neighborhood.Spec.Containers[i].Egress == nil {
+			neighborhood.Spec.Containers[i].Egress = []v1beta1.NetworkNeighbor{}
+		}
+	}
+	sc.NetworkNeighborhoods = append(sc.NetworkNeighborhoods, neighborhood)
+	return nil
+}
+
+func (sc *StorageHttpClientMock) PatchNetworkNeighborhood(name, _ string, patchJSON []byte, _ chan error) error {
+	if len(sc.NetworkNeighborhoods) == 0 {
+		return errors2.NewNotFound(v1beta1.Resource("networkneighborhood"), name)
+	}
+	// get last neighborhood
+	lastNeighborhood, err := json.Marshal(sc.NetworkNeighborhoods[len(sc.NetworkNeighborhoods)-1])
+	if err != nil {
+		return fmt.Errorf("marshal last neighborhood: %w", err)
+	}
+	patch, err := jsonpatch.DecodePatch(patchJSON)
+	if err != nil {
+		return fmt.Errorf("decode patch: %w", err)
+	}
+	patchedNeighborhood, err := patch.Apply(lastNeighborhood)
+	if err != nil {
+		return fmt.Errorf("apply patch: %w", err)
+	}
+	neighborhood := &v1beta1.NetworkNeighborhood{}
+	if err := json.Unmarshal(patchedNeighborhood, neighborhood); err != nil {
+		return fmt.Errorf("unmarshal patched neighborhood: %w", err)
+	}
+	sc.NetworkNeighborhoods = append(sc.NetworkNeighborhoods, neighborhood)
+	return nil
+}

--- a/pkg/storage/storage_interface.go
+++ b/pkg/storage/storage_interface.go
@@ -19,4 +19,7 @@ type StorageClient interface {
 	CreateNetworkNeighbors(networkNeighbors *v1beta1.NetworkNeighbors, namespace string) error
 	PatchNetworkNeighborsMatchLabels(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error
 	PatchNetworkNeighborsIngressAndEgress(name, namespace string, networkNeighbors *v1beta1.NetworkNeighbors) error
+	GetNetworkNeighborhood(namespace, name string) (*v1beta1.NetworkNeighborhood, error)
+	CreateNetworkNeighborhood(neighborhood *v1beta1.NetworkNeighborhood, namespace string) error
+	PatchNetworkNeighborhood(name, namespace string, patch []byte, channel chan error) error
 }

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -3,14 +3,10 @@ package storage
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"node-agent/pkg/utils"
 	"os"
 	"path"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
@@ -25,6 +21,7 @@ type StorageHttpClientMock struct {
 	ApplicationActivities []*spdxv1beta1.ApplicationActivity
 	ApplicationProfiles   []*spdxv1beta1.ApplicationProfile
 	FilteredSyftSBOMs     []*spdxv1beta1.SBOMSyftFiltered
+	NetworkNeighborhoods  []*v1beta1.NetworkNeighborhood
 	NetworkNeighborses    []*v1beta1.NetworkNeighbors
 	ImageCounters         map[string]int
 	nginxSBOMSpdxBytes    *spdxv1beta1.SBOMSPDXv2p3
@@ -38,20 +35,6 @@ func (sc *StorageHttpClientMock) GetApplicationActivity(_, _ string) (*spdxv1bet
 			Syscalls: []string{"open"},
 		},
 	}, nil
-}
-
-func (sc *StorageHttpClientMock) GetApplicationProfile(_, _ string) (*spdxv1beta1.ApplicationProfile, error) {
-	if len(sc.ApplicationProfiles) == 0 {
-		return &spdxv1beta1.ApplicationProfile{
-			Spec: spdxv1beta1.ApplicationProfileSpec{
-				Containers: []spdxv1beta1.ApplicationProfileContainer{
-					{Capabilities: []string{"SYS_ADMIN"}},
-					{Capabilities: []string{"NET_BROADCAST"}},
-				},
-			},
-		}, nil
-	}
-	return sc.ApplicationProfiles[len(sc.ApplicationProfiles)-1], nil
 }
 
 var _ StorageClient = (*StorageHttpClientMock)(nil)
@@ -86,40 +69,6 @@ func (sc *StorageHttpClientMock) CreateApplicationActivity(activity *spdxv1beta1
 	return nil
 }
 
-func (sc *StorageHttpClientMock) CreateApplicationProfile(profile *spdxv1beta1.ApplicationProfile, _ string) error {
-	if !sc.failedOnce {
-		sc.failedOnce = true
-		return errors.New("first time fail")
-	}
-	sc.ApplicationProfiles = append(sc.ApplicationProfiles, profile)
-	return nil
-}
-
-func (sc *StorageHttpClientMock) PatchApplicationProfile(name, _ string, patchJSON []byte, _ chan error) error {
-	if len(sc.ApplicationProfiles) == 0 {
-		return apierrors.NewNotFound(v1beta1.Resource("applicationprofile"), name)
-	}
-	// get last profile
-	lastProfile, err := json.Marshal(sc.ApplicationProfiles[len(sc.ApplicationProfiles)-1])
-	if err != nil {
-		return fmt.Errorf("marshal last profile: %w", err)
-	}
-	patch, err := jsonpatch.DecodePatch(patchJSON)
-	if err != nil {
-		return fmt.Errorf("decode patch: %w", err)
-	}
-	patchedProfile, err := patch.Apply(lastProfile)
-	if err != nil {
-		return fmt.Errorf("apply patch: %w", err)
-	}
-	profile := &spdxv1beta1.ApplicationProfile{}
-	if err := json.Unmarshal(patchedProfile, profile); err != nil {
-		return fmt.Errorf("unmarshal patched profile: %w", err)
-	}
-	sc.ApplicationProfiles = append(sc.ApplicationProfiles, profile)
-	return nil
-}
-
 func (sc *StorageHttpClientMock) CreateNetworkNeighbors(networkNeighbors *v1beta1.NetworkNeighbors, _ string) error {
 	sc.NetworkNeighborses = append(sc.NetworkNeighborses, networkNeighbors)
 	return nil
@@ -138,6 +87,7 @@ func (sc *StorageHttpClientMock) GetFilteredSBOM(name string) (*v1beta1.SBOMSyft
 	}
 	return nil, errors.New("not found")
 }
+
 func (sc *StorageHttpClientMock) GetSBOM(_ string) (*v1beta1.SBOMSyft, error) {
 	return sc.mockSBOM, nil
 }

--- a/pkg/storage/v1/applicationprofile.go
+++ b/pkg/storage/v1/applicationprofile.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"node-agent/pkg/utils"
+	"strconv"
+)
+
+func (sc Storage) GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error) {
+	return sc.StorageClient.ApplicationProfiles(namespace).Get(context.Background(), name, v1.GetOptions{})
+}
+
+func (sc Storage) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error {
+	// unset resourceVersion
+	profile.ResourceVersion = ""
+	_, err := sc.StorageClient.ApplicationProfiles(namespace).Create(context.Background(), profile, v1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc Storage) PatchApplicationProfile(name, namespace string, patch []byte, channel chan error) error {
+	profile, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, patch, v1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patch application profile: %w", err)
+	}
+	// check if returned profile is full
+	if s, ok := profile.Annotations[helpers.StatusMetadataKey]; ok {
+		if s == helpers.TooLarge {
+			if channel != nil {
+				channel <- utils.TooLargeObjectError
+			}
+		}
+		return nil
+	}
+	// check if returned profile is too big
+	if s, ok := profile.Annotations[helpers.ResourceSizeMetadataKey]; ok {
+		size, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("parse size: %w", err)
+		}
+		if size > sc.maxApplicationProfileSize {
+			// add annotation to indicate that the profile is full
+			annotationOperations := []utils.PatchOperation{
+				{
+					Op:    "replace",
+					Path:  "/metadata/annotations/" + utils.EscapeJSONPointerElement(helpers.StatusMetadataKey),
+					Value: helpers.TooLarge,
+				},
+			}
+			annotationsPatch, err := json.Marshal(annotationOperations)
+			if err != nil {
+				return fmt.Errorf("create patch for annotations: %w", err)
+			}
+			_, err = sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, annotationsPatch, v1.PatchOptions{})
+			if err != nil {
+				return fmt.Errorf("patch application profile annotations: %w", err)
+			}
+			if channel != nil {
+				channel <- utils.TooLargeObjectError
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/storage/v1/network.go
+++ b/pkg/storage/v1/network.go
@@ -1,0 +1,72 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"node-agent/pkg/utils"
+	"strconv"
+)
+
+func (sc Storage) GetNetworkNeighborhood(namespace, name string) (*v1beta1.NetworkNeighborhood, error) {
+	return sc.StorageClient.NetworkNeighborhoods(namespace).Get(context.Background(), name, v1.GetOptions{})
+}
+
+func (sc Storage) CreateNetworkNeighborhood(neighborhood *v1beta1.NetworkNeighborhood, namespace string) error {
+	// unset resourceVersion
+	neighborhood.ResourceVersion = ""
+	_, err := sc.StorageClient.NetworkNeighborhoods(namespace).Create(context.Background(), neighborhood, v1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc Storage) PatchNetworkNeighborhood(name, namespace string, patch []byte, channel chan error) error {
+	neighborhood, err := sc.StorageClient.NetworkNeighborhoods(namespace).Patch(context.Background(), name, types.JSONPatchType, patch, v1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("patch application neighborhood: %w", err)
+	}
+	// check if returned neighborhood is full
+	if s, ok := neighborhood.Annotations[helpers.StatusMetadataKey]; ok {
+		if s == helpers.TooLarge {
+			if channel != nil {
+				channel <- utils.TooLargeObjectError
+			}
+		}
+		return nil
+	}
+	// check if returned neighborhood is too big
+	if s, ok := neighborhood.Annotations[helpers.ResourceSizeMetadataKey]; ok {
+		size, err := strconv.Atoi(s)
+		if err != nil {
+			return fmt.Errorf("parse size: %w", err)
+		}
+		if size > sc.maxNetworkNeighborhoodSize {
+			// add annotation to indicate that the neighborhood is full
+			annotationOperations := []utils.PatchOperation{
+				{
+					Op:    "replace",
+					Path:  "/metadata/annotations/" + utils.EscapeJSONPointerElement(helpers.StatusMetadataKey),
+					Value: helpers.TooLarge,
+				},
+			}
+			annotationsPatch, err := json.Marshal(annotationOperations)
+			if err != nil {
+				return fmt.Errorf("create patch for annotations: %w", err)
+			}
+			_, err = sc.StorageClient.NetworkNeighborhoods(namespace).Patch(context.Background(), name, types.JSONPatchType, annotationsPatch, v1.PatchOptions{})
+			if err != nil {
+				return fmt.Errorf("patch application neighborhood annotations: %w", err)
+			}
+			if channel != nil {
+				channel <- utils.TooLargeObjectError
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/storage/v1/storage.go
+++ b/pkg/storage/v1/storage.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"node-agent/pkg/storage"
-	"node-agent/pkg/utils"
 	"os"
 	"strconv"
 
-	iidhelpers "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned"
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
@@ -21,14 +19,16 @@ import (
 )
 
 const (
-	DefaultMaxApplicationProfileSize = 10000
-	KubeConfig                       = "KUBECONFIG"
+	DefaultMaxApplicationProfileSize  = 10000
+	DefaultMaxNetworkNeighborhoodSize = 1000
+	KubeConfig                        = "KUBECONFIG"
 )
 
 type Storage struct {
-	StorageClient             spdxv1beta1.SpdxV1beta1Interface
-	maxApplicationProfileSize int
-	namespace                 string
+	StorageClient              spdxv1beta1.SpdxV1beta1Interface
+	maxApplicationProfileSize  int
+	maxNetworkNeighborhoodSize int
+	namespace                  string
 }
 
 var _ storage.StorageClient = (*Storage)(nil)
@@ -55,10 +55,16 @@ func CreateStorage(namespace string) (*Storage, error) {
 		maxApplicationProfileSize = DefaultMaxApplicationProfileSize
 	}
 
+	maxNetworkNeighborhoodSize, err := strconv.Atoi(os.Getenv("MAX_NETWORK_NEIGHBORHOOD_SIZE"))
+	if err != nil {
+		maxNetworkNeighborhoodSize = DefaultMaxNetworkNeighborhoodSize
+	}
+
 	return &Storage{
-		StorageClient:             clientset.SpdxV1beta1(),
-		maxApplicationProfileSize: maxApplicationProfileSize,
-		namespace:                 namespace,
+		StorageClient:              clientset.SpdxV1beta1(),
+		maxApplicationProfileSize:  maxApplicationProfileSize,
+		maxNetworkNeighborhoodSize: maxNetworkNeighborhoodSize,
+		namespace:                  namespace,
 	}, nil
 }
 
@@ -111,65 +117,6 @@ func (sc Storage) CreateApplicationActivity(activity *v1beta1.ApplicationActivit
 
 func (sc Storage) GetApplicationActivity(namespace, name string) (*v1beta1.ApplicationActivity, error) {
 	return sc.StorageClient.ApplicationActivities(namespace).Get(context.Background(), name, metav1.GetOptions{})
-}
-
-func (sc Storage) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, namespace string) error {
-	// unset resourceVersion
-	profile.ResourceVersion = ""
-	_, err := sc.StorageClient.ApplicationProfiles(namespace).Create(context.Background(), profile, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (sc Storage) PatchApplicationProfile(name, namespace string, patch []byte, channel chan error) error {
-	profile, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, patch, metav1.PatchOptions{})
-	if err != nil {
-		return fmt.Errorf("patch application profile: %w", err)
-	}
-	// check if returned profile is full
-	if s, ok := profile.Annotations[iidhelpers.StatusMetadataKey]; ok {
-		if s == iidhelpers.TooLarge {
-			if channel != nil {
-				channel <- utils.TooLargeApplicationProfileError
-			}
-		}
-		return nil
-	}
-	// check if returned profile is too big
-	if s, ok := profile.Annotations[iidhelpers.ResourceSizeMetadataKey]; ok {
-		size, err := strconv.Atoi(s)
-		if err != nil {
-			return fmt.Errorf("parse size: %w", err)
-		}
-		if size > sc.maxApplicationProfileSize {
-			// add annotation to indicate that the profile is full
-			annotationOperations := []utils.PatchOperation{
-				{
-					Op:    "replace",
-					Path:  "/metadata/annotations/" + utils.EscapeJSONPointerElement(iidhelpers.StatusMetadataKey),
-					Value: iidhelpers.TooLarge,
-				},
-			}
-			annotationsPatch, err := json.Marshal(annotationOperations)
-			if err != nil {
-				return fmt.Errorf("create patch for annotations: %w", err)
-			}
-			_, err = sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), name, types.JSONPatchType, annotationsPatch, metav1.PatchOptions{})
-			if err != nil {
-				return fmt.Errorf("patch application profile annotations: %w", err)
-			}
-			if channel != nil {
-				channel <- utils.TooLargeApplicationProfileError
-			}
-		}
-	}
-	return nil
-}
-
-func (sc Storage) GetApplicationProfile(namespace, name string) (*v1beta1.ApplicationProfile, error) {
-	return sc.StorageClient.ApplicationProfiles(namespace).Get(context.Background(), name, metav1.GetOptions{})
 }
 
 func (sc Storage) CreateFilteredSBOM(SBOM *v1beta1.SBOMSyftFiltered) error {

--- a/pkg/utils/applicationprofile.go
+++ b/pkg/utils/applicationprofile.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/deckarep/golang-set/v2"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"sort"
+)
+
+func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
+	var profileOperations []PatchOperation
+	// add capabilities
+	sort.Strings(capabilities)
+	capabilitiesPath := fmt.Sprintf("/spec/%s/%d/capabilities/-", containerType, containerIndex)
+	for _, capability := range capabilities {
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:    "add",
+			Path:  capabilitiesPath,
+			Value: capability,
+		})
+	}
+	// add syscalls
+	sort.Strings(syscalls)
+	sysCallsPath := fmt.Sprintf("/spec/%s/%d/syscalls/-", containerType, containerIndex)
+	for _, syscall := range syscalls {
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:    "add",
+			Path:  sysCallsPath,
+			Value: syscall,
+		})
+	}
+
+	// add execs
+	execsPath := fmt.Sprintf("/spec/%s/%d/execs/-", containerType, containerIndex)
+	for path, exec := range execs {
+		args := exec.ToSlice()
+		sort.Strings(args)
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:   "add",
+			Path: execsPath,
+			Value: v1beta1.ExecCalls{
+				Path: path,
+				Args: args,
+			},
+		})
+	}
+	// add opens
+	opensPath := fmt.Sprintf("/spec/%s/%d/opens/-", containerType, containerIndex)
+	for path, open := range opens {
+		flags := open.ToSlice()
+		sort.Strings(flags)
+
+		profileOperations = append(profileOperations, PatchOperation{
+			Op:   "add",
+			Path: opensPath,
+			Value: v1beta1.OpenCalls{
+				Path:  path,
+				Flags: flags,
+			},
+		})
+	}
+	return profileOperations
+}
+
+func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileContainer, observedCapabilities, observedSyscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
+	// add capabilities
+	sort.Strings(observedCapabilities)
+	container.Capabilities = observedCapabilities
+	// add syscalls
+	sort.Strings(observedSyscalls)
+	container.Syscalls = observedSyscalls
+	// add execs
+	container.Execs = make([]v1beta1.ExecCalls, 0)
+	for path, exec := range execs {
+		args := exec.ToSlice()
+		sort.Strings(args)
+		container.Execs = append(container.Execs, v1beta1.ExecCalls{
+			Path: path,
+			Args: args,
+		})
+	}
+	// add opens
+	container.Opens = make([]v1beta1.OpenCalls, 0)
+	for path, open := range opens {
+		flags := open.ToSlice()
+		sort.Strings(flags)
+		container.Opens = append(container.Opens, v1beta1.OpenCalls{
+			Path:  path,
+			Flags: flags,
+		})
+	}
+}
+
+// TODO make generic?
+func GetApplicationProfileContainer(object *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) *v1beta1.ApplicationProfileContainer {
+	if object == nil {
+		return nil
+	}
+	switch containerType {
+	case Container:
+		if len(object.Spec.Containers) > containerIndex {
+			return &object.Spec.Containers[containerIndex]
+		}
+	case InitContainer:
+		if len(object.Spec.InitContainers) > containerIndex {
+			return &object.Spec.InitContainers[containerIndex]
+		}
+	case EphemeralContainer:
+		if len(object.Spec.EphemeralContainers) > containerIndex {
+			return &object.Spec.EphemeralContainers[containerIndex]
+		}
+	}
+	return nil
+}

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+)
+
+func CreateNetworkPatchOperations(ingress, egress []v1beta1.NetworkNeighbor, containerType string, containerIndex int) []PatchOperation {
+	var networkOperations []PatchOperation
+	patchNeighbors := func(neighborType string, neighbors []v1beta1.NetworkNeighbor) {
+		networkPath := fmt.Sprintf("/spec/%s/%d/%s/-", containerType, containerIndex, neighborType)
+		for _, neighbor := range neighbors {
+			networkOperations = append(networkOperations, PatchOperation{
+				Op:    "add",
+				Path:  networkPath,
+				Value: neighbor,
+			})
+		}
+	}
+	patchNeighbors("ingress", ingress)
+	patchNeighbors("egress", egress)
+	return networkOperations
+}
+
+func EnrichNeighborhoodContainer(container *v1beta1.NetworkNeighborhoodContainer, ingress, egress []v1beta1.NetworkNeighbor) {
+	if container == nil {
+		return
+	}
+	container.Ingress = append(container.Ingress, ingress...)
+	container.Egress = append(container.Egress, egress...)
+}
+
+// TODO make generic?
+func GetNetworkNeighborhoodContainer(object *v1beta1.NetworkNeighborhood, containerType ContainerType, containerIndex int) *v1beta1.NetworkNeighborhoodContainer {
+	if object == nil {
+		return nil
+	}
+	switch containerType {
+	case Container:
+		if len(object.Spec.Containers) > containerIndex {
+			return &object.Spec.Containers[containerIndex]
+		}
+	case InitContainer:
+		if len(object.Spec.InitContainers) > containerIndex {
+			return &object.Spec.InitContainers[containerIndex]
+		}
+	case EphemeralContainer:
+		if len(object.Spec.EphemeralContainers) > containerIndex {
+			return &object.Spec.EphemeralContainers[containerIndex]
+		}
+	}
+	return nil
+}
+
+func GenerateNeighborsIdentifier(neighborEntry v1beta1.NetworkNeighbor) (string, error) {
+	// identifier is hash of everything in egress except ports
+	identifier := fmt.Sprintf("%s-%s-%s-%s-%s", neighborEntry.Type, neighborEntry.IPAddress, neighborEntry.DNS, neighborEntry.NamespaceSelector, neighborEntry.PodSelector)
+	hash := sha256.New()
+	_, err := hash.Write([]byte(identifier))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+func GetNamespaceMatchLabels(destinationNamespace, sourceNamespace string) map[string]string {
+	if destinationNamespace != sourceNamespace {
+		// from version 1.22, all namespace have the kubernetes.io/metadata.name label
+		return map[string]string{
+			"kubernetes.io/metadata.name": destinationNamespace,
+		}
+	}
+	return nil
+}

--- a/pkg/utils/network_test.go
+++ b/pkg/utils/network_test.go
@@ -1,0 +1,139 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestGenerateNeighborsIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    v1beta1.NetworkNeighbor
+		expected string
+	}{
+		{
+			name: "external",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "external",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port1", Protocol: "TCP"}},
+				PodSelector:       nil,
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "a13ce4ca8de4083d05986cdc9874c5bc75870f93a89363acc36e12511ceae5d8",
+		},
+		{
+			name: "external - different IP has different identifier",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "external",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port1", Protocol: "TCP"}},
+				PodSelector:       nil,
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.3",
+			},
+			expected: "5e620390e1aa074ccca30576eb9e09db9254a07b1d6cef9b45d7f98a1f72c863",
+		},
+		{
+			name: "internal",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port1", Protocol: "TCP"}},
+				PodSelector:       &v1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "fd41d439d5de80f684d53dc9682ca335f93f6f754031d6e3624a9772b8010680",
+		},
+		{
+			name: "internal - different ports has same identifier",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port2", Protocol: "udp"}},
+				PodSelector:       &v1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "fd41d439d5de80f684d53dc9682ca335f93f6f754031d6e3624a9772b8010680",
+		},
+		{
+			name: "internal - different pod labels has different identifier",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port2", Protocol: "udp"}},
+				PodSelector:       &v1.LabelSelector{MatchLabels: map[string]string{"app2": "nginx"}},
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "0848cb483e73375684bbc7333f64d74dfa13260fc9d9ff178cdead9b1f695944",
+		},
+		{
+			name: "internal - different namespace labels has different identifier",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "example.com",
+				Ports:             []v1beta1.NetworkPort{{Name: "port2", Protocol: "udp"}},
+				PodSelector:       &v1.LabelSelector{MatchLabels: map[string]string{"app2": "nginx"}},
+				NamespaceSelector: &v1.LabelSelector{MatchLabels: map[string]string{"app2": "nginx"}},
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "d4e9bce7335a0eee24b725edb9de785fecfebad7bfc4f2ea4a49830925b745da",
+		},
+		{
+			name: "internal - different dns has different identifier",
+			input: v1beta1.NetworkNeighbor{
+				Type:              "internal",
+				DNS:               "another.co m",
+				Ports:             []v1beta1.NetworkPort{{Name: "port2", Protocol: "udp"}},
+				PodSelector:       &v1.LabelSelector{MatchLabels: map[string]string{"app2": "nginx"}},
+				NamespaceSelector: nil,
+				IPAddress:         "192.168.1.1",
+			},
+			expected: "f3dd4abe5311abc6ab3768182af5a15cb96746dd82573a744e2132d9ac90f52d",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("Input: %s", tc.name), func(t *testing.T) {
+			result, err := GenerateNeighborsIdentifier(tc.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestGetNamespaceMatchLabels(t *testing.T) {
+	tests := []struct {
+		name                 string
+		destinationNamespace string
+		sourceNamespace      string
+		expected             map[string]string
+	}{
+		{
+			name:                 "same namespace - should not have namespace selector",
+			destinationNamespace: "default",
+			sourceNamespace:      "default",
+			expected:             nil,
+		},
+		{
+			name:                 "different namespace - should have the destination namespace as selector",
+			sourceNamespace:      "default",
+			destinationNamespace: "kubescape",
+			expected:             map[string]string{"kubernetes.io/metadata.name": "kubescape"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("Input: %s", tc.name), func(t *testing.T) {
+			result := GetNamespaceMatchLabels(tc.destinationNamespace, tc.sourceNamespace)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,12 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"node-agent/pkg/objectcache"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,9 +41,9 @@ import (
 )
 
 var (
-	ContainerHasTerminatedError     = errors.New("container has terminated")
-	TooLargeApplicationProfileError = errors.New("application profile is too large")
-	IncompleteSBOMError             = errors.New("incomplete SBOM")
+	ContainerHasTerminatedError = errors.New("container has terminated")
+	TooLargeObjectError         = errors.New("object is too large")
+	IncompleteSBOMError         = errors.New("incomplete SBOM")
 )
 
 type PackageSourceInfoData struct {
@@ -100,13 +100,13 @@ type WatchedContainerData struct {
 	SBOMResourceVersion                        int
 	ContainerType                              ContainerType
 	ContainerIndex                             int
-	ContainerNames                             []string // depends on the container type
+	ContainerNames                             map[ContainerType][]string
 	NsMntId                                    uint64
 	InitialDelayExpired                        bool
-
-	statusUpdated    bool
-	status           WatchedContainerStatus
-	completionStatus WatchedContainerCompletionStatus
+	statusUpdated                              bool
+	status                                     WatchedContainerStatus
+	completionStatus                           WatchedContainerCompletionStatus
+	ParentWorkloadSelector                     *metav1.LabelSelector
 }
 
 func Between(value string, a string, b string) string {
@@ -198,47 +198,6 @@ func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[
 	return labels
 }
 
-func GetApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) *v1beta1.ApplicationProfileContainer {
-	if profile == nil {
-		return nil
-	}
-	switch containerType {
-	case Container:
-		if len(profile.Spec.Containers) > containerIndex {
-			return &profile.Spec.Containers[containerIndex]
-		}
-	case InitContainer:
-		if len(profile.Spec.InitContainers) > containerIndex {
-			return &profile.Spec.InitContainers[containerIndex]
-		}
-	case EphemeralContainer:
-		if len(profile.Spec.EphemeralContainers) > containerIndex {
-			return &profile.Spec.EphemeralContainers[containerIndex]
-		}
-	}
-	return nil
-}
-
-func InsertApplicationProfileContainer(profile *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int, profileContainer *v1beta1.ApplicationProfileContainer) {
-	switch containerType {
-	case Container:
-		if len(profile.Spec.Containers) <= containerIndex {
-			profile.Spec.Containers = append(profile.Spec.Containers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.Containers)+1)...)
-		}
-		profile.Spec.Containers[containerIndex] = *profileContainer
-	case InitContainer:
-		if len(profile.Spec.InitContainers) <= containerIndex {
-			profile.Spec.InitContainers = append(profile.Spec.InitContainers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.InitContainers)+1)...)
-		}
-		profile.Spec.InitContainers[containerIndex] = *profileContainer
-	case EphemeralContainer:
-		if len(profile.Spec.EphemeralContainers) <= containerIndex {
-			profile.Spec.EphemeralContainers = append(profile.Spec.EphemeralContainers, make([]v1beta1.ApplicationProfileContainer, containerIndex-len(profile.Spec.EphemeralContainers)+1)...)
-		}
-		profile.Spec.EphemeralContainers[containerIndex] = *profileContainer
-	}
-}
-
 func (watchedContainer *WatchedContainerData) GetStatus() WatchedContainerStatus {
 	return watchedContainer.status
 }
@@ -270,6 +229,9 @@ func (watchedContainer *WatchedContainerData) StatusUpdated() bool {
 }
 
 func (watchedContainer *WatchedContainerData) SetContainerInfo(wl workloadinterface.IWorkload, containerName string) {
+	if watchedContainer.ContainerNames == nil {
+		watchedContainer.ContainerNames = make(map[ContainerType][]string)
+	}
 	checkContainers := func(containers []v1.Container, ephemeralContainers []v1.EphemeralContainer, containerType ContainerType) {
 		var containerNames []string
 		if containerType == EphemeralContainer {
@@ -278,7 +240,6 @@ func (watchedContainer *WatchedContainerData) SetContainerInfo(wl workloadinterf
 				if c.Name == containerName {
 					watchedContainer.ContainerIndex = i
 					watchedContainer.ContainerType = containerType
-					watchedContainer.ContainerNames = containerNames
 				}
 			}
 		} else {
@@ -287,10 +248,10 @@ func (watchedContainer *WatchedContainerData) SetContainerInfo(wl workloadinterf
 				if c.Name == containerName {
 					watchedContainer.ContainerIndex = i
 					watchedContainer.ContainerType = containerType
-					watchedContainer.ContainerNames = containerNames
 				}
 			}
 		}
+		watchedContainer.ContainerNames[containerType] = containerNames
 	}
 	// containers
 	containers, err := wl.GetContainers()
@@ -344,35 +305,6 @@ func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsC
 	return 0
 }
 
-func EnrichProfileContainer(newProfileContainer *v1beta1.ApplicationProfileContainer, observedCapabilities, observedSyscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
-	// add capabilities
-	sort.Strings(observedCapabilities)
-	newProfileContainer.Capabilities = observedCapabilities
-	// add syscalls
-	sort.Strings(observedSyscalls)
-	newProfileContainer.Syscalls = observedSyscalls
-	// add execs
-	newProfileContainer.Execs = make([]v1beta1.ExecCalls, 0)
-	for path, exec := range execs {
-		args := exec.ToSlice()
-		sort.Strings(args)
-		newProfileContainer.Execs = append(newProfileContainer.Execs, v1beta1.ExecCalls{
-			Path: path,
-			Args: args,
-		})
-	}
-	// add opens
-	newProfileContainer.Opens = make([]v1beta1.OpenCalls, 0)
-	for path, open := range opens {
-		flags := open.ToSlice()
-		sort.Strings(flags)
-		newProfileContainer.Opens = append(newProfileContainer.Opens, v1beta1.OpenCalls{
-			Path:  path,
-			Flags: flags,
-		})
-	}
-}
-
 type PatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
@@ -385,61 +317,6 @@ func EscapeJSONPointerElement(s string) string {
 	s = strings.ReplaceAll(s, "~", "~0")
 	s = strings.ReplaceAll(s, "/", "~1")
 	return s
-}
-
-func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
-	var profileOperations []PatchOperation
-	// add capabilities
-	sort.Strings(capabilities)
-	capabilitiesPath := fmt.Sprintf("/spec/%s/%d/capabilities/-", containerType, containerIndex)
-	for _, capability := range capabilities {
-		profileOperations = append(profileOperations, PatchOperation{
-			Op:    "add",
-			Path:  capabilitiesPath,
-			Value: capability,
-		})
-	}
-	// add syscalls
-	sort.Strings(syscalls)
-	sysCallsPath := fmt.Sprintf("/spec/%s/%d/syscalls/-", containerType, containerIndex)
-	for _, syscall := range syscalls {
-		profileOperations = append(profileOperations, PatchOperation{
-			Op:    "add",
-			Path:  sysCallsPath,
-			Value: syscall,
-		})
-	}
-
-	// add execs
-	execsPath := fmt.Sprintf("/spec/%s/%d/execs/-", containerType, containerIndex)
-	for path, exec := range execs {
-		args := exec.ToSlice()
-		sort.Strings(args)
-		profileOperations = append(profileOperations, PatchOperation{
-			Op:   "add",
-			Path: execsPath,
-			Value: v1beta1.ExecCalls{
-				Path: path,
-				Args: args,
-			},
-		})
-	}
-	// add opens
-	opensPath := fmt.Sprintf("/spec/%s/%d/opens/-", containerType, containerIndex)
-	for path, open := range opens {
-		flags := open.ToSlice()
-		sort.Strings(flags)
-
-		profileOperations = append(profileOperations, PatchOperation{
-			Op:   "add",
-			Path: opensPath,
-			Value: v1beta1.OpenCalls{
-				Path:  path,
-				Flags: flags,
-			},
-		})
-	}
-	return profileOperations
 }
 
 func AppendStatusAnnotationPatchOperations(existingPatch []PatchOperation, watchedContainer *WatchedContainerData) []PatchOperation {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Implemented a new version (`v2`) of `NetworkManager` for managing network events in Kubernetes pods, including unit tests.
- Refactored existing `NetworkManager` (`v1`) for versioning and minor adjustments.
- Updated `ApplicationProfileManager` and utility functions for error handling and container information management.
- Introduced configuration options for network neighborhood size in storage and enhanced storage mocks.
- Integrated `NetworkManager` v1 into `ContainerWatcher` for improved network event handling.
- Added utility functions for application profile patch operations and container management.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Implement NetworkManager for Kubernetes Pod Network Events</code></dd></summary>
<hr>

pkg/networkmanager/v2/network_manager.go
<li>Introduced <code>NetworkManager</code> struct for managing network events in <br>Kubernetes pods.<br> <li> Implemented <code>CreateNetworkManager</code> function to initialize a new <br><code>NetworkManager</code>.<br> <li> Added methods for ensuring instance ID, deleting resources, validating <br>events, and monitoring containers.<br> <li> Implemented functionality to save network profiles and handle network <br>events.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-0d21f2a259391c6d4901ddffa2252ee46113d379a1453d54cbcecbbe0fa331f6">+642/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Refactor NetworkManager for Versioning and Event Handling Adjustments</code></dd></summary>
<hr>

pkg/networkmanager/v1/network_manager.go
<li>Refactored import paths to accommodate new versioning structure.<br> <li> Minor adjustments to align with changes in the network event handling <br>logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-91001aa3daf6f273c1ae3ded661c9acea7486080c3ff3da88c268ec56258fed0">+31/-67</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Update Error Handling and Comments in ApplicationProfileManager</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Updated error handling logic to use a more generic error for oversized <br>objects.<br> <li> Adjusted comments and minor logic for clarity and consistency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+50/-48</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Introduce New Utility Functions and Error Types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils.go
<li>Introduced new error types for container termination and object size <br>limits.<br> <li> Added utility functions for handling labels and container information.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+13/-136</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile.go</strong><dd><code>Utility Functions for Application Profile Patch Operations and </code><br><code>Container Management</code></dd></summary>
<hr>

pkg/utils/applicationprofile.go
<li>Added functions for creating patch operations and enriching <br>application profile containers.<br> <li> Introduced utility for retrieving application profile containers by <br>type and index.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-8d04187903dc650c355ad4c0bb3842e12f9b8a6ecc2ea543169f2b2c063dbe77">+114/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Integrate NetworkManager v1 into ContainerWatcher for Enhanced Network </code><br><code>Event Handling</code></dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Integrated <code>NetworkManager</code> v1 into container watcher for handling <br>network events.<br> <li> Adjusted container event callback logic to support new network event <br>handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_event.go</strong><dd><code>Enhancements to Network Event Handling with New Constants and Utility </code><br><code>Functions</code></dd></summary>
<hr>

pkg/networkmanager/network_event.go
<li>Introduced constants for network event types and default labels to <br>ignore.<br> <li> Added function for generating port identifiers from network events.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-85704f242cb3bc2ea40ea3fd371bd25f5da2a081955ebc30732bc1b2e3f6b590">+16/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>network_manager_test.go</strong><dd><code>Unit Tests for NetworkManager Methods and Event Handling</code>&nbsp; </dd></summary>
<hr>

pkg/networkmanager/v2/network_manager_test.go
<li>Added unit tests for <code>NetworkManager</code> methods including event validation <br>and network monitoring.<br> <li> Tested creation of <code>NetworkManager</code> and its ability to handle network <br>events.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-8632bbb211e22ba63be3bde3ec36028f5ed6dd704c0696fa7a7bdab4628505e5">+343/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager_test.go</strong><dd><code>Update NetworkManager Unit Tests for New Versioning Structure</code></dd></summary>
<hr>

pkg/networkmanager/v1/network_manager_test.go
<li>Updated unit tests to reflect changes in the network manager and event <br>handling logic.<br> <li> Adjusted import paths and test data references for the new versioning <br>structure.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-092126bb5b156799cd8d08c7a1d32ea528c34e2990219ea4df640e0250697cc3">+55/-264</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_test.go</strong><dd><code>Unit Tests for Network Utility Functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/network_test.go
<li>Added unit tests for network utility functions including label <br>filtering and identifier generation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-b9a6966f16f7a29819fe0de805add86d45e89352252f1bbf3c0980ba59d2b956">+139/-0</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_neighbors_test.go</strong><dd><code>Refactor Network Neighbors Tests for Centralized Test Data</code></dd></summary>
<hr>

pkg/networkmanager/network_neighbors_test.go
<li>Refactored test data references to use a centralized test data <br>package.<br> <li> Updated tests to reflect changes in network neighbors handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-68558d20912d8cea617db22ea1956d124a034165a1251171d6e2b3c161b42772">+13/-24</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>storage_mock.go</strong><dd><code>Enhance Storage Mock with Network Neighborhood Functionality</code></dd></summary>
<hr>

pkg/storage/storage_mock.go
<li>Added mock functionality for network neighborhood storage operations.<br> <li> Removed outdated application profile patching logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-46ba336587e6a6a63e35733ffff9449ccc4b58a4dae87718d60bc991ca9adc9a">+2/-52</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>open_test.go</strong><dd><code>Benchmark Test Adjustment for Open Event Callback with NetworkManager </code><br><code>v1 Integration</code></dd></summary>
<hr>

pkg/containerwatcher/v1/open_test.go
<li>Adjusted benchmark test for open event callback to reflect integration <br>of <code>NetworkManager</code> v1.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-108b6c5c8056d52d17a43bba61a908715238d3bc3a2919f6332ca926509d2ec2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>storage.go</strong><dd><code>Introduce Configuration for Network Neighborhood Size in Storage</code></dd></summary>
<hr>

pkg/storage/v1/storage.go
<li>Introduced configuration for maximum network neighborhood size.<br> <li> Adjusted storage initialization to include new configuration options.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/242/files#diff-73a4faef80a41742c579b4d5818714eee4932420d87b5e24f0bc186a0ca23cc0">+16/-69</a>&nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

