### PR TITLE
Ignore DNS events that do not have address resolution

### DIFF
--- a/pkg/containerwatcher/v1/container_watcher.go
+++ b/pkg/containerwatcher/v1/container_watcher.go
@@ -224,9 +224,17 @@ func CreateIGContainerWatcher(cfg config.Config, applicationProfileManager appli
 		if event.K8s.ContainerName == "" {
 			return
 		}
+
+		// ignore DNS events that are not responses
 		if event.Qr != tracerdnstype.DNSPktTypeResponse {
 			return
 		}
+
+		// ignore DNS events that do not have address resolution
+		if event.NumAnswers == 0 {
+			return
+		}
+
 		metrics.ReportEvent(utils.DnsEventType)
 		dnsManagerClient.ReportDNSEvent(event)
 		ruleManager.ReportDNSEvent(event)

--- a/pkg/dnsmanager/dns_manager.go
+++ b/pkg/dnsmanager/dns_manager.go
@@ -20,19 +20,18 @@ func CreateDNSManager() *DNSManager {
 }
 
 func (dm *DNSManager) ReportDNSEvent(dnsEvent tracerdnstype.Event) {
-	if dnsEvent.NumAnswers > 0 {
-		if len(dnsEvent.Addresses) > 0 {
-			for _, address := range dnsEvent.Addresses {
-				dm.addressToDomainMap.Set(address, dnsEvent.DNSName)
-			}
-		} else {
-			addresses, err := net.LookupIP(dnsEvent.DNSName)
-			if err != nil {
-				return
-			}
-			for _, address := range addresses {
-				dm.addressToDomainMap.Set(address.String(), dnsEvent.DNSName)
-			}
+
+	if len(dnsEvent.Addresses) > 0 {
+		for _, address := range dnsEvent.Addresses {
+			dm.addressToDomainMap.Set(address, dnsEvent.DNSName)
+		}
+	} else {
+		addresses, err := net.LookupIP(dnsEvent.DNSName)
+		if err != nil {
+			return
+		}
+		for _, address := range addresses {
+			dm.addressToDomainMap.Set(address.String(), dnsEvent.DNSName)
 		}
 	}
 }

--- a/pkg/networkmanager/network_manager.go
+++ b/pkg/networkmanager/network_manager.go
@@ -341,7 +341,6 @@ func (am *NetworkManager) saveNetworkEvents(_ context.Context, container *contai
 	}
 
 	networkEvents := am.containerAndPodToEventsMap.Get(container.Runtime.ContainerID + container.K8s.PodName)
-	// TODO: dns enrichment
 
 	// update CRD based on events
 	networkNeighborsSpec := am.generateNetworkNeighborsEntries(container.K8s.Namespace, networkEvents, networkNeighbors.Spec)


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix


___

## **Description**
- Enhanced DNS event filtering in `container_watcher.go` to ignore non-response events or those without address resolution.
- Simplified DNS event reporting in `dns_manager.go` by removing redundant checks and directly mapping addresses to domain names.
- Noted a potential area for future work by commenting out a TODO related to DNS enrichment in `network_manager.go`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>container_watcher.go</strong><dd><code>Enhance DNS Event Filtering Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher.go
<li>Added checks to ignore DNS events that are not responses or do not <br>have address resolution.<br> <li> Metrics reporting for DNS events is now conditional on these new <br>checks.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/247/files#diff-9fa1df18c7f441eb315fcce4daa355a4517ee2d692d1b6a572f93ee5edbd247d">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dns_manager.go</strong><dd><code>Simplify DNS Event Reporting Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/dnsmanager/dns_manager.go
<li>Simplified the logic for reporting DNS events by removing redundant <br>checks.<br> <li> DNS event handling now directly maps addresses to domain names without <br>unnecessary conditions.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/247/files#diff-0dab52ba0ff558420648197d0c96ddc21321f647351ab03b63a4037b29389005">+12/-13</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Comment Out DNS Enrichment TODO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/network_manager.go
<li>Commented out a TODO related to DNS enrichment, indicating a potential <br>area for future work.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/247/files#diff-cbcd69c2d2fb59b909f8b3cec3ff32348a1ddb4f1d465ece79ead0fa0ba7168b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

