### PR TITLE
When termination exit code is missing, we assume it is != 0

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -278,7 +278,7 @@ func (watchedContainer *WatchedContainerData) SetContainerInfo(wl workloadinterf
 	checkContainers(nil, ephemeralContainers, EphemeralContainer)
 }
 
-// SetTerminationStatus updates the terminated flag and sets the exit code on the watched container
+// GetTerminationExitCode returns the termination exit code of the container, otherwise -1
 func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsCache objectcache.K8sObjectCache, namespace, podName, containerName string) int32 {
 	time.Sleep(3 * time.Second)
 	podStatus := k8sObjectsCache.GetPodStatus(namespace, podName)
@@ -287,7 +287,6 @@ func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsC
 			if podStatus.ContainerStatuses[i].Name == containerName {
 				if podStatus.ContainerStatuses[i].LastTerminationState.Terminated != nil {
 					return podStatus.ContainerStatuses[i].LastTerminationState.Terminated.ExitCode
-
 				}
 			}
 		}
@@ -307,7 +306,7 @@ func (watchedContainer *WatchedContainerData) GetTerminationExitCode(k8sObjectsC
 		}
 	}
 
-	return 0
+	return -1
 }
 
 type PatchOperation struct {


### PR DESCRIPTION
## **User description**
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->


___

## **Type**
enhancement


___

## **Description**
- Renamed `SetTerminationStatus` to `GetTerminationExitCode` to better reflect its functionality.
- Modified `GetTerminationExitCode` to return -1 by default if no termination exit code is present, indicating an abnormal termination.
- Updated documentation comment to align with the new logic of the function.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Update Termination Exit Code Handling in WatchedContainerData</code></dd></summary>
<hr>

pkg/utils/utils.go
<li>Renamed function from <code>SetTerminationStatus</code> to <code>GetTerminationExitCode</code>.<br> <li> Changed the default return value from 0 to -1 when no termination exit <br>code is found.<br> <li> Updated function documentation to reflect new behavior.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/node-agent/pull/269/files#diff-81ddbadfb415ccbb9c7af84f11668d1aa5e53c34025bf86d4702f16b4e42f045">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

