### PR TITLE
Adding pod name to rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.3
 toolchain go1.21.4
 
 require (
-	github.com/armosec/armoapi-go v0.0.379
+	github.com/armosec/armoapi-go v0.0.385
 	github.com/armosec/utils-k8s-go v0.0.26
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cilium/ebpf v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.379 h1:y9pIjRQmfWoQ5zuFS9PRKRsPtZAPWVyDNSYJZBc2I5Q=
-github.com/armosec/armoapi-go v0.0.379/go.mod h1:THr0weLNkxJvZPgwk2GSCtGWw4ERGDYo81g9MqHOUwk=
+github.com/armosec/armoapi-go v0.0.385 h1:zkVQ/ZHcdE8cYP6Ca/tWsgVsgxTQxHfUNQ907RQykE4=
+github.com/armosec/armoapi-go v0.0.385/go.mod h1:THr0weLNkxJvZPgwk2GSCtGWw4ERGDYo81g9MqHOUwk=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.57 h1:0RaqexK+t7HeKWfldBv2C1JiLLGuUx9FP0DGWDNRJpg=

--- a/pkg/exporters/alert_manager.go
+++ b/pkg/exporters/alert_manager.go
@@ -123,7 +123,7 @@ func (ame *AlertManagerExporter) SendMalwareAlert(malwareResult malwaremanager.M
 				"container_name":         malwareResult.GetTriggerEvent().GetBaseEvent().GetContainer(),
 				"namespace":              malwareResult.GetTriggerEvent().GetBaseEvent().GetNamespace(),
 				"pod_name":               malwareResult.GetTriggerEvent().GetBaseEvent().GetPod(),
-				"size":                   *malwareResult.GetBasicRuntimeAlert().Size,
+				"size":                   malwareResult.GetBasicRuntimeAlert().Size,
 				"md5hash":                malwareResult.GetBasicRuntimeAlert().MD5Hash,
 				"sha256hash":             malwareResult.GetBasicRuntimeAlert().SHA256Hash,
 				"sha1hash":               malwareResult.GetBasicRuntimeAlert().SHA1Hash,

--- a/pkg/exporters/alert_manager_test.go
+++ b/pkg/exporters/alert_manager_test.go
@@ -95,11 +95,10 @@ func TestSendMalwareAlert(t *testing.T) {
 		t.Fatalf("Failed to create new Alertmanager exporter")
 	}
 	// Call SendAlert
-	sizeStr := "2MiB"
 	exporter.SendMalwareAlert(&mmtypes.GenericMalwareResult{
 		BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:  "testmalware",
-			Size:       &sizeStr,
+			Size:       "2MiB",
 			MD5Hash:    "testmalwarehash",
 			SHA1Hash:   "testmalwarehash",
 			SHA256Hash: "testmalwarehash",

--- a/pkg/exporters/csv_exporter.go
+++ b/pkg/exporters/csv_exporter.go
@@ -122,7 +122,7 @@ func (ce *CsvExporter) SendMalwareAlert(malwareResult malwaremanager.MalwareResu
 		malwareResult.GetBasicRuntimeAlert().MD5Hash,
 		malwareResult.GetBasicRuntimeAlert().SHA256Hash,
 		malwareResult.GetBasicRuntimeAlert().SHA1Hash,
-		*malwareResult.GetBasicRuntimeAlert().Size,
+		malwareResult.GetBasicRuntimeAlert().Size,
 		malwareResult.GetTriggerEvent().GetBaseEvent().GetNamespace(),
 		malwareResult.GetTriggerEvent().GetBaseEvent().GetPod(),
 		malwareResult.GetTriggerEvent().GetBaseEvent().GetContainer(),

--- a/pkg/exporters/csv_exporter_test.go
+++ b/pkg/exporters/csv_exporter_test.go
@@ -31,11 +31,10 @@ func TestCsvExporter(t *testing.T) {
 			RuleDescription: "Application profile is missing",
 		},
 	})
-	sizeStr := "2MiB"
 	csvExporter.SendMalwareAlert(&mmtypes.GenericMalwareResult{
 		BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:  "testmalware",
-			Size:       &sizeStr,
+			Size:       "2MiB",
 			MD5Hash:    "testmalwarehash",
 			SHA1Hash:   "testmalwarehash",
 			SHA256Hash: "testmalwarehash",

--- a/pkg/exporters/http_exporter_test.go
+++ b/pkg/exporters/http_exporter_test.go
@@ -165,11 +165,10 @@ func TestSendMalwareAlertHTTPExporter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a mock malware description
-	sizeStr := "2MiB"
 	malwareDesc := &mmtypes.GenericMalwareResult{
 		BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:  "testmalware",
-			Size:       &sizeStr,
+			Size:       "2MiB",
 			MD5Hash:    "testmalwarehash",
 			SHA1Hash:   "testmalwarehash",
 			SHA256Hash: "testmalwarehash",

--- a/pkg/exporters/syslog_exporter.go
+++ b/pkg/exporters/syslog_exporter.go
@@ -146,7 +146,7 @@ func (se *SyslogExporter) SendMalwareAlert(malwareResult malwaremanager.MalwareR
 					},
 					{
 						Name:  "size",
-						Value: *malwareResult.GetBasicRuntimeAlert().Size,
+						Value: malwareResult.GetBasicRuntimeAlert().Size,
 					},
 					{
 						Name:  "namespace",

--- a/pkg/exporters/syslog_exporter_test.go
+++ b/pkg/exporters/syslog_exporter_test.go
@@ -93,12 +93,11 @@ func TestSyslogExporter(t *testing.T) {
 			RuleDescription: "Application profile is missing",
 		},
 	})
-	sizeStr := "2MiB"
 
 	syslogExp.SendMalwareAlert(&mmtypes.GenericMalwareResult{
 		BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
 			AlertName:  "testmalware",
-			Size:       &sizeStr,
+			Size:       "2MiB",
 			MD5Hash:    "testmalwarehash",
 			SHA1Hash:   "testmalwarehash",
 			SHA256Hash: "testmalwarehash",

--- a/pkg/malwaremanager/v1/clamav/clamav.go
+++ b/pkg/malwaremanager/v1/clamav/clamav.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"node-agent/pkg/malwaremanager"
 	mmtypes "node-agent/pkg/malwaremanager/v1/types"
+	"node-agent/pkg/utils"
 	nautils "node-agent/pkg/utils"
 	"time"
 
@@ -107,30 +108,27 @@ func (c *ClamAVClient) handleExecEvent(execEvent *tracerexectype.Event, containe
 				logger.L().Error("Error getting file size of %s", helpers.String("path", result.Path), helpers.Error(err))
 			}
 			path := strings.TrimPrefix(result.Path, os.Getenv("HOST_ROOT"))
-			commandLine := fmt.Sprintf("%s %s", execEvent.Comm, strings.Join(execEvent.Args, " "))
-			sizeStr := humanize.IBytes(uint64(size))
+
+			commandLine := fmt.Sprintf("%s %s", utils.GetExecPathFromEvent(execEvent), utils.GetExecArgsFromEvent(execEvent))
 			return &mmtypes.GenericMalwareResult{
 				BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
-					AlertName:   result.Description,
-					InfectedPID: execEvent.Pid,
-					Arguments: map[string]interface{}{
-						"hardlink": execEvent.ExePath,
-						"path":     path,
-					},
+					AlertName:      result.Description,
+					InfectedPID:    execEvent.Pid,
 					FixSuggestions: FixSuggestions,
 					SHA1Hash:       sha1hash,
 					SHA256Hash:     sha256hash,
 					MD5Hash:        md5hash,
 					Severity:       10, // TODO: Get severity from api.
-					Size:           &sizeStr,
+					Size:           humanize.IBytes(uint64(size)),
 					Timestamp:      time.Unix(int64(execEvent.Timestamp), 0),
 				},
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm:       execEvent.Comm,
-						Gid:        execEvent.Gid,
+						Path:       path,
+						Gid:        &execEvent.Gid,
 						PID:        execEvent.Pid,
-						Uid:        execEvent.Uid,
+						Uid:        &execEvent.Uid,
 						UpperLayer: execEvent.UpperLayer,
 						PPID:       execEvent.Ppid,
 						Pcomm:      execEvent.Pcomm,
@@ -199,26 +197,25 @@ func (c *ClamAVClient) handleOpenEvent(openEvent *traceropentype.Event, containe
 			}
 
 			path := strings.TrimPrefix(result.Path, os.Getenv("HOST_ROOT"))
-			sizeStr := humanize.IBytes(uint64(size))
 			return &mmtypes.GenericMalwareResult{
 				BasicRuntimeAlert: apitypes.BaseRuntimeAlert{
 					AlertName:      result.Description,
-					Arguments:      map[string]interface{}{"path": path},
 					InfectedPID:    openEvent.Pid,
 					FixSuggestions: FixSuggestions,
 					SHA1Hash:       sha1hash,
 					SHA256Hash:     sha256hash,
 					MD5Hash:        md5hash,
 					Severity:       10, // TODO: Get severity from api.
-					Size:           &sizeStr,
+					Size:           humanize.IBytes(uint64(size)),
 					Timestamp:      time.Unix(int64(openEvent.Timestamp), 0),
 				},
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm: openEvent.Comm,
-						Gid:  openEvent.Gid,
+						Path: path,
+						Gid:  &openEvent.Gid,
 						PID:  openEvent.Pid,
-						Uid:  openEvent.Uid,
+						Uid:  &openEvent.Uid,
 					},
 					ContainerID: openEvent.Runtime.ContainerID,
 				},

--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -230,14 +230,12 @@ func (mm *MalwareManager) enrichMalwareResult(malwareResult malwaremanager.Malwa
 		baseRuntimeAlert.SHA256Hash = sha256hash
 	}
 
-	if baseRuntimeAlert.Size == nil && hostPath != "" {
+	if baseRuntimeAlert.Size == "" && hostPath != "" {
 		size, err := utils.GetFileSize(hostPath)
 		if err != nil {
-			sizeStr := ""
-			baseRuntimeAlert.Size = &sizeStr
+			baseRuntimeAlert.Size = ""
 		} else {
-			size := humanize.Bytes(uint64(size))
-			baseRuntimeAlert.Size = &size
+			baseRuntimeAlert.Size = humanize.Bytes(uint64(size))
 		}
 	}
 
@@ -280,6 +278,10 @@ func (mm *MalwareManager) enrichMalwareResult(malwareResult malwaremanager.Malwa
 			comm = ""
 		}
 		runtimeProcessDetails.ProcessTree.Comm = comm
+	}
+
+	if runtimeProcessDetails.ProcessTree.Path == "" && path != "" {
+		runtimeProcessDetails.ProcessTree.Path = path
 	}
 
 	if mm.containerIdToShimPid.Has(malwareResult.GetRuntimeProcessDetails().ContainerID) {

--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
@@ -122,6 +122,9 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType utils.EventTy
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected process launched: %s in: %s", execPath, execEvent.GetContainer()),
 		},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: execEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
@@ -105,9 +105,9 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType utils.EventTy
 		RuntimeProcessDetails: apitypes.ProcessTree{
 			ProcessTree: apitypes.Process{
 				Comm:       execEvent.Comm,
-				Gid:        execEvent.Gid,
+				Gid:        &execEvent.Gid,
 				PID:        execEvent.Pid,
-				Uid:        execEvent.Uid,
+				Uid:        &execEvent.Uid,
 				UpperLayer: execEvent.UpperLayer,
 				PPID:       execEvent.Ppid,
 				Pcomm:      execEvent.Pcomm,

--- a/pkg/ruleengine/v1/r0002_unexpected_file_access.go
+++ b/pkg/ruleengine/v1/r0002_unexpected_file_access.go
@@ -186,6 +186,9 @@ func (rule *R0002UnexpectedFileAccess) ProcessEvent(eventType utils.EventType, e
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected file access: %s with flags %s in: %s", openEvent.Path, strings.Join(openEvent.Flags, ","), openEvent.GetContainer()),
 		},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: openEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0002_unexpected_file_access.go
+++ b/pkg/ruleengine/v1/r0002_unexpected_file_access.go
@@ -175,9 +175,9 @@ func (rule *R0002UnexpectedFileAccess) ProcessEvent(eventType utils.EventType, e
 		RuntimeProcessDetails: apitypes.ProcessTree{
 			ProcessTree: apitypes.Process{
 				Comm: openEvent.Comm,
-				Gid:  openEvent.Gid,
+				Gid:  &openEvent.Gid,
 				PID:  openEvent.Pid,
-				Uid:  openEvent.Uid,
+				Uid:  &openEvent.Uid,
 			},
 			ContainerID: openEvent.Runtime.ContainerID,
 		},

--- a/pkg/ruleengine/v1/r0003_unexpected_system_call.go
+++ b/pkg/ruleengine/v1/r0003_unexpected_system_call.go
@@ -105,7 +105,9 @@ func (rule *R0003UnexpectedSystemCall) ProcessEvent(eventType utils.EventType, e
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected system call: %s in: %s", syscallEvent.SyscallName, syscallEvent.GetContainer()),
 		},
-		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: syscallEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
+++ b/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
@@ -102,7 +102,9 @@ func (rule *R0004UnexpectedCapabilityUsed) ProcessEvent(eventType utils.EventTyp
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected capability used (capability %s used in syscall %s) in: %s", capEvent.CapName, capEvent.Syscall, capEvent.GetContainer()),
 		},
-		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: capEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
+++ b/pkg/ruleengine/v1/r0004_unexpected_capability_used.go
@@ -91,9 +91,9 @@ func (rule *R0004UnexpectedCapabilityUsed) ProcessEvent(eventType utils.EventTyp
 		RuntimeProcessDetails: apitypes.ProcessTree{
 			ProcessTree: apitypes.Process{
 				Comm: capEvent.Comm,
-				Gid:  capEvent.Gid,
+				Gid:  &capEvent.Gid,
 				PID:  capEvent.Pid,
-				Uid:  capEvent.Uid,
+				Uid:  &capEvent.Uid,
 			},
 			ContainerID: capEvent.Runtime.ContainerID,
 		},

--- a/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
+++ b/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
@@ -91,9 +91,9 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType utils.EventType
 		RuntimeProcessDetails: apitypes.ProcessTree{
 			ProcessTree: apitypes.Process{
 				Comm: domainEvent.Comm,
-				Gid:  domainEvent.Gid,
+				Gid:  &domainEvent.Gid,
 				PID:  domainEvent.Pid,
-				Uid:  domainEvent.Uid,
+				Uid:  &domainEvent.Uid,
 			},
 			ContainerID: domainEvent.Runtime.ContainerID,
 		},

--- a/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
+++ b/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
@@ -102,7 +102,9 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType utils.EventType
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected domain communication: %s from: %s", domainEvent.DNSName, domainEvent.GetContainer()),
 		},
-		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: domainEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
+++ b/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
@@ -124,9 +124,9 @@ func (rule *R0006UnexpectedServiceAccountTokenAccess) ProcessEvent(eventType uti
 		RuntimeProcessDetails: apitypes.ProcessTree{
 			ProcessTree: apitypes.Process{
 				Comm: openEvent.Comm,
-				Gid:  openEvent.Gid,
+				Gid:  &openEvent.Gid,
 				PID:  openEvent.Pid,
-				Uid:  openEvent.Uid,
+				Uid:  &openEvent.Uid,
 			},
 			ContainerID: openEvent.Runtime.ContainerID,
 		},

--- a/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
+++ b/pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
@@ -135,7 +135,9 @@ func (rule *R0006UnexpectedServiceAccountTokenAccess) ProcessEvent(eventType uti
 			RuleID:          rule.ID(),
 			RuleDescription: fmt.Sprintf("Unexpected access to service account token: %s with flags: %s in: %s", openEvent.Path, strings.Join(openEvent.Flags, ","), openEvent.GetContainer()),
 		},
-		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+		RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+			PodName: openEvent.GetPod(),
+		},
 	}
 
 	return &ruleFailure

--- a/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
+++ b/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
@@ -112,7 +112,9 @@ func (rule *R0007KubernetesClientExecuted) handleNetworkEvent(event *tracernetwo
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Kubernetes client executed: %s", event.Comm),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: event.GetPod(),
+			},
 		}
 
 		return &ruleFailure
@@ -166,7 +168,9 @@ func (rule *R0007KubernetesClientExecuted) handleExecEvent(event *tracerexectype
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Kubernetes client %s was executed in: %s", execPath, event.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: event.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
+++ b/pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
@@ -101,9 +101,9 @@ func (rule *R0007KubernetesClientExecuted) handleNetworkEvent(event *tracernetwo
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm: event.Comm,
-					Gid:  event.Gid,
+					Gid:  &event.Gid,
 					PID:  event.Pid,
-					Uid:  event.Uid,
+					Uid:  &event.Uid,
 				},
 				ContainerID: event.Runtime.ContainerID,
 			},
@@ -151,9 +151,9 @@ func (rule *R0007KubernetesClientExecuted) handleExecEvent(event *tracerexectype
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm:       event.Comm,
-					Gid:        event.Gid,
+					Gid:        &event.Gid,
 					PID:        event.Pid,
-					Uid:        event.Uid,
+					Uid:        &event.Uid,
 					UpperLayer: event.UpperLayer,
 					PPID:       event.Ppid,
 					Pcomm:      event.Pcomm,

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -89,9 +89,9 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm:       execEvent.Comm,
-						Gid:        execEvent.Gid,
+						Gid:        &execEvent.Gid,
 						PID:        execEvent.Pid,
-						Uid:        execEvent.Uid,
+						Uid:        &execEvent.Uid,
 						UpperLayer: execEvent.UpperLayer,
 						PPID:       execEvent.Ppid,
 						Pcomm:      execEvent.Pcomm,

--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -106,7 +106,9 @@ func (rule *R1000ExecFromMaliciousSource) ProcessEvent(eventType utils.EventType
 					RuleID:          rule.ID(),
 					RuleDescription: fmt.Sprintf("Execution from malicious source: %s in: %s", execPath, execEvent.GetContainer()),
 				},
-				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+					PodName: execEvent.GetPod(),
+				},
 			}
 
 			return &ruleFailure

--- a/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
@@ -71,9 +71,9 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventTyp
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm:       execEvent.Comm,
-					Gid:        execEvent.Gid,
+					Gid:        &execEvent.Gid,
 					PID:        execEvent.Pid,
-					Uid:        execEvent.Uid,
+					Uid:        &execEvent.Uid,
 					UpperLayer: execEvent.UpperLayer,
 					PPID:       execEvent.Ppid,
 					Pcomm:      execEvent.Pcomm,

--- a/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
@@ -88,7 +88,9 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventTyp
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Process (%s) was executed in: %s and is not part of the image", execEvent.Comm, execEvent.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: execEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r1002_load_kernel_module.go
+++ b/pkg/ruleengine/v1/r1002_load_kernel_module.go
@@ -88,7 +88,9 @@ func (rule *R1002LoadKernelModule) ProcessEvent(eventType utils.EventType, event
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Kernel module load syscall (init_module) was called in: %s", syscallEvent.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: syscallEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r1002_load_kernel_module.go
+++ b/pkg/ruleengine/v1/r1002_load_kernel_module.go
@@ -77,9 +77,9 @@ func (rule *R1002LoadKernelModule) ProcessEvent(eventType utils.EventType, event
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm: syscallEvent.Comm,
-					Gid:  syscallEvent.Gid,
+					Gid:  &syscallEvent.Gid,
 					PID:  syscallEvent.Pid,
-					Uid:  syscallEvent.Uid,
+					Uid:  &syscallEvent.Uid,
 				},
 				ContainerID: syscallEvent.Runtime.ContainerID,
 			},

--- a/pkg/ruleengine/v1/r1003_malicious_ssh_connection.go
+++ b/pkg/ruleengine/v1/r1003_malicious_ssh_connection.go
@@ -169,7 +169,9 @@ func (rule *R1003MaliciousSSHConnection) ProcessEvent(eventType utils.EventType,
 					RuleID:          rule.ID(),
 					RuleDescription: fmt.Sprintf("SSH connection to disallowed port %d", networkEvent.Port),
 				},
-				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+					PodName: networkEvent.GetPod(),
+				},
 			}
 
 			return &ruleFailure

--- a/pkg/ruleengine/v1/r1003_malicious_ssh_connection.go
+++ b/pkg/ruleengine/v1/r1003_malicious_ssh_connection.go
@@ -158,9 +158,9 @@ func (rule *R1003MaliciousSSHConnection) ProcessEvent(eventType utils.EventType,
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm: networkEvent.Comm,
-						Gid:  networkEvent.Gid,
+						Gid:  &networkEvent.Gid,
 						PID:  networkEvent.Pid,
-						Uid:  networkEvent.Uid,
+						Uid:  &networkEvent.Uid,
 					},
 					ContainerID: networkEvent.Runtime.ContainerID,
 				},

--- a/pkg/ruleengine/v1/r1004_exec_from_mount.go
+++ b/pkg/ruleengine/v1/r1004_exec_from_mount.go
@@ -79,9 +79,9 @@ func (rule *R1004ExecFromMount) ProcessEvent(eventType utils.EventType, event in
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm:       execEvent.Comm,
-						Gid:        execEvent.Gid,
+						Gid:        &execEvent.Gid,
 						PID:        execEvent.Pid,
-						Uid:        execEvent.Uid,
+						Uid:        &execEvent.Uid,
 						UpperLayer: execEvent.UpperLayer,
 						PPID:       execEvent.Ppid,
 						Pcomm:      execEvent.Pcomm,

--- a/pkg/ruleengine/v1/r1004_exec_from_mount.go
+++ b/pkg/ruleengine/v1/r1004_exec_from_mount.go
@@ -96,7 +96,9 @@ func (rule *R1004ExecFromMount) ProcessEvent(eventType utils.EventType, event in
 					RuleID:          rule.ID(),
 					RuleDescription: fmt.Sprintf("Process (%s) was executed from a mounted path (%s) in: %s", p, mount, execEvent.GetContainer()),
 				},
-				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+					PodName: execEvent.GetPod(),
+				},
 			}
 
 			return &ruleFailure

--- a/pkg/ruleengine/v1/r1005_fileless_execution.go
+++ b/pkg/ruleengine/v1/r1005_fileless_execution.go
@@ -84,9 +84,9 @@ func (rule *R1005FilelessExecution) handleSyscallEvent(syscallEvent *ruleenginet
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm: syscallEvent.Comm,
-					Gid:  syscallEvent.Gid,
+					Gid:  &syscallEvent.Gid,
 					PID:  syscallEvent.Pid,
-					Uid:  syscallEvent.Uid,
+					Uid:  &syscallEvent.Uid,
 				},
 				ContainerID: syscallEvent.Runtime.ContainerID,
 			},
@@ -134,9 +134,9 @@ func (rule *R1005FilelessExecution) handleExecveEvent(execEvent *tracerexectype.
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm:       execEvent.Comm,
-					Gid:        execEvent.Gid,
+					Gid:        &execEvent.Gid,
 					PID:        execEvent.Pid,
-					Uid:        execEvent.Uid,
+					Uid:        &execEvent.Uid,
 					UpperLayer: execEvent.UpperLayer,
 					PPID:       execEvent.Ppid,
 					Pcomm:      execEvent.Pcomm,

--- a/pkg/ruleengine/v1/r1005_fileless_execution.go
+++ b/pkg/ruleengine/v1/r1005_fileless_execution.go
@@ -95,7 +95,9 @@ func (rule *R1005FilelessExecution) handleSyscallEvent(syscallEvent *ruleenginet
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Fileless execution detected: syscall memfd_create executed in: %s", syscallEvent.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: syscallEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure
@@ -149,7 +151,9 @@ func (rule *R1005FilelessExecution) handleExecveEvent(execEvent *tracerexectype.
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("Fileless execution detected: exec call \"%s\" is from a malicious source \"%s\"", execPath, "/proc/self/fd"),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: execEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r1006_unshare_system_call.go
+++ b/pkg/ruleengine/v1/r1006_unshare_system_call.go
@@ -90,7 +90,9 @@ func (rule *R1006UnshareSyscall) ProcessEvent(eventType utils.EventType, event i
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("unshare system call executed in %s", syscallEvent.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: syscallEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r1006_unshare_system_call.go
+++ b/pkg/ruleengine/v1/r1006_unshare_system_call.go
@@ -79,9 +79,9 @@ func (rule *R1006UnshareSyscall) ProcessEvent(eventType utils.EventType, event i
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm: syscallEvent.Comm,
-					Gid:  syscallEvent.Gid,
+					Gid:  &syscallEvent.Gid,
 					PID:  syscallEvent.Pid,
-					Uid:  syscallEvent.Uid,
+					Uid:  &syscallEvent.Uid,
 				},
 				ContainerID: syscallEvent.Runtime.ContainerID,
 			},

--- a/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
+++ b/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
@@ -82,7 +82,9 @@ func (rule *R1007XMRCryptoMining) ProcessEvent(eventType utils.EventType, event 
 				RuleID:          rule.ID(),
 				RuleDescription: fmt.Sprintf("XMR Crypto Miner process: (%s) executed in: %s", randomXEvent.Comm, randomXEvent.GetContainer()),
 			},
-			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+			RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+				PodName: randomXEvent.GetPod(),
+			},
 		}
 
 		return &ruleFailure

--- a/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
+++ b/pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
@@ -69,9 +69,9 @@ func (rule *R1007XMRCryptoMining) ProcessEvent(eventType utils.EventType, event 
 			RuntimeProcessDetails: apitypes.ProcessTree{
 				ProcessTree: apitypes.Process{
 					Comm:       randomXEvent.Comm,
-					Gid:        randomXEvent.Gid,
+					Gid:        &randomXEvent.Gid,
 					PID:        randomXEvent.Pid,
-					Uid:        randomXEvent.Uid,
+					Uid:        &randomXEvent.Uid,
 					UpperLayer: randomXEvent.UpperLayer,
 					PPID:       randomXEvent.PPid,
 				},

--- a/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
+++ b/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
@@ -178,9 +178,9 @@ func (rule *R1008CryptoMiningDomainCommunication) ProcessEvent(eventType utils.E
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm: dnsEvent.Comm,
-						Gid:  dnsEvent.Gid,
+						Gid:  &dnsEvent.Gid,
 						PID:  dnsEvent.Pid,
-						Uid:  dnsEvent.Uid,
+						Uid:  &dnsEvent.Uid,
 					},
 					ContainerID: dnsEvent.Runtime.ContainerID,
 				},

--- a/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
+++ b/pkg/ruleengine/v1/r1008_crypto_mining_domain.go
@@ -189,7 +189,9 @@ func (rule *R1008CryptoMiningDomainCommunication) ProcessEvent(eventType utils.E
 					RuleID:          rule.ID(),
 					RuleDescription: fmt.Sprintf("Communication with a known crypto mining domain: %s in: %s", dnsEvent.DNSName, dnsEvent.GetContainer()),
 				},
-				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+					PodName: dnsEvent.GetPod(),
+				},
 			}
 
 			return &ruleFailure

--- a/pkg/ruleengine/v1/r1009_crypto_mining_port.go
+++ b/pkg/ruleengine/v1/r1009_crypto_mining_port.go
@@ -75,9 +75,9 @@ func (rule *R1009CryptoMiningRelatedPort) ProcessEvent(eventType utils.EventType
 				RuntimeProcessDetails: apitypes.ProcessTree{
 					ProcessTree: apitypes.Process{
 						Comm: networkEvent.Comm,
-						Gid:  networkEvent.Gid,
+						Gid:  &networkEvent.Gid,
 						PID:  networkEvent.Pid,
-						Uid:  networkEvent.Uid,
+						Uid:  &networkEvent.Uid,
 					},
 					ContainerID: networkEvent.Runtime.ContainerID,
 				},

--- a/pkg/ruleengine/v1/r1009_crypto_mining_port.go
+++ b/pkg/ruleengine/v1/r1009_crypto_mining_port.go
@@ -86,7 +86,9 @@ func (rule *R1009CryptoMiningRelatedPort) ProcessEvent(eventType utils.EventType
 					RuleID:          rule.ID(),
 					RuleDescription: fmt.Sprintf("Communication on a commonly used crypto mining port: %d in: %s", networkEvent.Port, networkEvent.GetContainer()),
 				},
-				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{},
+				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
+					PodName: networkEvent.GetPod(),
+				},
 			}
 
 			return &ruleFailure

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -449,14 +449,12 @@ func (rm *RuleManager) enrichRuleFailure(ruleFailure ruleengine.RuleFailure) rul
 		baseRuntimeAlert.SHA256Hash = sha256hash
 	}
 
