### PR TITLE
wip: ContainerReachedMaxTime

### DIFF
--- a/pkg/applicationprofilemanager/applicationprofile_manager_interface.go
+++ b/pkg/applicationprofilemanager/applicationprofile_manager_interface.go
@@ -9,4 +9,5 @@ type ApplicationProfileManagerClient interface {
 	ReportFileExec(k8sContainerID, path string, args []string)
 	ReportFileOpen(k8sContainerID, path string, flags []string)
 	ReportDroppedEvent(k8sContainerID string)
+	ContainerReachedMaxTime(containerID string)
 }

--- a/pkg/applicationprofilemanager/applicationprofile_manager_mock.go
+++ b/pkg/applicationprofilemanager/applicationprofile_manager_mock.go
@@ -34,3 +34,6 @@ func (a ApplicationProfileManagerMock) ReportFileOpen(_, _ string, _ []string) {
 func (a ApplicationProfileManagerMock) ReportDroppedEvent(_ string) {
 	// noop
 }
+func (a ApplicationProfileManagerMock) ContainerReachedMaxTime(_ string) {
+	// noop
+}

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -36,6 +36,10 @@ func (ch *IGContainerWatcher) containerCallback(notif containercollection.PubSub
 		time.AfterFunc(ch.cfg.MaxSniffingTime, func() {
 			ch.timeBasedContainers.Remove(notif.Container.Runtime.ContainerID)
 			ch.unregisterContainer(notif.Container)
+			ch.applicationProfileManager.ContainerReachedMaxTime(notif.Container.Runtime.ContainerID)
+			ch.relevancyManager.ContainerReachedMaxTime(notif.Container.Runtime.ContainerID)
+			ch.networkManagerv1.ContainerReachedMaxTime(notif.Container.Runtime.ContainerID)
+			ch.networkManager.ContainerReachedMaxTime(notif.Container.Runtime.ContainerID)
 		})
 	case containercollection.EventTypeRemoveContainer:
 		ch.preRunningContainersIDs.Remove(notif.Container.Runtime.ContainerID)

--- a/pkg/networkmanager/network_manager_interface.go
+++ b/pkg/networkmanager/network_manager_interface.go
@@ -7,6 +7,7 @@ import (
 
 type NetworkManagerClient interface {
 	ContainerCallback(notif containercollection.PubSubEvent)
+	ContainerReachedMaxTime(containerID string)
 	ReportNetworkEvent(k8sContainerID string, event tracernetworktype.Event)
 	ReportDroppedEvent(k8sContainerID string)
 }

--- a/pkg/networkmanager/network_manager_mock.go
+++ b/pkg/networkmanager/network_manager_mock.go
@@ -25,3 +25,6 @@ func (am *NetworkManagerMock) ReportNetworkEvent(_ string, _ tracernetworktype.E
 func (am *NetworkManagerMock) ReportDroppedEvent(_ string) {
 	// noop
 }
+func (am *NetworkManagerMock) ContainerReachedMaxTime(_ string) {
+	// noop
+}

--- a/pkg/networkmanager/v1/network_manager_interface.go
+++ b/pkg/networkmanager/v1/network_manager_interface.go
@@ -7,6 +7,7 @@ import (
 
 type NetworkManagerClient interface {
 	ContainerCallback(notif containercollection.PubSubEvent)
+	ContainerReachedMaxTime(containerID string)
 	ReportNetworkEvent(containerID string, event tracernetworktype.Event)
 	ReportDroppedEvent(containerID string, event tracernetworktype.Event)
 }

--- a/pkg/networkmanager/v1/network_manager_mock.go
+++ b/pkg/networkmanager/v1/network_manager_mock.go
@@ -25,3 +25,6 @@ func (am *NetworkManagerMock) ReportNetworkEvent(_ string, _ tracernetworktype.E
 func (am *NetworkManagerMock) ReportDroppedEvent(_ string, _ tracernetworktype.Event) {
 	// noop
 }
+func (am *NetworkManagerMock) ContainerReachedMaxTime(_ string) {
+	// noop
+}

--- a/pkg/relevancymanager/relevancy_manager_interface.go
+++ b/pkg/relevancymanager/relevancy_manager_interface.go
@@ -6,6 +6,7 @@ import (
 
 type RelevancyManagerClient interface {
 	ContainerCallback(notif containercollection.PubSubEvent)
+	ContainerReachedMaxTime(containerID string)
 	ReportFileExec(containerID, k8sContainerID, file string)
 	ReportFileOpen(containerID, k8sContainerID, file string)
 }

--- a/pkg/relevancymanager/relevancy_manager_mock.go
+++ b/pkg/relevancymanager/relevancy_manager_mock.go
@@ -22,3 +22,6 @@ func (r RelevancyManagerMock) ReportFileExec(_, _, _ string) {
 func (r RelevancyManagerMock) ReportFileOpen(_, _, _ string) {
 	// noop
 }
+func (r RelevancyManagerMock) ContainerReachedMaxTime(_ string) {
+	// noop
+}

--- a/pkg/relevancymanager/v1/relevancy_manager.go
+++ b/pkg/relevancymanager/v1/relevancy_manager.go
@@ -257,10 +257,19 @@ func (rm *RelevancyManager) monitorContainer(ctx context.Context, container *con
 				// handle collection of relevant data one more time
 				rm.handleRelevancy(ctx, watchedContainer, container.Runtime.ContainerID)
 				return nil
+			case errors.Is(err, utils.ContainerReachedMaxTime):
+				rm.handleRelevancy(ctx, watchedContainer, container.Runtime.ContainerID)
+				return nil
 			case errors.Is(err, utils.IncompleteSBOMError):
 				return utils.IncompleteSBOMError
 			}
 		}
+	}
+}
+
+func (rm *RelevancyManager) ContainerReachedMaxTime(containerID string) {
+	if channel := rm.watchedContainerChannels.Get(containerID); channel != nil {
+		channel <- utils.ContainerReachedMaxTime
 	}
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/rand"
 	"node-agent/pkg/objectcache"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mapset "github.com/deckarep/golang-set/v2"
 
@@ -42,6 +43,7 @@ import (
 
 var (
 	ContainerHasTerminatedError = errors.New("container has terminated")
+	ContainerReachedMaxTime     = errors.New("container reached max time")
 	TooLargeObjectError         = errors.New("object is too large")
 	IncompleteSBOMError         = errors.New("incomplete SBOM")
 )


### PR DESCRIPTION
## **User description**
## Overview
Create an event when we reach max sniffing time so the managers will stop caching the events.
This will save a lot of memory and CPU.

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Added handling for containers reaching maximum allowed time across various managers (`ApplicationProfileManager`, `NetworkManager`, `RelevancyManager`).
- Introduced a new error `ContainerReachedMaxTime` in utils to signal the max time event.
- Implemented no-operation `ContainerReachedMaxTime` methods in mock classes for testing.
- Enhanced container watcher to propagate the max time event to relevant managers.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_interface.go</strong><dd><code>Add Max Time Handler to ApplicationProfileManager Interface</code></dd></summary>
<hr>

pkg/applicationprofilemanager/applicationprofile_manager_interface.go
<li>Added <code>ContainerReachedMaxTime</code> method to the <br><code>ApplicationProfileManagerClient</code> interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-c8a552f73130367e711a6bd1c8b00dbb9a7b1ab7d7274fc0db6be59f333afb51">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_mock.go</strong><dd><code>Implement Max Time Handler in ApplicationProfileManager Mock</code></dd></summary>
<hr>

pkg/applicationprofilemanager/applicationprofile_manager_mock.go
<li>Implemented <code>ContainerReachedMaxTime</code> method as a no-operation in the <br>mock.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-ac635659b069359e3de4a50076026861cedfcfe02ac5ebc31176fb5cf49b506e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Implement Container Max Time Handling in ApplicationProfileManager</code></dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Added <code>ContainerReachedMaxTime</code> method to trigger a max time event for a <br>container.<br> <li> Save profile upon container reaching max time.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>container_watcher_private.go</strong><dd><code>Propagate Container Max Time Event in ContainerWatcher</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/containerwatcher/v1/container_watcher_private.go
<li>Trigger <code>ContainerReachedMaxTime</code> across multiple managers when a <br>container reaches max time.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-6f95b4caa6090a17da5aed1923600fd049392d228e0fba99cc212f48111f3ffe">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager_interface.go</strong><dd><code>Add Max Time Handler to NetworkManager Interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/network_manager_interface.go
<li>Added <code>ContainerReachedMaxTime</code> method to the <code>NetworkManagerClient</code> <br>interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-0071d030dc01d58e970e074979804a9df2f4d78f4ea199df561cc6cf9266dcb1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager_mock.go</strong><dd><code>Implement Max Time Handler in NetworkManager Mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/network_manager_mock.go
<li>Implemented <code>ContainerReachedMaxTime</code> method as a no-operation in the <br>mock.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-c1af333278c20e1191d77e9ad0baef0b4fc7ab9a1dab0d83606bb71f4fc1498f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Implement Container Max Time Handling in NetworkManager</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/v1/network_manager.go
<li>Added <code>ContainerReachedMaxTime</code> method to handle max time event for a <br>container.<br> <li> Save network events upon container reaching max time.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-91001aa3daf6f273c1ae3ded661c9acea7486080c3ff3da88c268ec56258fed0">+10/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_interface.go</strong><dd><code>Add Max Time Handler to RelevancyManager Interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/relevancymanager/relevancy_manager_interface.go
<li>Added <code>ContainerReachedMaxTime</code> method to the <code>RelevancyManagerClient</code> <br>interface.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-15761e78a5217b4c8e272a8a33389c153ff9e9744a6fac9e008eff354858041c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager_mock.go</strong><dd><code>Implement Max Time Handler in RelevancyManager Mock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/relevancymanager/relevancy_manager_mock.go
<li>Implemented <code>ContainerReachedMaxTime</code> method as a no-operation in the <br>mock.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-62a84f3a30d5aef360919a77b6f637666155db4d9b33204417ebf9f57dbc8fb8">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relevancy_manager.go</strong><dd><code>Implement Container Max Time Handling in RelevancyManager</code></dd></summary>
<hr>

pkg/relevancymanager/v1/relevancy_manager.go
<li>Added <code>ContainerReachedMaxTime</code> method to trigger relevancy handling <br>upon reaching max time.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-f665b80e0e8d6552b56e677f5579b3b90cb7cd78999a4bec61d41522469393a3">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Add Container Max Time Error in Utils</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils.go
<li>Introduced <code>ContainerReachedMaxTime</code> error to signal when a container <br>reaches its maximum allowed time.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/250/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

