### PR TITLE
Adding a fix for the container name

### DIFF
--- a/pkg/malwaremanager/v1/clamav/clamav.go
+++ b/pkg/malwaremanager/v1/clamav/clamav.go
@@ -144,7 +144,7 @@ func (c *ClamAVClient) handleExecEvent(execEvent *tracerexectype.Event, containe
 				},
 				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
 					ContainerID:   execEvent.Runtime.ContainerID,
-					ContainerName: execEvent.Runtime.ContainerName,
+					ContainerName: execEvent.K8s.ContainerName,
 					Namespace:     execEvent.GetNamespace(),
 					PodName:       execEvent.GetPod(),
 					PodNamespace:  execEvent.GetNamespace(),
@@ -225,7 +225,7 @@ func (c *ClamAVClient) handleOpenEvent(openEvent *traceropentype.Event, containe
 				},
 				RuntimeAlertK8sDetails: apitypes.RuntimeAlertK8sDetails{
 					ContainerID:   openEvent.Runtime.ContainerID,
-					ContainerName: openEvent.Runtime.ContainerName,
+					ContainerName: openEvent.K8s.ContainerName,
 					Namespace:     openEvent.GetNamespace(),
 					PodName:       openEvent.GetPod(),
 					PodNamespace:  openEvent.GetNamespace(),

--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -317,7 +317,7 @@ func (mm *MalwareManager) enrichMalwareResult(malwareResult malwaremanager.Malwa
 	}
 
 	if runtimek8sdetails.ContainerName == "" {
-		runtimek8sdetails.ContainerName = malwareResult.GetTriggerEvent().Runtime.ContainerName
+		runtimek8sdetails.ContainerName = malwareResult.GetTriggerEvent().K8s.ContainerName
 	}
 
 	if runtimek8sdetails.ContainerID == "" {

--- a/pkg/rulemanager/v1/rule_manager.go
+++ b/pkg/rulemanager/v1/rule_manager.go
@@ -536,7 +536,7 @@ func (rm *RuleManager) enrichRuleFailure(ruleFailure ruleengine.RuleFailure) rul
 	}
 
 	if runtimek8sdetails.ContainerName == "" {
-		runtimek8sdetails.ContainerName = ruleFailure.GetTriggerEvent().Runtime.ContainerName
+		runtimek8sdetails.ContainerName = ruleFailure.GetTriggerEvent().K8s.ContainerName
 	}
 
 	if runtimek8sdetails.ContainerID == "" {
@@ -552,7 +552,7 @@ func (rm *RuleManager) enrichRuleFailure(ruleFailure ruleengine.RuleFailure) rul
 
 	return ruleFailure
 }
- 
+
 // Checks if the event type is relevant to the rule.
 func isEventRelevant(ruleSpec ruleengine.RuleSpec, eventType utils.EventType) bool {
 	for _, i := range ruleSpec.RequiredEventTypes() {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
bug_fix


___

## **Description**
- This PR addresses the incorrect source of container names in both the Malware Manager and Rule Manager modules.
- The `ContainerName` is now consistently sourced from `K8s.ContainerName` instead of `Runtime.ContainerName`, ensuring that the container name is correctly populated based on Kubernetes details.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>malware_manager.go</strong><dd><code>Fix Container Name Source in Malware Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/malwaremanager/v1/malware_manager.go
<li>Fixed the source of <code>ContainerName</code> to use <code>K8s.ContainerName</code> instead of <br><code>Runtime.ContainerName</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/261/files#diff-39e99490e457120b984db82ca98c0e5227942707d1e37245ffd2287079ad89af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rule_manager.go</strong><dd><code>Correct Container Name Source in Rule Manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/rulemanager/v1/rule_manager.go
<li>Corrected the assignment of <code>ContainerName</code> to use <code>K8s.ContainerName</code> <br>instead of <code>Runtime.ContainerName</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/261/files#diff-256c2d268cc7600c33337b908014ecfeb9f05e4ff302df5627aff93079a982a6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

