### PR TITLE
Adding unique RuleFailure

### DIFF
--- a/pkg/ruleengine/ruleengine_interface.go
+++ b/pkg/ruleengine/ruleengine_interface.go
@@ -51,6 +51,8 @@ type RuleSpec interface {
 }
 
 type RuleFailure interface {
+	// GetUnique returns the unique identifier of the alert
+	GetUnique() string
 	// Get Base Runtime Alert
 	GetBaseRuntimeAlert() apitypes.BaseRuntimeAlert
 	// Get Runtime Process Details

--- a/pkg/ruleengine/v1/failureobj.go
+++ b/pkg/ruleengine/v1/failureobj.go
@@ -11,11 +11,17 @@ import (
 var _ ruleengine.RuleFailure = (*GenericRuleFailure)(nil)
 
 type GenericRuleFailure struct {
+	Unique                 string // alert identification for deduplication, should be unique per alert (I did not use "ID" so it wont be confused with ruleID)
 	BaseRuntimeAlert       apitypes.BaseRuntimeAlert
 	RuntimeProcessDetails  apitypes.RuntimeAlertProcessDetails
 	TriggerEvent           igtypes.Event
 	RuleAlert              apitypes.RuleAlert
 	RuntimeAlertK8sDetails apitypes.RuntimeAlertK8sDetails
+}
+
+// GetUnique returns the unique identifier of the alert
+func (rule *GenericRuleFailure) GetUnique() string {
+	return rule.Unique
 }
 
 func (rule *GenericRuleFailure) GetBaseRuntimeAlert() apitypes.BaseRuntimeAlert {

--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
@@ -92,6 +92,7 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType utils.EventTy
 
 	isPartOfImage := !execEvent.UpperLayer
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), execEvent.GetPod(), execEvent.GetContainer(), execEvent.Pid, execEvent.ExePath),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName: rule.Name(),
 			Arguments: map[string]interface{}{

--- a/pkg/ruleengine/v1/r0002_unexpected_file_access.go
+++ b/pkg/ruleengine/v1/r0002_unexpected_file_access.go
@@ -163,6 +163,7 @@ func (rule *R0002UnexpectedFileAccess) ProcessEvent(eventType utils.EventType, e
 	}
 
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), openEvent.GetPod(), openEvent.GetContainer(), openEvent.Pid, strings.Join(openEvent.Flags, ";")),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName: rule.Name(),
 			Arguments: map[string]interface{}{

--- a/pkg/ruleengine/v1/r0003_unexpected_system_call.go
+++ b/pkg/ruleengine/v1/r0003_unexpected_system_call.go
@@ -88,6 +88,7 @@ func (rule *R0003UnexpectedSystemCall) ProcessEvent(eventType utils.EventType, e
 	}
 
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), syscallEvent.GetPod(), syscallEvent.GetContainer(), syscallEvent.Pid, syscallEvent.SyscallName),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:      rule.Name(),
 			FixSuggestions: fmt.Sprintf("If this is a valid behavior, please add the system call \"%s\" to the whitelist in the application profile for the Pod \"%s\".", syscallEvent.SyscallName, syscallEvent.GetPod()),

--- a/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
+++ b/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
@@ -82,6 +82,7 @@ func (rule *R0004UnexpectedCapabilityUsed) ProcessEvent(eventType utils.EventTyp
 	}
 
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), capEvent.GetPod(), capEvent.GetContainer(), capEvent.Pid, capEvent.CapName),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:      rule.Name(),
 			FixSuggestions: fmt.Sprintf("If this is a valid behavior, please add the capability use \"%s\" to the whitelist in the application profile for the Pod \"%s\". You can use the following command: %s", capEvent.CapName, capEvent.GetPod(), rule.generatePatchCommand(capEvent, ap)),

