### PR TITLE
Fix nil reference in saveNetworkEvents

### DIFF
--- a/pkg/networkmanager/v1/network_manager.go
+++ b/pkg/networkmanager/v1/network_manager.go
@@ -335,8 +335,11 @@ func (am *NetworkManager) saveNetworkEvents(_ context.Context, container *contai
 			return
 		}
 	}
+
+	currSpec := v1beta1.NetworkNeighborsSpec{}
 	if err == nil {
 		networkNeighborsExists = true
+		currSpec = networkNeighbors.Spec
 	}
 
 	if droppedEvents := am.containerAndPodToDroppedEvent.Get(container.Runtime.ContainerID + container.K8s.PodName); droppedEvents {
@@ -346,7 +349,7 @@ func (am *NetworkManager) saveNetworkEvents(_ context.Context, container *contai
 	networkEvents := am.containerAndPodToEventsMap.Get(container.Runtime.ContainerID + container.K8s.PodName)
 
 	// update CRD based on events
-	networkNeighborsSpec := am.generateNetworkNeighborsEntries(container.K8s.Namespace, networkEvents, networkNeighbors.Spec)
+	networkNeighborsSpec := am.generateNetworkNeighborsEntries(container.K8s.Namespace, networkEvents, currSpec)
 
 	if networkNeighborsExists {
 		// patch only if there are changes

--- a/tests/testutils/k8s.go
+++ b/tests/testutils/k8s.go
@@ -77,10 +77,11 @@ func NewTestWorkload(namespace, resourcePath string) (*TestWorkload, error) {
 }
 
 func (w *TestWorkload) ExecIntoPod(command []string) (string, string, error) {
-	pod, err := w.GetPod()
+	pods, err := w.GetPods()
 	if err != nil {
 		return "", "", err
 	}
+	pod := pods[0]
 
 	k8sClient := k8sinterface.NewKubernetesApi()
 
@@ -114,7 +115,7 @@ func (w *TestWorkload) ExecIntoPod(command []string) (string, string, error) {
 	return buf.String(), errBuf.String(), nil
 }
 
-func (w *TestWorkload) GetPod() (*v1.Pod, error) {
+func (w *TestWorkload) GetPods() ([]v1.Pod, error) {
 	k8sClient := k8sinterface.NewKubernetesApi()
 
 	appLabel, _ := w.WorkloadObj.GetLabel("app")
@@ -132,33 +133,42 @@ func (w *TestWorkload) GetPod() (*v1.Pod, error) {
 	if len(pods.Items) == 0 {
 		return nil, fmt.Errorf("no pods found")
 	}
-	return &pods.Items[0], nil
+	return pods.Items, nil
 }
 
 func (w *TestWorkload) WaitForReady(maxRetries uint64) error {
 	time.Sleep(5 * time.Second)
 	k8sClient := k8sinterface.NewKubernetesApi()
 
-	pod, err := w.GetPod()
+	pods, err := w.GetPods()
 	if err != nil {
 		return err
 	}
-	podName := pod.Name
-	return backoff.RetryNotify(func() error {
-		p, err := k8sClient.KubernetesClient.CoreV1().Pods(w.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	podNames := make([]string, 0)
+	for _, pod := range pods {
+		podNames = append(podNames, pod.Name)
+	}
+
+	for _, podName := range podNames {
+		err := backoff.RetryNotify(func() error {
+			p, err := k8sClient.KubernetesClient.CoreV1().Pods(w.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			for _, cond := range p.Status.Conditions {
+				if cond.Type == "Ready" && cond.Status == "True" {
+					return nil
+				}
+			}
+			return fmt.Errorf("pod %s is not ready", podName)
+		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), maxRetries), func(err error, d time.Duration) {
+			logger.L().Info("waiting for pod to be ready", helpers.String("pod", podName), helpers.Error(err), helpers.String("retry in", d.String()))
+		})
 		if err != nil {
 			return err
 		}
-		for _, cond := range p.Status.Conditions {
-			if cond.Type == "Ready" && cond.Status == "True" {
-				return nil
-			}
-		}
-		return fmt.Errorf("pod %s is not ready", podName)
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), maxRetries), func(err error, d time.Duration) {
-		logger.L().Info("waiting for pod to be ready", helpers.String("pod", podName), helpers.Error(err), helpers.String("retry in", d.String()))
-	})
-
+	}
+	return nil
 }
 
 func (w *TestWorkload) listApplicationProfilesInNamespace() ([]v1beta1.ApplicationProfile, error) {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Fixed a potential nil reference error in `saveNetworkEvents` by initializing `currSpec` before use.
- Enhanced the network neighbors CRD update logic in `NetworkManager` to use a safely initialized spec.
- Refactored test utility functions to support operations on multiple pods, improving the robustness of test executions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>network_manager.go</strong><dd><code>Fix nil reference and enhance CRD update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/networkmanager/v1/network_manager.go
<li>Initialized <code>currSpec</code> to avoid nil reference when updating network <br>neighbors.<br> <li> Updated the method to use <code>currSpec</code> instead of directly accessing <br><code>networkNeighbors.Spec</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/268/files#diff-91001aa3daf6f273c1ae3ded661c9acea7486080c3ff3da88c268ec56258fed0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>k8s.go</strong><dd><code>Refactor test utilities to handle multiple pods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/testutils/k8s.go
<li>Changed <code>GetPod</code> to <code>GetPods</code> to return a slice of pods.<br> <li> Updated <code>ExecIntoPod</code> and <code>WaitForReady</code> to handle multiple pods.<br> <li> Enhanced error handling and retry logic in <code>WaitForReady</code>.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/268/files#diff-703f8ff02f59b4a7413f3f1970984a6e6dbb11547ac785b6a9fa93df6dc4310c">+27/-17</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

