### PR TITLE
Fix application profile and NN patching

### DIFF
--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -181,17 +181,18 @@ func (am *ApplicationProfileManager) monitorContainer(ctx context.Context, conta
 				}
 
 				am.saveProfile(ctx, watchedContainer, container.K8s.Namespace)
-				return nil
+				return err
 			case errors.Is(err, utils.ContainerReachedMaxTime):
 				watchedContainer.SetStatus(utils.WatchedContainerStatusCompleted)
 				am.saveProfile(ctx, watchedContainer, container.K8s.Namespace)
-				return nil
+				return err
 			case errors.Is(err, utils.ObjectCompleted):
 				watchedContainer.SetStatus(utils.WatchedContainerStatusCompleted)
-				return nil
+				return err
 			case errors.Is(err, utils.TooLargeObjectError):
+				logger.L().Debug("ApplicationProfileManager - object is too large")
 				watchedContainer.SetStatus(utils.WatchedContainerStatusTooLarge)
-				return nil
+				return err
 			}
 		}
 	}

--- a/pkg/networkmanager/v2/network_manager.go
+++ b/pkg/networkmanager/v2/network_manager.go
@@ -195,17 +195,17 @@ func (nm *NetworkManager) monitorContainer(ctx context.Context, container *conta
 					watchedContainer.SetStatus(utils.WatchedContainerStatusCompleted)
 				}
 				nm.saveNetworkEvents(ctx, watchedContainer, container.K8s.Namespace)
-				return nil
+				return err
 			case errors.Is(err, utils.ContainerReachedMaxTime):
 				watchedContainer.SetStatus(utils.WatchedContainerStatusCompleted)
 				nm.saveNetworkEvents(ctx, watchedContainer, container.K8s.Namespace)
-				return nil
+				return err
 			case errors.Is(err, utils.ObjectCompleted):
 				watchedContainer.SetStatus(utils.WatchedContainerStatusCompleted)
-				return nil
+				return err
 			case errors.Is(err, utils.TooLargeObjectError):
 				watchedContainer.SetStatus(utils.WatchedContainerStatusTooLarge)
-				return nil
+				return err
 			}
 		}
 	}