--- a/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
+++ b/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
@@ -79,6 +79,7 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType utils.EventType
 	}
 
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), domainEvent.GetPod(), domainEvent.GetContainer(), domainEvent.Pid, domainEvent.DNSName),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName: rule.Name(),
 			FixSuggestions: fmt.Sprintf("If this is a valid behavior, please add the domain %s to the whitelist in the application profile for the Pod %s. You can use the following command: %s",

--- a/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
+++ b/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
@@ -115,6 +115,7 @@ func (rule *R0006UnexpectedServiceAccountTokenAccess) ProcessEvent(eventType uti
 	}
 
 	ruleFailure := GenericRuleFailure{
+		Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), openEvent.GetPod(), openEvent.GetContainer(), openEvent.Pid, openEvent.Path),
 		BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:      rule.Name(),
 			FixSuggestions: fmt.Sprintf("If this is a valid behavior, please add the open call \"%s\" to the whitelist in the application profile for the Pod \"%s\". You can use the following command: %s", openEvent.Path, openEvent.GetPod(), rule.generatePatchCommand(openEvent, ap)),

--- a/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
+++ b/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
@@ -91,6 +91,7 @@ func (rule *R0007KubernetesClientExecuted) handleNetworkEvent(event *tracernetwo
 
 	if event.DstEndpoint.Addr == apiServerIP {
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), event.GetPod(), event.GetContainer(), event.Pid, event.DstEndpoint.Addr),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -78,6 +78,7 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 		if strings.HasPrefix(execPath, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.Cwd, maliciousExecPathPrefix) || strings.HasPrefix(execEvent.ExePath, maliciousExecPathPrefix) {
 			isPartOfImage := !execEvent.UpperLayer
 			ruleFailure := GenericRuleFailure{
+				Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), execEvent.GetPod(), execEvent.GetContainer(), execEvent.Pid, execEvent.ExePath),
 				BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 					AlertName: rule.Name(),
 					Arguments: map[string]interface{}{

--- a/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
@@ -62,6 +62,7 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventTyp
 	if execEvent.UpperLayer {
 		isPartOfImage := !execEvent.UpperLayer
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), execEvent.GetPod(), execEvent.GetContainer(), execEvent.Pid, execEvent.ExePath),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				FixSuggestions: "If this is an expected behavior it is strongly suggested to include all executables in the container image. If this is not possible you can remove the rule binding to this workload.",

--- a/pkg/ruleengine/v1/r1002_load_kernel_module.go
+++ b/pkg/ruleengine/v1/r1002_load_kernel_module.go
@@ -68,6 +68,7 @@ func (rule *R1002LoadKernelModule) ProcessEvent(eventType utils.EventType, event
 	if syscallEvent.SyscallName == "init_module" {
 		rule.alerted = true
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), syscallEvent.GetPod(), syscallEvent.GetContainer(), syscallEvent.Pid, syscallEvent.SyscallName),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				FixSuggestions: "If this is a legitimate action, please add consider removing this workload from the binding of this rule",

