### PR TITLE
Adding node name and cluster to init

### DIFF
--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -82,7 +82,9 @@ func InitHTTPExporter(config HTTPExporterConfig, clusterName string, nodeName st
 	}
 
 	return &HTTPExporter{
-		config: config,
+		ClusterName: clusterName,
+		NodeName:    nodeName,
+		config:      config,
 		httpClient: &http.Client{
 			Timeout: time.Duration(config.TimeoutSeconds) * time.Second,
 		},

--- a/pkg/exporters/http_exporter_test.go
+++ b/pkg/exporters/http_exporter_test.go
@@ -240,12 +240,14 @@ func TestValidateHTTPExporterConfig(t *testing.T) {
 	// Test case: URL is not empty
 	exp, err := InitHTTPExporter(HTTPExporterConfig{
 		URL: "http://localhost:9093",
-	}, "", "")
+	}, "cluster", "node")
 	assert.NoError(t, err)
 	assert.Equal(t, "POST", exp.config.Method)
 	assert.Equal(t, 5, exp.config.TimeoutSeconds)
 	assert.Equal(t, 10000, exp.config.MaxAlertsPerMinute)
 	assert.Equal(t, map[string]string{}, exp.config.Headers)
+	assert.Equal(t, "cluster", exp.ClusterName)
+	assert.Equal(t, "node", exp.NodeName)
 
 	// Test case: Method is PUT
 	exp, err = InitHTTPExporter(HTTPExporterConfig{


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- The `HTTPExporter` struct in `http_exporter.go` has been enhanced to include `ClusterName` and `NodeName` during its initialization.
- This change allows the exporter to use the node and cluster names directly, improving the clarity and usability of the exporter configuration.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter.go</strong><dd><code>Enhance HTTPExporter Initialization with Node and Cluster Names</code></dd></summary>
<hr>

pkg/exporters/http_exporter.go
<li>Added <code>ClusterName</code> and <code>NodeName</code> fields to <code>HTTPExporter</code> struct <br>initialization.<br> <li> These fields are now initialized with <code>clusterName</code> and <code>nodeName</code> <br>parameters.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/254/files#diff-6e04fd42d767812ea2855370a21a524371930b320544c0ee0954e1500242fbbd">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

