### PR TITLE
Improvement/changing r1001 r1004 behavior

### DIFF
--- a/pkg/ruleengine/v1/r0001_unexpected_process_launched_test.go
+++ b/pkg/ruleengine/v1/r0001_unexpected_process_launched_test.go
@@ -81,4 +81,64 @@ func TestR0001UnexpectedProcessLaunched(t *testing.T) {
 	if ruleResult == nil {
 		t.Errorf("Expected ruleResult to not be nil since exec is not whitelisted")
 	}
+
+}
+
+func TestR0001UnexpectedProcessLaunchedArgCompare(t *testing.T) {
+	// Create a new rule
+	r := CreateRuleR0001UnexpectedProcessLaunched()
+	// Assert r is not nil
+	if r == nil {
+		t.Errorf("Expected r to not be nil")
+	}
+
+	r.SetParameters(map[string]interface{}{"enforceArgs": false})
+
+	objCache := RuleObjectCacheMock{}
+	profile := objCache.ApplicationProfileCache().GetApplicationProfile("test")
+	if profile == nil {
+		profile = &v1beta1.ApplicationProfile{}
+		profile.Spec.Containers = append(profile.Spec.Containers, v1beta1.ApplicationProfileContainer{
+			Name: "test",
+			Execs: []v1beta1.ExecCalls{
+				{
+					Path: "/test",
+					Args: []string{"test"},
+				},
+			},
+		})
+
+		objCache.SetApplicationProfile(profile)
+	}
+
+	e := &tracerexectype.Event{
+		Event: eventtypes.Event{
+			CommonData: eventtypes.CommonData{
+				K8s: eventtypes.K8sMetadata{
+					BasicK8sMetadata: eventtypes.BasicK8sMetadata{
+						ContainerName: "test",
+					},
+				},
+			},
+		},
+		ExePath: "/test",
+		Args:    []string{"/test", "something"},
+	}
+
+	// Test with whitelisted exec
+	ruleResult := r.ProcessEvent(utils.ExecveEventType, e, &objCache)
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since exec is whitelisted and args are not enforced")
+	}
+
+	// Create a new rule with enforceArgs set to true
+	r = CreateRuleR0001UnexpectedProcessLaunched()
+	r.SetParameters(map[string]interface{}{"enforceArgs": true})
+
+	// Test with whitelisted exec and enforceArgs set to true
+	ruleResult = r.ProcessEvent(utils.ExecveEventType, e, &objCache)
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult to not be nil since exec is whitelisted but args are enforced")
+	}
+
 }

--- a/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
@@ -62,7 +62,7 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventTyp
 
 	if execEvent.UpperLayer {
 
-		if whiteListed, err := isExecEventWhitelisted(execEvent, objectCache, false); whiteListed || err != nil {
+		if whiteListed, err := isExecEventWhitelisted(execEvent, objectCache, false); whiteListed && err != nil {
 			return nil
 		}
 

--- a/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
+++ b/pkg/ruleengine/v1/r1001_exec_binary_not_in_base_image.go
@@ -50,7 +50,7 @@ func (rule *R1001ExecBinaryNotInBaseImage) ID() string {
 func (rule *R1001ExecBinaryNotInBaseImage) DeleteRule() {
 }
 
-func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventType, event interface{}, objCache objectcache.ObjectCache) ruleengine.RuleFailure {
+func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventType, event interface{}, objectCache objectcache.ObjectCache) ruleengine.RuleFailure {
 	if eventType != utils.ExecveEventType {
 		return nil
 	}
@@ -61,6 +61,11 @@ func (rule *R1001ExecBinaryNotInBaseImage) ProcessEvent(eventType utils.EventTyp
 	}
 
 	if execEvent.UpperLayer {
+
+		if whiteListed, err := isExecEventWhitelisted(execEvent, objectCache, false); whiteListed || err != nil {
+			return nil
+		}
+
 		ruleFailure := GenericRuleFailure{
 			BaseRuntimeAlert: apitypes.BaseRuntimeAlert{
 				AlertName:      rule.Name(),

--- a/pkg/ruleengine/v1/r1004_exec_from_mount.go
+++ b/pkg/ruleengine/v1/r1004_exec_from_mount.go
@@ -58,6 +58,11 @@ func (rule *R1004ExecFromMount) ProcessEvent(eventType utils.EventType, event in
 		return nil
 	}
 
+	// Check if the event is whitelisted, if so return nil
+	if whiteListed, err := isExecEventWhitelisted(execEvent, objCache, false); whiteListed || err != nil {
+		return nil
+	}
+
 	mounts, err := getContainerMountPaths(execEvent.GetNamespace(), execEvent.GetPod(), execEvent.GetContainer(), objCache.K8sObjectCache())
 	if err != nil {
 		return nil

--- a/pkg/ruleengine/v1/r1004_exec_from_mount.go
+++ b/pkg/ruleengine/v1/r1004_exec_from_mount.go
@@ -59,7 +59,7 @@ func (rule *R1004ExecFromMount) ProcessEvent(eventType utils.EventType, event in
 	}
 
 	// Check if the event is whitelisted, if so return nil
-	if whiteListed, err := isExecEventWhitelisted(execEvent, objCache, false); whiteListed || err != nil {
+	if whiteListed, err := isExecEventWhitelisted(execEvent, objCache, false); whiteListed && err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
## Overview

This PR changes behavior on two rules:

R1001 - Exec not in base image
R1004 - Exec in mounted path
Both of the rules generated alerts on whitelisted processes. This causes many false positives for users who have good application profiles.

The change removes alerts for whitelisted processes, though this should be refined in the future when the rule information becomes available in the application profile therefore a full comparison of behavior can be done.

Related PR #283 