--- a/pkg/ruleengine/v1/r1004_exec_from_mount.go
+++ b/pkg/ruleengine/v1/r1004_exec_from_mount.go
@@ -71,6 +71,7 @@ func (rule *R1004ExecFromMount) ProcessEvent(eventType utils.EventType, event in
 			logger.L().Debug("Exec from mount", helpers.String("path", p), helpers.String("mount", mount))
 			isPartOfImage := !execEvent.UpperLayer
 			ruleFailure := GenericRuleFailure{
+				Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), execEvent.GetPod(), execEvent.GetContainer(), execEvent.Pid, execEvent.ExePath),
 				BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 					AlertName: rule.Name(),
 					Arguments: map[string]interface{}{

--- a/pkg/ruleengine/v1/r1005_fileless_execution.go
+++ b/pkg/ruleengine/v1/r1005_fileless_execution.go
@@ -75,6 +75,7 @@ func (rule *R1005FilelessExecution) handleSyscallEvent(syscallEvent *ruleenginet
 	if syscallEvent.SyscallName == "memfd_create" {
 		rule.alreadyNotified = true
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), syscallEvent.GetPod(), syscallEvent.GetContainer(), syscallEvent.Pid, syscallEvent.SyscallName),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule",

--- a/pkg/ruleengine/v1/r1006_unshare_system_call.go
+++ b/pkg/ruleengine/v1/r1006_unshare_system_call.go
@@ -70,6 +70,7 @@ func (rule *R1006UnshareSyscall) ProcessEvent(eventType utils.EventType, event i
 	if syscallEvent.SyscallName == "unshare" {
 		rule.alreadyNotified = true
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), syscallEvent.GetPod(), syscallEvent.GetContainer(), syscallEvent.Pid, syscallEvent.SyscallName),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule",

--- a/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
+++ b/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
@@ -61,6 +61,7 @@ func (rule *R1007XMRCryptoMining) ProcessEvent(eventType utils.EventType, event 
 	if randomXEvent, ok := event.(*tracerrandomxtype.Event); ok {
 		isPartOfImage := !randomXEvent.UpperLayer
 		ruleFailure := GenericRuleFailure{
+			Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), randomXEvent.GetPod(), randomXEvent.GetContainer(), randomXEvent.Pid, randomXEvent.Comm),
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),
 				IsPartOfImage:  &isPartOfImage,

--- a/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
+++ b/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
@@ -169,6 +169,7 @@ func (rule *R1008CryptoMiningDomainCommunication) ProcessEvent(eventType utils.E
 	if dnsEvent, ok := event.(*tracerdnstype.Event); ok {
 		if slices.Contains(commonlyUsedCryptoMinersDomains, dnsEvent.DNSName) {
 			ruleFailure := GenericRuleFailure{
+				Unique: fmt.Sprintf("%s-%s-%s-%d-%s", rule.ID(), dnsEvent.GetPod(), dnsEvent.GetContainer(), dnsEvent.Pid, dnsEvent.DNSName),
 				BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 					AlertName:      rule.Name(),
 					FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",

--- a/pkg/ruleengine/v1/r1009_crypto_mining_port.go
+++ b/pkg/ruleengine/v1/r1009_crypto_mining_port.go
@@ -66,6 +66,7 @@ func (rule *R1009CryptoMiningRelatedPort) ProcessEvent(eventType utils.EventType
 	if networkEvent, ok := event.(*tracernetworktype.Event); ok {
 		if networkEvent.Proto == "TCP" && networkEvent.PktType == "OUTGOING" && slices.Contains(CommonlyUsedCryptoMinersPorts, networkEvent.Port) {
 			ruleFailure := GenericRuleFailure{
+				Unique: fmt.Sprintf("%s-%s-%s-%d-%d", rule.ID(), networkEvent.GetPod(), networkEvent.GetContainer(), networkEvent.Pid, networkEvent.Port),
 				BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 					AlertName:      rule.Name(),
 					FixSuggestions: "If this is a legitimate action, please consider removing this workload from the binding of this rule.",


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Enhancement


___

## **Description**
- Added a unique identifier for each rule failure to support alert deduplication.
- Introduced `GetUnique` method in the `RuleFailure` interface and implemented it in `GenericRuleFailure`.
- Enhanced various rule processing methods to generate unique identifiers based on rule and event details.
- Simplified the `RuleManager` by removing redundant caching checks and added a method to deduplicate alerts.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ruleengine_interface.go</strong><dd><code>Add unique identifier method to RuleFailure interface</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/ruleengine_interface.go
<li>Added <code>GetUnique</code> method to the <code>RuleFailure</code> interface to retrieve unique <br>identifiers for alerts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/251/files#diff-d2a3a4db98d7aa1d8a220ea3ea3d68d7f3aa7fd052bed167611eb4cac9ccd094">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>failureobj.go</strong><dd><code>Implement unique identifier in GenericRuleFailure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/failureobj.go
<li>Added <code>Unique</code> field to <code>GenericRuleFailure</code> struct for alert <br>deduplication.<br> <li> Implemented <code>GetUnique</code> method in <code>GenericRuleFailure</code> to return the <br>unique identifier.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/251/files#diff-986eeff862c3536b579506fc567d20c06509e81eef0c85b96cb38e36dcb07b20">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>*.go</strong><dd><code>Generate unique identifiers for rule failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/*.go
<li>Added unique identifier generation in the constructor of <br><code>GenericRuleFailure</code> for various rules.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/251/files#diff-ba7d049a8c6c1efb55df2fd5296dc38f547dd29fd03c58ef6a9161e679c63de6"></a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Refactor RuleManager and add alert deduplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Removed redundant caching checks in various reporting methods.<br> <li> Added <code>deduplicateAlerts</code> method to handle alert deduplication.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/251/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+2/-68</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

