### PR TITLE
Change default MaxAlertsPerMinute

### DIFF
--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -64,7 +64,7 @@ func (config *HTTPExporterConfig) Validate() error {
 		config.TimeoutSeconds = 5
 	}
 	if config.MaxAlertsPerMinute == 0 {
-		config.MaxAlertsPerMinute = 10000
+		config.MaxAlertsPerMinute = 100
 	}
 	if config.Headers == nil {
 		config.Headers = make(map[string]string)

--- a/pkg/exporters/http_exporter_test.go
+++ b/pkg/exporters/http_exporter_test.go
@@ -244,7 +244,7 @@ func TestValidateHTTPExporterConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "POST", exp.config.Method)
 	assert.Equal(t, 5, exp.config.TimeoutSeconds)
-	assert.Equal(t, 10000, exp.config.MaxAlertsPerMinute)
+	assert.Equal(t, 100, exp.config.MaxAlertsPerMinute)
 	assert.Equal(t, map[string]string{}, exp.config.Headers)
 	assert.Equal(t, "cluster", exp.ClusterName)
 	assert.Equal(t, "node", exp.NodeName)

--- a/pkg/rulebindingmanager/cache/cache.go
+++ b/pkg/rulebindingmanager/cache/cache.go
@@ -268,6 +268,10 @@ func (c *RBCache) addPod(ctx context.Context, pod *corev1.Pod) {
 	}
 
 	for _, rb := range c.rbNameToRB.Values() {
+		if rb.GetNamespace() != "" && rb.GetNamespace() != pod.GetNamespace() {
+			// rule binding is not in the same namespace as the pod
+			continue
+		}
 		rbName := rbUniqueName(&rb)
 
 		// check pod selectors

--- a/pkg/rulebindingmanager/cache/cache_test.go
+++ b/pkg/rulebindingmanager/cache/cache_test.go
@@ -938,6 +938,67 @@ func TestAddRuleBinding(t *testing.T) {
 			},
 		},
 		{
+			name: "Add namespaced roleBinding",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rb1",
+					Namespace: "other",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+						{
+							RuleID: "R0002",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{
+				"other/collection-94c495554-z8s5k",
+				"other/nginx-77b4fdf86c-hp4x5",
+			},
+		},
+		{
+			name: "Add namespaced roleBinding without pods",
+			rb: &typesv1.RuntimeAlertRuleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rb1",
+					Namespace: "blabla",
+				},
+				Spec: typesv1.RuntimeAlertRuleBindingSpec{
+					NamespaceSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"other"},
+							},
+						},
+					},
+					Rules: []typesv1.RuntimeAlertRuleBindingRule{
+						{
+							RuleID: "R0001",
+						},
+						{
+							RuleID: "R0002",
+						},
+					},
+				},
+			},
+			expectedNotifiedPods: []string{},
+		},
+		{
 			name: "Add roleBinding exclude namespace 'other'",
 			rb: &typesv1.RuntimeAlertRuleBinding{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement, tests


___

## **Description**
- Reduced the default `MaxAlertsPerMinute` in HTTP exporter configuration from 10000 to 100 to prevent overload.
- Updated corresponding tests to reflect this change in default settings.
- Enhanced rule binding cache logic to consider namespace during pod addition, improving performance and accuracy.
- Added comprehensive tests for the new namespace handling in rule bindings, ensuring robustness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter.go</strong><dd><code>Reduce Default MaxAlertsPerMinute in HTTP Exporter Config</code></dd></summary>
<hr>

pkg/exporters/http_exporter.go
<li>Reduced the default value of <code>MaxAlertsPerMinute</code> from 10000 to 100.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/257/files#diff-6e04fd42d767812ea2855370a21a524371930b320544c0ee0954e1500242fbbd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Enhance Namespace Handling in Rule Binding Cache</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache.go
<li>Added a check to skip rule bindings that are not in the same namespace <br>as the pod.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/257/files#diff-0674d450411ce55370a6341da8d3a34cadffe21ba15112d3f29955de58e51156">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_exporter_test.go</strong><dd><code>Update HTTP Exporter Config Tests for MaxAlertsPerMinute</code>&nbsp; </dd></summary>
<hr>

pkg/exporters/http_exporter_test.go
<li>Updated test to reflect the new default value of <code>MaxAlertsPerMinute</code> <br>(100).


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/257/files#diff-89585231dfa94efdc4cac61ef6426f59bf494acd49c810bb29d56e16574fd350">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cache_test.go</strong><dd><code>Extend Tests for Namespaced Rule Bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulebindingmanager/cache/cache_test.go
<li>Added tests for namespaced rule bindings with and without matching <br>pods.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/257/files#diff-387cbffbe5655030d0bb5dff8e6b40070c87fc8aa5447a5f7762ec6016a41912">+61/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

