### PR TITLE
Cleaning isCached function

### DIFF
--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -128,11 +128,6 @@ func (rm *RuleManager) monitorContainer(ctx context.Context, container *containe
 				syscalls = syscallsFromFunc
 			}
 
-			if !rm.isCached(pod.GetNamespace(), pod.GetName()) {
-				logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", pod.GetNamespace()), helpers.String("name", pod.GetName()))
-				continue
-			}
-
 			rules := rm.ruleBindingCache.ListRulesForPod(pod.GetNamespace(), pod.GetName())
 			for _, syscall := range syscalls {
 				event := ruleenginetypes.SyscallEvent{
@@ -327,10 +322,6 @@ func (rm *RuleManager) ReportCapability(k8sContainerID string, event tracercapab
 		logger.L().Error("RuleManager - failed to get namespace and pod name from ReportCapability event")
 		return
 	}
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
-		return
-	}
 
 	// list capability rules
 	rules := rm.ruleBindingCache.ListRulesForPod(event.GetNamespace(), event.GetPod())
@@ -343,10 +334,6 @@ func (rm *RuleManager) ReportFileExec(k8sContainerID string, event tracerexectyp
 		logger.L().Error("RuleManager - failed to get namespace and pod name from ReportFileExec event")
 		return
 	}
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
-		return
-	}
 
 	// list exec rules
 	rules := rm.ruleBindingCache.ListRulesForPod(event.GetNamespace(), event.GetPod())
@@ -356,10 +343,6 @@ func (rm *RuleManager) ReportFileExec(k8sContainerID string, event tracerexectyp
 func (rm *RuleManager) ReportFileOpen(k8sContainerID string, event traceropentype.Event) {
 	if event.GetNamespace() == "" || event.GetPod() == "" {
 		logger.L().Error("RuleManager - failed to get namespace and pod name from ReportFileOpen event")
-		return
-	}
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
 		return
 	}
 
@@ -374,10 +357,6 @@ func (rm *RuleManager) ReportNetworkEvent(k8sContainerID string, event tracernet
 		logger.L().Error("RuleManager - failed to get namespace and pod name from ReportNetworkEvent event")
 		return
 	}
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
-		return
-	}
 
 	// list network rules
 	rules := rm.ruleBindingCache.ListRulesForPod(event.GetNamespace(), event.GetPod())
@@ -390,10 +369,6 @@ func (rm *RuleManager) ReportDNSEvent(event tracerdnstype.Event) {
 		logger.L().Error("RuleManager - failed to get namespace and pod name from ReportDNSEvent event")
 		return
 	}
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
-		return
-	}
 
 	// list dns rules
 	rules := rm.ruleBindingCache.ListRulesForPod(event.GetNamespace(), event.GetPod())
@@ -404,11 +379,6 @@ func (rm *RuleManager) ReportDNSEvent(event tracerdnstype.Event) {
 func (rm *RuleManager) ReportRandomxEvent(k8sContainerID string, event tracerrandomxtype.Event) {
 	if event.GetNamespace() == "" || event.GetPod() == "" {
 		logger.L().Error("RuleManager - failed to get namespace and pod name from randomx event")
-		return
-	}
-
-	if !rm.isCached(event.GetNamespace(), event.GetPod()) {
-		logger.L().Error("isCached - failed to get pod from cache", helpers.String("namespace", event.GetNamespace()), helpers.String("name", event.GetPod()))
 		return
 	}
 
@@ -587,45 +557,6 @@ func (rm *RuleManager) enrichRuleFailure(ruleFailure ruleengine.RuleFailure) rul
 	ruleFailure.SetRuntimeAlertK8sDetails(runtimek8sdetails)
 
 	return ruleFailure
-}
-
-func (rm *RuleManager) isCached(namespace, name string) bool {
-	return true
-
-	podName := fmt.Sprintf("%s/%s", namespace, name)
-
-	// this will prevent multiple goroutines from waiting for the same pod to be cached
-	// first, try to read lock the pod
-	rm.podInCacheMutexes.RLock(podName)
-
-	if rm.cachedPods.Contains(podName) {
-		rm.podInCacheMutexes.RUnlock(podName)
-		return true
-	}
-	rm.podInCacheMutexes.RUnlock(podName)
-
-	// if the pod is not cached, lock it for writing
-	rm.podInCacheMutexes.Lock(podName)
-	defer rm.podInCacheMutexes.Unlock(podName)
-
-	// check again (because another goroutine might have cached the pod while we were waiting for the lock)
-	if rm.cachedPods.Contains(podName) {
-		return true
-	}
-
-	// wait for pod to be cached
-	if err := backoff.Retry(func() error {
-		if !rm.objectCache.K8sObjectCache().IsCached("Pod", namespace, name) {
-			return fmt.Errorf("pod %s/%s not found in K8sObjectCache", namespace, name)
-		}
-
-		return nil
-	}, backoff.NewExponentialBackOff()); err != nil {
-		return false
-	}
-
-	rm.cachedPods.Add(podName)
-	return true
 }
 
 // Checks if the event type is relevant to the rule.


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Removed the `isCached` function and its usage across multiple event reporting functions in `RuleManager`, which previously added unnecessary complexity and error handling.
- Simplified the event handling process by directly listing rules for pods without checking if they are cached, thereby reducing error logs and improving performance.
- This change enhances the clarity and maintainability of the code by eliminating redundant checks and focusing on essential operations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Simplify Event Handling by Removing Redundant Caching Checks</code></dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Removed redundant error logging and checks for pod caching in various <br>event reporting functions.<br> <li> Simplified the event handling by removing the <code>isCached</code> function and <br>its usage.<br> <li> Enhanced clarity and reduced complexity in the event processing <br>workflow.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/258/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+0/-69</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

