### PR TITLE
Stop dns monitoring over dns servers containers

### DIFF
--- a/pkg/containerwatcher/v1/container_watcher.go
+++ b/pkg/containerwatcher/v1/container_watcher.go
@@ -126,16 +126,14 @@ type IGContainerWatcher struct {
 	sshWorkerChan          chan *tracersshtype.Event
 
 	preRunningContainersIDs mapset.Set[string]
-
-	timeBasedContainers mapset.Set[string] // list of containers to track based on ticker
-	ruleManagedPods     mapset.Set[string] // list of pods to track based on rules
-	metrics             metricsmanager.MetricsManager
-
+	timeBasedContainers     mapset.Set[string] // list of containers to track based on ticker
+	ruleManagedPods         mapset.Set[string] // list of pods to track based on rules
+	metrics                 metricsmanager.MetricsManager
 	// cache
 	ruleBindingPodNotify *chan rulebinding.RuleBindingNotify
-
 	// container runtime
-	runtime *containerutilsTypes.RuntimeConfig
+	runtime    *containerutilsTypes.RuntimeConfig
+	dnsServers mapset.Set[*containercollection.Container]
 }
 
 var _ containerwatcher.ContainerWatcher = (*IGContainerWatcher)(nil)
@@ -354,11 +352,10 @@ func CreateIGContainerWatcher(cfg config.Config, applicationProfileManager appli
 
 		// cache
 		ruleBindingPodNotify: ruleBindingPodNotify,
-
-		timeBasedContainers: mapset.NewSet[string](),
-		ruleManagedPods:     mapset.NewSet[string](),
-
-		runtime: runtime,
+		timeBasedContainers:  mapset.NewSet[string](),
+		ruleManagedPods:      mapset.NewSet[string](),
+		runtime:              runtime,
+		dnsServers:           mapset.NewSet[*containercollection.Container](),
 	}, nil
 }
 

--- a/pkg/containerwatcher/v1/dns.go
+++ b/pkg/containerwatcher/v1/dns.go
@@ -64,6 +64,15 @@ func (ch *IGContainerWatcher) startDNSTracing() error {
 		return fmt.Errorf("creating tracer: %w", err)
 	}
 
+	// Detach the dns tracer from dns servers
+	for dnsServer := range ch.dnsServers.Iter() {
+		logger.L().Info("Detaching dns tracer from dns server", helpers.String("dnsServer", dnsServer.Runtime.ContainerName))
+		err := ch.dnsTracer.DetachContainer(dnsServer)
+		if err != nil {
+			return fmt.Errorf("detaching dns tracer: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR detaches the dns tracer from dns servers to avoid cpu throttling.