### PR TITLE
Fix execs

### DIFF
--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -374,13 +374,6 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 					existingContainer := utils.GetApplicationProfileContainer(existingObject, watchedContainer.ContainerType, watchedContainer.ContainerIndex)
 					var addContainer bool
 					if existingContainer == nil {
-
-						logger.L().Ctx(ctx).Error("ApplicationProfileManager::saveProfile - existing container is nil, will add a new one",
-							helpers.String("slug", slug),
-							helpers.Int("container index", watchedContainer.ContainerIndex),
-							helpers.String("container ID", watchedContainer.ContainerID),
-							helpers.String("k8s workload", watchedContainer.K8sContainerID))
-
 						existingContainer = &v1beta1.ApplicationProfileContainer{
 							Name: watchedContainer.ContainerNames[watchedContainer.ContainerType][watchedContainer.ContainerIndex],
 						}
@@ -401,12 +394,6 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 					// replace or add container using patch
 					switch {
 					case existingContainers == nil:
-						logger.L().Ctx(ctx).Error("ApplicationProfileManager::saveProfile - existingContainers is nil",
-							helpers.String("slug", slug),
-							helpers.Int("container index", watchedContainer.ContainerIndex),
-							helpers.String("container ID", watchedContainer.ContainerID),
-							helpers.String("k8s workload", watchedContainer.K8sContainerID))
-
 						// 3a. insert a new container slice, with the new container at the right index
 						containers := make([]v1beta1.ApplicationProfileContainer, watchedContainer.ContainerIndex+1)
 						containers[watchedContainer.ContainerIndex] = *existingContainer
@@ -443,13 +430,6 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 					replaceOperations = utils.AppendStatusAnnotationPatchOperations(replaceOperations, watchedContainer)
 
 					patch, err := json.Marshal(replaceOperations)
-					logger.L().Ctx(ctx).Error("ApplicationProfileManager::saveProfile - patch result",
-						helpers.String("patch", string(patch)),
-						helpers.String("slug", slug),
-						helpers.Int("container index", watchedContainer.ContainerIndex),
-						helpers.String("container ID", watchedContainer.ContainerID),
-						helpers.String("k8s workload", watchedContainer.K8sContainerID))
-
 					if err != nil {
 						logger.L().Ctx(ctx).Error("ApplicationProfileManager - failed to marshal patch", helpers.Error(err),
 							helpers.String("slug", slug),

--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
@@ -86,10 +86,10 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType utils.EventTy
 		return nil
 	}
 
-	slices.Sort(execEvent.Args)
+	// slices.Sort(execEvent.Args)
 
 	for _, execCall := range appProfileExecList.Execs {
-		slices.Sort(execCall.Args)
+		// slices.Sort(execCall.Args)
 		if execCall.Path == execPath && slices.Compare(execCall.Args, execEvent.Args) == 0 {
 			return nil
 		}

--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched.go
@@ -86,10 +86,7 @@ func (rule *R0001UnexpectedProcessLaunched) ProcessEvent(eventType utils.EventTy
 		return nil
 	}
 
-	// slices.Sort(execEvent.Args)
-
 	for _, execCall := range appProfileExecList.Execs {
-		// slices.Sort(execCall.Args)
 		if execCall.Path == execPath && slices.Compare(execCall.Args, execEvent.Args) == 0 {
 			return nil
 		}

--- a/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
+++ b/pkg/ruleengine/v1/r0005_unexpected_domain_request.go
@@ -5,6 +5,7 @@ import (
 	"node-agent/pkg/objectcache"
 	"node-agent/pkg/ruleengine"
 	"node-agent/pkg/utils"
+	"strings"
 
 	apitypes "github.com/armosec/armoapi-go/armotypes"
 	tracerdnstype "github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
@@ -66,12 +67,17 @@ func (rule *R0005UnexpectedDomainRequest) ProcessEvent(eventType utils.EventType
 		return nil
 	}
 
+	// TODO: fix this, currently we are ignoring in-cluster communication
+	if strings.HasSuffix(domainEvent.DNSName, "svc.cluster.local.") {
+		return nil
+	}
+
 	nn := objCache.NetworkNeighborsCache().GetNetworkNeighbors(domainEvent.GetNamespace(), domainEvent.GetPod())
 	if nn == nil {
 		return nil
 	}
 
-	// // Check that the domain is in the application profile
+	// Check that the domain is in the network neighbors
 	for _, dns := range nn.Spec.Egress {
 		if dns.DNS == domainEvent.DNSName {
 			return nil

--- a/pkg/utils/applicationprofile.go
+++ b/pkg/utils/applicationprofile.go
@@ -52,6 +52,7 @@ func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs ma
 	opensPath := fmt.Sprintf("/spec/%s/%d/opens/-", containerType, containerIndex)
 	for path, open := range opens {
 		flags := open.ToSlice()
+		sort.Strings(flags)
 
 		profileOperations = append(profileOperations, PatchOperation{
 			Op:   "add",
@@ -89,6 +90,7 @@ func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileCont
 	container.Opens = make([]v1beta1.OpenCalls, 0)
 	for path, open := range opens {
 		flags := open.ToSlice()
+		sort.Strings(flags)
 		container.Opens = append(container.Opens, v1beta1.OpenCalls{
 			Path:  path,
 			Flags: flags,

--- a/pkg/utils/applicationprofile.go
+++ b/pkg/utils/applicationprofile.go
@@ -2,12 +2,13 @@ package utils
 
 import (
 	"fmt"
-	"github.com/deckarep/golang-set/v2"
-	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"sort"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
-func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
+func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs map[string][]string, opens map[string]mapset.Set[string], containerType string, containerIndex int) []PatchOperation {
 	var profileOperations []PatchOperation
 	// add capabilities
 	sort.Strings(capabilities)
@@ -32,9 +33,12 @@ func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs ma
 
 	// add execs
 	execsPath := fmt.Sprintf("/spec/%s/%d/execs/-", containerType, containerIndex)
-	for path, exec := range execs {
-		args := exec.ToSlice()
-		sort.Strings(args)
+	for _, pathAndArgs := range execs {
+		path := pathAndArgs[0]
+		var args []string
+		if len(pathAndArgs) > 1 {
+			args = pathAndArgs[1:]
+		}
 		profileOperations = append(profileOperations, PatchOperation{
 			Op:   "add",
 			Path: execsPath,
@@ -48,7 +52,6 @@ func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs ma
 	opensPath := fmt.Sprintf("/spec/%s/%d/opens/-", containerType, containerIndex)
 	for path, open := range opens {
 		flags := open.ToSlice()
-		sort.Strings(flags)
 
 		profileOperations = append(profileOperations, PatchOperation{
 			Op:   "add",
@@ -62,7 +65,7 @@ func CreateCapabilitiesPatchOperations(capabilities, syscalls []string, execs ma
 	return profileOperations
 }
 
-func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileContainer, observedCapabilities, observedSyscalls []string, execs map[string]mapset.Set[string], opens map[string]mapset.Set[string]) {
+func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileContainer, observedCapabilities, observedSyscalls []string, execs map[string][]string, opens map[string]mapset.Set[string]) {
 	// add capabilities
 	sort.Strings(observedCapabilities)
 	container.Capabilities = observedCapabilities
@@ -71,9 +74,12 @@ func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileCont
 	container.Syscalls = observedSyscalls
 	// add execs
 	container.Execs = make([]v1beta1.ExecCalls, 0)
-	for path, exec := range execs {
-		args := exec.ToSlice()
-		sort.Strings(args)
+	for _, pathAndArgs := range execs {
+		path := pathAndArgs[0]
+		var args []string
+		if len(pathAndArgs) > 1 {
+			args = pathAndArgs[1:]
+		}
 		container.Execs = append(container.Execs, v1beta1.ExecCalls{
 			Path: path,
 			Args: args,
@@ -83,7 +89,6 @@ func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileCont
 	container.Opens = make([]v1beta1.OpenCalls, 0)
 	for path, open := range opens {
 		flags := open.ToSlice()
-		sort.Strings(flags)
 		container.Opens = append(container.Opens, v1beta1.OpenCalls{
 			Path:  path,
 			Flags: flags,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -325,11 +325,12 @@ func EscapeJSONPointerElement(s string) string {
 
 func AppendStatusAnnotationPatchOperations(existingPatch []PatchOperation, watchedContainer *WatchedContainerData) []PatchOperation {
 	if watchedContainer.statusUpdated {
-		existingPatch = append(existingPatch, PatchOperation{
-			Op:    "replace",
-			Path:  "/metadata/annotations/" + EscapeJSONPointerElement(helpersv1.StatusMetadataKey),
-			Value: string(watchedContainer.status),
-		},
+		existingPatch = append(existingPatch,
+			PatchOperation{
+				Op:    "replace",
+				Path:  "/metadata/annotations/" + EscapeJSONPointerElement(helpersv1.StatusMetadataKey),
+				Value: string(watchedContainer.status),
+			},
 			PatchOperation{
 				Op:    "replace",
 				Path:  "/metadata/annotations/" + EscapeJSONPointerElement(helpersv1.CompletionMetadataKey),
@@ -450,6 +451,13 @@ func GetFileSize(path string) (int64, error) {
 	}
 
 	return fileInfo.Size(), nil
+}
+
+func CalculateSHA256FileExecHash(path string, args []string) string {
+	hash := sha256.New()
+	hash.Write([]byte(fmt.Sprintf("%s;%v", path, args)))
+	hashInBytes := hash.Sum(nil)
+	return hex.EncodeToString(hashInBytes)
 }
 
 // Calculate the SHA256 hash of the given file.

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -11,6 +11,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCalculateSHA256FileExecHash(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		args []string
+		want string
+	}{
+		{
+			name: "Test with path only",
+			path: "/usr/local/bin/python",
+			args: []string{},
+			want: "c3c3590ac3929a993cce758788838263ce47309429f486d8ebb8ee59fba42650",
+		},
+		{
+			name: "Test with path and one argument",
+			path: "/usr/local/bin/python",
+			args: []string{"-v"},
+			want: "5b4db099511640892a59a841aa0d13914610f60e8ca3922b0adaada599002a15",
+		},
+		{
+			name: "Test with path and multiple arguments",
+			path: "/usr/local/bin/python",
+			args: []string{"-v", "-m", "pip"},
+			want: "4fa7e242cfbe5b2d5ec4440821cae0b9830672c01dfb3959834aad5b46a6cec5",
+		},
+		{
+			name: "Test with path and multiple arguments different order",
+			path: "/usr/local/bin/python",
+			args: []string{"-v", "pip", "-m"},
+			want: "0fbe286986472240a59623fa225c96c02a2976bb248083a06f220c00f8863490",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateSHA256FileExecHash(tt.path, tt.args); got != tt.want {
+				t.Errorf("CalculateSHA256FileExecHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUtilsBetween(t *testing.T) {
 	str := "TYPE=openat(fd: <f>/lib/x86_64-linux-gnu/libc.so.6, dirfd: AT_FDCWD, name: /lib/x86_64-linux-gnu/libc.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0, dev: 34, ino: 1321)"
 	fileName := Between(str, "name: ", ", flags")


### PR DESCRIPTION
## **User description**

Application profile fixes:
- Args will not be sorted
- Each exec (path + args) combination is unique.

Rule Manager:
- Removed args sorting
- Pod to pod communication is ignored (temporary) since the NN object does not fill the DNS string.

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Enhancement, Bug fix


___

## **Description**
- Refactored exec tracking in `ApplicationProfileManager` to use slices instead of sets for efficiency and better management.
- Updated related utility functions and tests to align with the new data structure for exec tracking.
- Enhanced rule processing in `R0001UnexpectedProcessLaunched` by removing unnecessary sorting.
- Added handling to ignore in-cluster DNS requests in `R0005UnexpectedDomainRequest`.
- Introduced a new utility function `CalculateSHA256FileExecHash` for generating unique identifiers for execs, with corresponding tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager.go</strong><dd><code>Refactor exec tracking from set to slice for efficiency</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager.go
<li>Changed the data structure for tracking execs from <code>mapset.Set[string]</code> <br>to <code>[]string</code> to handle execs more efficiently.<br> <li> Modified methods to adapt to the new execs data structure, including <br><code>saveProfile</code>, <code>ReportFileExec</code>, and error handling sections.<br> <li> Updated initialization and cleanup of exec tracking structures in <br>various lifecycle methods.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-fc815317651e17975c117749e7661127dbcde82fd9d4d36ebc76cb5b09b3c54e">+28/-20</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0001_unexpected_process_launched.go</strong><dd><code>Simplify exec comparison in process event rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0001_unexpected_process_launched.go
<li>Removed sorting of exec args which is now unnecessary due to new exec <br>handling logic.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-ac1a37fd641e5d6211b057e4cbc91e8e5d6fad1ebdf030ad944240e92c48bffe">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>r0005_unexpected_domain_request.go</strong><dd><code>Enhance domain request rule to ignore in-cluster DNS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/ruleengine/v1/r0005_unexpected_domain_request.go
- Added a check to ignore in-cluster DNS requests.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-fe45fd0bea6a18b7edee9a1e285e10ce183b9ae962a0d5e441c4bfbd33ab47af">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>applicationprofile.go</strong><dd><code>Update utility functions for new execs data structure</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/applicationprofile.go
<li>Updated <code>CreateCapabilitiesPatchOperations</code> and <br><code>EnrichApplicationProfileContainer</code> to support the new execs data <br>structure.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-8d04187903dc650c355ad4c0bb3842e12f9b8a6ecc2ea543169f2b2c063dbe77">+17/-10</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Add utility function for exec identification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils.go
<li>Added a new utility function <code>CalculateSHA256FileExecHash</code> to generate <br>unique identifiers for execs.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+13/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>applicationprofile_manager_test.go</strong><dd><code>Update tests for new exec tracking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
<li>Added tests to verify the handling of duplicate and unique exec <br>reports.<br> <li> Adjusted assertions to reflect the new data structure and handling <br>logic for execs.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-4e4af04b3ed98cb9feaf13f1406a7d71609ab637ea5cb47c4f749cfb240afca1">+19/-2</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils_test.go</strong><dd><code>Implement tests for new exec hash utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/utils/utils_test.go
<li>Added tests for the new <code>CalculateSHA256FileExecHash</code> utility function.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/265/files#diff-dbb00af8f58edf5a904cecaf0c5eb4c07979ce8711d22f826bfd70ce5e9634c9">+42/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

