### PR TITLE
Ignore networkmanagerv2

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	metricprometheus "node-agent/pkg/metricsmanager/prometheus"
 	"node-agent/pkg/networkmanager"
 	networkmanagerv1 "node-agent/pkg/networkmanager/v1"
-	networkmanagerv2 "node-agent/pkg/networkmanager/v2"
 	"node-agent/pkg/objectcache"
 	"node-agent/pkg/objectcache/applicationprofilecache"
 	"node-agent/pkg/objectcache/k8scache"
@@ -211,7 +210,8 @@ func main() {
 		dnsManager := dnsmanager.CreateDNSManager()
 		dnsManagerClient = dnsManager
 		networkManagerv1Client = networkmanagerv1.CreateNetworkManager(ctx, cfg, k8sClient, storageClient, clusterData.ClusterName, dnsManager, preRunningContainersIDs, k8sObjectCache)
-		networkManagerClient = networkmanagerv2.CreateNetworkManager(ctx, cfg, clusterData.ClusterName, k8sClient, storageClient, dnsManager, preRunningContainersIDs, k8sObjectCache)
+		// networkManagerClient = networkmanagerv2.CreateNetworkManager(ctx, cfg, clusterData.ClusterName, k8sClient, storageClient, dnsManager, preRunningContainersIDs, k8sObjectCache)
+		networkManagerClient = networkmanager.CreateNetworkManagerMock()
 	} else {
 		networkManagerv1Client = networkmanagerv1.CreateNetworkManagerMock()
 		networkManagerClient = networkmanager.CreateNetworkManagerMock()

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -350,7 +350,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 						helpers.String("k8s workload", watchedContainer.K8sContainerID))
 				}
 			} else {
-				logger.L().Ctx(ctx).Warning("ApplicationProfileManager - failed to patch application profile, will get existing one and adjust patch", helpers.Error(err),
+				logger.L().Ctx(ctx).Debug("ApplicationProfileManager - failed to patch application profile, will get existing one and adjust patch", helpers.Error(err),
 					helpers.String("slug", slug),
 					helpers.Int("container index", watchedContainer.ContainerIndex),
 					helpers.String("container ID", watchedContainer.ContainerID),

--- a/pkg/networkmanager/v2/network_manager.go
+++ b/pkg/networkmanager/v2/network_manager.go
@@ -339,7 +339,7 @@ func (nm *NetworkManager) saveNetworkEvents(ctx context.Context, watchedContaine
 						helpers.String("k8s workload", watchedContainer.K8sContainerID))
 				}
 			} else {
-				logger.L().Ctx(ctx).Warning("NetworkManager - failed to patch network neighborhood, will get existing one and adjust patch", helpers.Error(err),
+				logger.L().Ctx(ctx).Debug("NetworkManager - failed to patch network neighborhood, will get existing one and adjust patch", helpers.Error(err),
 					helpers.String("slug", slug),
 					helpers.Int("container index", watchedContainer.ContainerIndex),
 					helpers.String("container ID", watchedContainer.ContainerID),

--- a/pkg/rulebindingmanager/types/v1/types.go
+++ b/pkg/rulebindingmanager/types/v1/types.go
@@ -27,11 +27,11 @@ type RuntimeAlertRuleBindingSpec struct {
 }
 
 type RuntimeAlertRuleBindingRule struct {
+	Parameters map[string]interface{} `json:"parameters" yaml:"parameters"`
 	RuleName   string                 `json:"ruleName" yaml:"ruleName"`
 	RuleID     string                 `json:"ruleID" yaml:"ruleID"`
-	RuleTags   []string               `json:"ruleTags" yaml:"ruleTags"`
 	Severity   string                 `json:"severity" yaml:"severity"`
-	Parameters map[string]interface{} `json:"parameters" yaml:"parameters"`
+	RuleTags   []string               `json:"ruleTags" yaml:"ruleTags"`
 }
 
 func (r *RuntimeAlertRuleBindingRule) Equal(other *RuntimeAlertRuleBindingRule) bool {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Replaced `networkmanagerv2` usage with a mock network manager in `main.go` to potentially isolate issues or dependencies.
- Changed logging levels from Warning to Debug in `applicationprofile_manager.go` and `network_manager.go` to reduce log noise.
- Enhanced namespace handling in `rulebindingmanager/cache/cache.go` to improve the robustness of rule binding cache operations.
- Reordered fields in `types.go` for better code clarity and maintainability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Replace networkmanagerv2 with Mock in Main Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.go
<li>Removed import of <code>networkmanagerv2</code>.<br> <li> Commented out the instantiation of <code>networkmanagerv2</code> and replaced it <br>with a mock network manager.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/255/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Enhance Namespace Handling in RuleBinding Cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Added conditional logic to handle namespace listing based on the rule <br>binding's namespace.<br> <li> Improved error handling and logging for namespace listing failures.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/255/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+10/-5</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Reorder Fields in RuntimeAlertRuleBindingRule Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/types/v1/types.go
<li>Reordered fields in <code>RuntimeAlertRuleBindingRule</code> struct for clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/255/files#diff-eb28dcdc4acae4451de4b9f792e253ff8f0d476c1e47c3e706a46eb0cc670950">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Modify Log Level in ApplicationProfileManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Changed log level from Warning to Debug when failing to patch <br>application profile.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/255/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Modify Log Level in NetworkManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/v2/network_manager.go
<li>Changed log level from Warning to Debug when failing to patch network <br>neighborhood.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/255/files#diff-0d21f2a259391c6d4901ddffa2252ee46113d379a1453d54cbcecbbe0fa331f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