--- a/pkg/storage/v1/applicationprofile.go
+++ b/pkg/storage/v1/applicationprofile.go
@@ -46,26 +46,25 @@ func (sc Storage) patchApplicationProfile(name, namespace string, operations []u
 	if err != nil {
 		return fmt.Errorf("patch application profile: %w", err)
 	}
+
 	// check if returned profile is full
-	if s, ok := profile.Annotations[helpers.StatusMetadataKey]; ok {
-		if s == helpers.TooLarge {
-			if channel != nil {
-				channel <- utils.TooLargeObjectError
-			}
+	if status, ok := profile.Annotations[helpers.StatusMetadataKey]; ok && status == helpers.TooLarge {
+		if channel != nil {
+			channel <- utils.TooLargeObjectError
 		}
 		return nil
 	}
+
 	// check if returned profile is completed
 	if c, ok := profile.Annotations[helpers.CompletionMetadataKey]; ok {
-		if s, ok := profile.Annotations[helpers.StatusMetadataKey]; ok {
-			if s == helpers.Complete && c == helpers.Completed {
-				if channel != nil {
-					channel <- utils.ObjectCompleted
-				}
+		if s, ok := profile.Annotations[helpers.StatusMetadataKey]; ok && s == helpers.Complete && c == helpers.Completed {
+			if channel != nil {
+				channel <- utils.ObjectCompleted
 			}
+			return nil
 		}
-		return nil
 	}
+
 	// check if returned profile is too big
 	if s, ok := profile.Annotations[helpers.ResourceSizeMetadataKey]; ok {
 		size, err := strconv.Atoi(s)

--- a/pkg/storage/v1/network.go
+++ b/pkg/storage/v1/network.go
@@ -48,25 +48,22 @@ func (sc Storage) patchNetworkNeighborhood(name, namespace string, operations []
 		return fmt.Errorf("patch application neighborhood: %w", err)
 	}
 	// check if returned neighborhood is full
-	if s, ok := neighborhood.Annotations[helpers.StatusMetadataKey]; ok {
-		if s == helpers.TooLarge {
-			if channel != nil {
-				channel <- utils.TooLargeObjectError
-			}
+	if status, ok := neighborhood.Annotations[helpers.StatusMetadataKey]; ok && status == helpers.TooLarge {
+		if channel != nil {
+			channel <- utils.TooLargeObjectError
 		}
 		return nil
 	}
 	// check if returned profile is completed
 	if c, ok := neighborhood.Annotations[helpers.CompletionMetadataKey]; ok {
-		if s, ok := neighborhood.Annotations[helpers.StatusMetadataKey]; ok {
-			if s == helpers.Complete && c == helpers.Completed {
-				if channel != nil {
-					channel <- utils.ObjectCompleted
-				}
+		if s, ok := neighborhood.Annotations[helpers.StatusMetadataKey]; ok && s == helpers.Complete && c == helpers.Completed {
+			if channel != nil {
+				channel <- utils.ObjectCompleted
 			}
+			return nil
 		}
-		return nil
 	}
+
 	// check if returned neighborhood is too big
 	if s, ok := neighborhood.Annotations[helpers.ResourceSizeMetadataKey]; ok {
 		size, err := strconv.Atoi(s)

--- a/pkg/storage/v1/storage.go
+++ b/pkg/storage/v1/storage.go
@@ -60,11 +60,13 @@ func CreateStorage(namespace string) (*Storage, error) {
 	if err != nil {
 		maxApplicationProfileSize = DefaultMaxApplicationProfileSize
 	}
+	logger.L().Debug("maxApplicationProfileSize", helpers.Int("size", maxApplicationProfileSize))
 
 	maxNetworkNeighborhoodSize, err := strconv.Atoi(os.Getenv("MAX_NETWORK_NEIGHBORHOOD_SIZE"))
 	if err != nil {
 		maxNetworkNeighborhoodSize = DefaultMaxNetworkNeighborhoodSize
 	}
+	logger.L().Debug("maxNetworkNeighborhoodSize", helpers.Int("size", maxNetworkNeighborhoodSize))
 
 	// wait for storage to be ready
 	if err := backoff.RetryNotify(func() error {


### PR DESCRIPTION
## Overview

Bug fix:
- Application profiles and network neighborhoods were not marked as too big when passing the resource size threshold, due to a bug in the logic. The existing patch logic would exit from the function whenever the status annotation exists (regardless of its value).
- `monitorContainer` function now returns the error - so that a log message with the reason will be printed to the log.

Logs after the fix:
```
{"level":"debug","ts":"2024-08-06T12:21:03Z","msg":"ApplicationProfileManager - saved application profile","capabilities":3,"execs":10,"opens":138,"slug":"pod-ping-app","container index":0,"container ID":"ee8d0d98e0700c349ab01565bcb2fff3ddca66bb3a8eb0aa7d6c240c33cebf00","k8s workload":"default/ping-app/ping-app"}
{"level":"debug","ts":"2024-08-06T12:21:03Z","msg":"ApplicationProfileManager - object is too large"}
{"level":"info","ts":"2024-08-06T12:21:03Z","msg":"ApplicationProfileManager - stop monitor on container","reason":"object is too large","container index":0,"container ID":"ee8d0d98e0700c349ab01565bcb2fff3ddca66bb3a8eb0aa7d6c240c33cebf00","k8s workload":"default/ping-app/ping-app"}
```

Application profile (setting the max size to 12):
```
kubectl get applicationprofiles pod-ping-app -oyaml
apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
kind: ApplicationProfile
metadata:
  annotations:
    kubescape.io/completion: complete
    kubescape.io/resource-size: "148"
    kubescape.io/status: too-large
    kubescape.io/wlid: wlid://cluster-xxxx/namespace-default/pod-ping-app
  creationTimestamp: "2024-08-06T12:18:55Z"
....
```