-	if baseRuntimeAlert.Size == nil && hostPath != "" {
+	if baseRuntimeAlert.Size == "" && hostPath != "" {
 		size, err := utils.GetFileSize(hostPath)
 		if err != nil {
-			sizeStr := ""
-			baseRuntimeAlert.Size = &sizeStr
+			baseRuntimeAlert.Size = ""
 		} else {
-			size := humanize.Bytes(uint64(size))
-			baseRuntimeAlert.Size = &size
+			baseRuntimeAlert.Size = humanize.Bytes(uint64(size))
 		}
 	}
 
@@ -499,6 +497,10 @@ func (rm *RuleManager) enrichRuleFailure(ruleFailure ruleengine.RuleFailure) rul
 			comm = ""
 		}
 		runtimeProcessDetails.ProcessTree.Comm = comm
+	}
+
+	if runtimeProcessDetails.ProcessTree.Path == "" && path != "" {
+		runtimeProcessDetails.ProcessTree.Path = path
 	}
 
 	if rm.containerIdToShimPid.Has(ruleFailure.GetRuntimeProcessDetails().ContainerID) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -571,6 +571,13 @@ func buildProcessTree(proc procfs.Proc, procfs *procfs.FS, shimPid uint32, proce
 	// Make the parent process the parent of the current process (move the current process to the parent's children).
 	currentProcess := apitypes.Process{
 		Comm: stat.Comm,
+		Path: func() string {
+			path, err := proc.Executable()
+			if err != nil {
+				return ""
+			}
+			return path
+		}(),
 		// TODO: Hardlink
 		// TODO: UpperLayer
 		PID:  uint32(stat.PID),
@@ -589,8 +596,8 @@ func buildProcessTree(proc procfs.Proc, procfs *procfs.FS, shimPid uint32, proce
 			}
 			return pcomm
 		}(),
-		Gid: gid,
-		Uid: uid,
+		Gid: &gid,
+		Uid: &uid,
 		Cwd: func() string {
 			cwd, err := proc.Cwd()
 			if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -651,3 +651,17 @@ func GetCommFromPid(pid uint32) (string, error) {
 
 	return comm, nil
 }
+
+func GetProcessFromProcessTree(process *apitypes.Process, pid uint32) *apitypes.Process {
+	if process.PID == pid {
+		return process
+	}
+
+	for i := range process.Children {
+		if p := GetProcessFromProcessTree(&process.Children[i], pid); p != nil {
+			return p
+		}
+	}
+
+	return nil
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	apitypes "github.com/armosec/armoapi-go/armotypes"
 	"github.com/kubescape/k8s-interface/instanceidhandler/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -218,6 +220,64 @@ func Test_GetLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetLabels(tt.args.watchedContainer, tt.args.stripContainer)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetProcessFromProcessTree(t *testing.T) {
+	type args struct {
+		process *apitypes.Process
+		pid     uint32
+	}
+	tests := []struct {
+		name string
+		args args
+		want *apitypes.Process
+	}{
+		{
+			name: "Test Case 1: Process found in tree",
+			args: args{
+				process: &apitypes.Process{
+					PID: 1,
+					Children: []apitypes.Process{
+						{
+							PID: 2,
+						},
+						{
+							PID: 3,
+						},
+					},
+				},
+				pid: 2,
+			},
+			want: &apitypes.Process{
+				PID: 2,
+			},
+		},
+		{
+			name: "Test Case 2: Process not found in tree",
+			args: args{
+				process: &apitypes.Process{
+					PID: 1,
+					Children: []apitypes.Process{
+						{
+							PID: 2,
+						},
+						{
+							PID: 3,
+						},
+					},
+				},
+				pid: 4,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetProcessFromProcessTree(tt.args.process, tt.args.pid); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetProcessFromProcessTree() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Enhancement


___

## **Description**
- Enhanced multiple security rules to include Kubernetes pod name details in the alert descriptions.
- This update applies to a wide range of rule alerts including unexpected process launches, file accesses, system calls, and more.
- The inclusion of pod names aims to provide more contextual information in security alerts, improving the monitoring and troubleshooting processes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>r0001_unexpected_process_launched.go</strong><dd><code>Include Pod Name in Unexpected Process Launch Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0001_unexpected_process_launched.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>process launches.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-ac1a37fd641e5d6211b057e4cbc91e8e5d6fad1ebdf030ad944240e92c48bffe">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0002_unexpected_file_access.go</strong><dd><code>Include Pod Name in Unexpected File Access Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0002_unexpected_file_access.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>file access.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-90d1aefc909570233d7720d28979df55666d6e53899a1804cb20fea684236645">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0003_unexpected_system_call.go</strong><dd><code>Include Pod Name in Unexpected System Call Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0003_unexpected_system_call.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>system calls.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-568cbe0cc0bf0dd1a7e5d0888401264dffa3e1d0fa2f2c842707838a180e8b5f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0004_unexpected_capability_used.go</strong><dd><code>Include Pod Name in Unexpected Capability Usage Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0004_unexpected_capability_used.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>capability usage.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-6dc1f7271d498e55fae382df54c7ec5cdb80420bff7e5b2483475b5e69958a8c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0005_unexpected_domain_request.go</strong><dd><code>Include Pod Name in Unexpected Domain Request Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0005_unexpected_domain_request.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>domain requests.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-fe45fd0bea6a18b7edee9a1e285e10ce183b9ae962a0d5e441c4bfbd33ab47af">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0006_unexpected_service_account_token_access.go</strong><dd><code>Include Pod Name in Unexpected Service Account Token Access Alert</code></dd></summary>
<hr>

pkg/ruleengine/v1/r0006_unexpected_service_account_token_access.go
<li>Added Kubernetes pod name details to the rule alert for unexpected <br>service account token access.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-397dd96e7b0070e47905927ec1d599ef0cae06f2dcaaa1af58743ebd710f9fa5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0007_kubernetes_client_executed.go</strong><dd><code>Include Pod Name in Kubernetes Client Execution Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0007_kubernetes_client_executed.go
<li>Added Kubernetes pod name details to the rule alert for executed <br>Kubernetes client.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-c7f3697d600957bfc81d25f2f4f3ad77f03a09775a62f1a878856621f88ad653">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1000_exec_from_malicious_source.go</strong><dd><code>Include Pod Name in Execution from Malicious Source Alert</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
<li>Added Kubernetes pod name details to the rule alert for execution from <br>malicious sources.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-00351ce4b75a85e267a68663f357265bbcc7721c2e461fa6112363fdfb2150c5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1001_exec_binary_not_in_base_image.go</strong><dd><code>Include Pod Name in Binary Not in Base Image Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
<li>Added Kubernetes pod name details to the rule alert for binaries not <br>in base image.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-8479b29787e63469835f6fcaeb959853977447da62ee58f8f09e07b3e596f330">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1002_load_kernel_module.go</strong><dd><code>Include Pod Name in Kernel Module Load Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1002_load_kernel_module.go
<li>Added Kubernetes pod name details to the rule alert for kernel module <br>loads.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-f80cb11de3abc1ce0efc94eebb11abfeda71d4ce628d1c4694bd9472b1a16544">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1003_malicious_ssh_connection.go</strong><dd><code>Include Pod Name in Malicious SSH Connection Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1003_malicious_ssh_connection.go
<li>Added Kubernetes pod name details to the rule alert for malicious SSH <br>connections.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-4caaeaf9d44ed40d0917224bc264b00ef40c6516b5672eed2020e68de8c5c7fe">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1004_exec_from_mount.go</strong><dd><code>Include Pod Name in Execution from Mount Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1004_exec_from_mount.go
<li>Added Kubernetes pod name details to the rule alert for execution from <br>mounts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-8f5b768a5ef0c288aced9e6b01d68113ed010afcf9df9343db29b6d5376b80ef">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1005_fileless_execution.go</strong><dd><code>Include Pod Name in Fileless Execution Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1005_fileless_execution.go
<li>Added Kubernetes pod name details to the rule alert for fileless <br>executions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-ef0155bc510f47092b9799316b90b72f6eda3347ee96da897e27fe9961f06792">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1006_unshare_system_call.go</strong><dd><code>Include Pod Name in Unshare System Call Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1006_unshare_system_call.go
<li>Added Kubernetes pod name details to the rule alert for unshare system <br>calls.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-120d22ed5d0fa78ea4fe1404b171433cf9483309e16a4489486e69bcfef136f2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1007_xmr_crypto_mining.go</strong><dd><code>Include Pod Name in XMR Crypto Mining Alert</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r1007_xmr_crypto_mining.go
<li>Added Kubernetes pod name details to the rule alert for XMR crypto <br>mining processes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-97cc4a4c5d887aedfe4d9384769e20249ab46018c83988d9ddedf57a984016c0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1008_crypto_mining_domain.go</strong><dd><code>Include Pod Name in Crypto Mining Domain Communication Alert</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1008_crypto_mining_domain.go
<li>Added Kubernetes pod name details to the rule alert for crypto mining <br>domain communications.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-6789c9f27a5f55cdaf52ed9dbf4b560714092348f28a38ccdfe86cc64e356259">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r1009_crypto_mining_port.go</strong><dd><code>Include Pod Name in Crypto Mining Related Port Communication Alert</code></dd></summary>
<hr>

pkg/ruleengine/v1/r1009_crypto_mining_port.go
<li>Added Kubernetes pod name details to the rule alert for crypto mining <br>related port communications.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/260/files#diff-947f67400948fbd3b67f9d5322bc87e5b74955b4d4b87ebd290a75dc6c189914">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

