### PR TITLE
fix http sniffer logic in AP manager

### DIFF
--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -41,16 +41,16 @@ type ApplicationProfileManager struct {
 	containerMutexes         storageUtils.MapMutex[string]                                      // key is k8sContainerID
 	trackedContainers        mapset.Set[string]                                                 // key is k8sContainerID
 	removedContainers        mapset.Set[string]                                                 // key is k8sContainerID
-	savedCapabilities        maps.SafeMap[string, mapset.Set[string]]                           // key is k8sContainerID
-	savedExecs               maps.SafeMap[string, *maps.SafeMap[string, []string]]              // key is k8sContainerID
 	droppedEvents            maps.SafeMap[string, bool]                                         // key is k8sContainerID
+	savedCapabilities        maps.SafeMap[string, mapset.Set[string]]                           // key is k8sContainerID
+	savedEndpoints           maps.SafeMap[string, *maps.SafeMap[string, *v1beta1.HTTPEndpoint]] // key is k8sContainerID
+	savedExecs               maps.SafeMap[string, *maps.SafeMap[string, []string]]              // key is k8sContainerID
 	savedOpens               maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]]    // key is k8sContainerID
-	savedHttpEndpoints       maps.SafeMap[string, *maps.SafeMap[string, *v1beta1.HTTPEndpoint]] // key is k8sContainerID
 	savedSyscalls            maps.SafeMap[string, mapset.Set[string]]                           // key is k8sContainerID
 	toSaveCapabilities       maps.SafeMap[string, mapset.Set[string]]                           // key is k8sContainerID
+	toSaveEndpoints          maps.SafeMap[string, *maps.SafeMap[string, *v1beta1.HTTPEndpoint]] // key is k8sContainerID
 	toSaveExecs              maps.SafeMap[string, *maps.SafeMap[string, []string]]              // key is k8sContainerID
 	toSaveOpens              maps.SafeMap[string, *maps.SafeMap[string, mapset.Set[string]]]    // key is k8sContainerID
-	toSaveHttpEndpoints      maps.SafeMap[string, *maps.SafeMap[string, *v1beta1.HTTPEndpoint]] // key is k8sContainerID
 	watchedContainerChannels maps.SafeMap[string, chan error]                                   // key is ContainerID
 	k8sClient                k8sclient.K8sClientInterface
 	k8sObjectCache           objectcache.K8sObjectCache
@@ -259,6 +259,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 
 	// get capabilities from IG
 	var capabilities []string
+	endpoints := make(map[string]*v1beta1.HTTPEndpoint)
 	execs := make(map[string][]string)
 	opens := make(map[string]mapset.Set[string])
 	if toSaveCapabilities := am.toSaveCapabilities.Get(watchedContainer.K8sContainerID); toSaveCapabilities.Cardinality() > 0 {
@@ -273,11 +274,19 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		}
 	}
 
+	// get pointer to endpoints map from IG
+	toSaveEndpoints := am.toSaveEndpoints.Get(watchedContainer.K8sContainerID)
+	// point IG to a new endpoints map
+	am.toSaveEndpoints.Set(watchedContainer.K8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
+	// prepare endpoints map
+	toSaveEndpoints.Range(func(path string, endpoint *v1beta1.HTTPEndpoint) bool {
+		endpoints[path] = endpoint
+		return true
+	})
 	// get pointer to execs map from IG
 	toSaveExecs := am.toSaveExecs.Get(watchedContainer.K8sContainerID)
 	// point IG to a new exec map
 	am.toSaveExecs.Set(watchedContainer.K8sContainerID, new(maps.SafeMap[string, []string]))
-
 	// prepare execs map
 	toSaveExecs.Range(func(execIdentifier string, pathAndArgs []string) bool {
 		execs[execIdentifier] = pathAndArgs
@@ -295,17 +304,6 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		opens[path].Append(open.ToSlice()...)
 		return true
 	})
-
-	endpoints := make(map[string]*v1beta1.HTTPEndpoint)
-
-	toSaveHttpEndpoints := am.toSaveHttpEndpoints.Get(watchedContainer.K8sContainerID)
-	am.toSaveHttpEndpoints.Set(watchedContainer.K8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
-	toSaveHttpEndpoints.Range(func(path string, endpoint *v1beta1.HTTPEndpoint) bool {
-		if _, exist := endpoints[path]; !exist {
-			endpoints[path] = endpoint
-		}
-		return true
-	})
 	// new activity
 	// the process tries to use JSON patching to avoid conflicts between updates on the same object from different containers
 	// 0. create both a patch and a new object
@@ -315,7 +313,7 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 	// 3a. the object is missing its container slice - ADD one with the container profile at the right index
 	// 3b. the object is missing the container profile - ADD the container profile at the right index
 	// 3c. default - patch the container ourselves and REPLACE it at the right index
-	if len(capabilities) > 0 || len(execs) > 0 || len(opens) > 0 || len(toSaveSyscalls) > 0 || len(endpoints) > 0 || watchedContainer.StatusUpdated() {
+	if len(capabilities) > 0 || len(endpoints) > 0 || len(execs) > 0 || len(opens) > 0 || len(toSaveSyscalls) > 0 || watchedContainer.StatusUpdated() {
 		// 0. calculate patch
 		operations := utils.CreateCapabilitiesPatchOperations(capabilities, observedSyscalls, execs, opens, endpoints, watchedContainer.ContainerType.String(), watchedContainer.ContainerIndex)
 		operations = utils.AppendStatusAnnotationPatchOperations(operations, watchedContainer)
@@ -353,12 +351,12 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 						}
 						containers = append(containers, v1beta1.ApplicationProfileContainer{
 							Name:           name,
+							Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 							Execs:          make([]v1beta1.ExecCalls, 0),
 							Opens:          make([]v1beta1.OpenCalls, 0),
 							Capabilities:   make([]string, 0),
 							Syscalls:       make([]string, 0),
 							SeccompProfile: seccompProfile,
-							Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 						})
 					}
 					return containers
@@ -412,11 +410,11 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 						logger.L().Debug("ApplicationProfileManager - got seccomp profile", helpers.Interface("profile", seccompProfile))
 						existingContainer = &v1beta1.ApplicationProfileContainer{
 							Name:           containerNames[watchedContainer.ContainerIndex],
+							Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 							Execs:          make([]v1beta1.ExecCalls, 0),
 							Opens:          make([]v1beta1.OpenCalls, 0),
 							Capabilities:   make([]string, 0),
 							Syscalls:       make([]string, 0),
-							Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 							SeccompProfile: seccompProfile,
 						}
 					}
@@ -456,11 +454,11 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 							Path: fmt.Sprintf("/spec/%s/%d", watchedContainer.ContainerType, i),
 							Value: v1beta1.ApplicationProfileContainer{
 								Name:           name,
+								Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 								Execs:          make([]v1beta1.ExecCalls, 0),
 								Opens:          make([]v1beta1.OpenCalls, 0),
 								Capabilities:   make([]string, 0),
 								Syscalls:       make([]string, 0),
-								Endpoints:      make([]v1beta1.HTTPEndpoint, 0),
 								SeccompProfile: seccompProfile,
 							},
 						})
@@ -501,6 +499,13 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 		if gotErr != nil {
 			// restore capabilities set
 			am.toSaveCapabilities.Get(watchedContainer.K8sContainerID).Append(capabilities...)
+			// restore endpoints map entries
+			toSaveEndpoints.Range(func(path string, endpoint *v1beta1.HTTPEndpoint) bool {
+				if !am.toSaveEndpoints.Get(watchedContainer.K8sContainerID).Has(path) {
+					am.toSaveEndpoints.Get(watchedContainer.K8sContainerID).Set(path, endpoint)
+				}
+				return true
+			})
 			// restore execs map entries
 			toSaveExecs.Range(func(uniqueExecIdentifier string, v []string) bool {
 				if !am.toSaveExecs.Get(watchedContainer.K8sContainerID).Has(uniqueExecIdentifier) {
@@ -518,6 +523,13 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 			am.savedSyscalls.Get(watchedContainer.K8sContainerID).Append(toSaveSyscalls...)
 			// record saved capabilities
 			am.savedCapabilities.Get(watchedContainer.K8sContainerID).Append(capabilities...)
+			// record saved endpoints
+			toSaveEndpoints.Range(func(path string, endpoint *v1beta1.HTTPEndpoint) bool {
+				if !am.savedEndpoints.Get(watchedContainer.K8sContainerID).Has(path) {
+					am.savedEndpoints.Get(watchedContainer.K8sContainerID).Set(path, endpoint)
+				}
+				return true
+			})
 			// record saved execs
 			toSaveExecs.Range(func(uniqueExecIdentifier string, v []string) bool {
 				if !am.savedExecs.Get(watchedContainer.K8sContainerID).Has(uniqueExecIdentifier) {
@@ -527,19 +539,11 @@ func (am *ApplicationProfileManager) saveProfile(ctx context.Context, watchedCon
 			})
 			// record saved opens
 			toSaveOpens.Range(utils.SetInMap(am.savedOpens.Get(watchedContainer.K8sContainerID)))
-			// record saved endpoints
-			toSaveHttpEndpoints.Range(func(path string, endpoint *v1beta1.HTTPEndpoint) bool {
-				if !am.savedHttpEndpoints.Get(watchedContainer.K8sContainerID).Has(path) {
-					am.savedHttpEndpoints.Get(watchedContainer.K8sContainerID).Set(path, endpoint)
-				}
-				return true
-			})
-
 			logger.L().Debug("ApplicationProfileManager - saved application profile",
 				helpers.Int("capabilities", len(capabilities)),
+				helpers.Int("endpoints", toSaveEndpoints.Len()),
 				helpers.Int("execs", toSaveExecs.Len()),
 				helpers.Int("opens", toSaveOpens.Len()),
-				helpers.Int("endpoints", toSaveHttpEndpoints.Len()),
 				helpers.String("slug", slug),
 				helpers.Int("container index", watchedContainer.ContainerIndex),
 				helpers.String("container ID", watchedContainer.ContainerID),
@@ -612,15 +616,15 @@ func (am *ApplicationProfileManager) ContainerCallback(notif containercollection
 		}
 		am.savedCapabilities.Set(k8sContainerID, mapset.NewSet[string]())
 		am.droppedEvents.Set(k8sContainerID, false)
+		am.savedEndpoints.Set(k8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
 		am.savedExecs.Set(k8sContainerID, new(maps.SafeMap[string, []string]))
 		am.savedOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
 		am.savedSyscalls.Set(k8sContainerID, mapset.NewSet[string]())
-		am.savedHttpEndpoints.Set(k8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
 		am.toSaveCapabilities.Set(k8sContainerID, mapset.NewSet[string]())
+		am.toSaveEndpoints.Set(k8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
 		am.toSaveExecs.Set(k8sContainerID, new(maps.SafeMap[string, []string]))
 		am.toSaveOpens.Set(k8sContainerID, new(maps.SafeMap[string, mapset.Set[string]]))
-		am.toSaveHttpEndpoints.Set(k8sContainerID, new(maps.SafeMap[string, *v1beta1.HTTPEndpoint]))
-		am.removedContainers.Remove(k8sContainerID)
+		am.removedContainers.Remove(k8sContainerID) // make sure container is not in the removed list
 		am.trackedContainers.Add(k8sContainerID)
 		go am.startApplicationProfiling(ctx, notif.Container, k8sContainerID)
 
@@ -711,7 +715,7 @@ func (am *ApplicationProfileManager) ReportHTTPEvent(k8sContainerID string, even
 		return
 	}
 
-	tosaveHttp := am.toSaveHttpEndpoints.Get(k8sContainerID)
+	endpointMap := am.toSaveEndpoints.Get(k8sContainerID)
 	endpointHash := CalculateHTTPEndpointHash(endpoint)
-	tosaveHttp.Set(endpointHash, endpoint)
+	endpointMap.Set(endpointHash, endpoint)
 }

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -48,7 +48,6 @@ func TestApplicationProfileManager(t *testing.T) {
 			},
 		},
 	}
-
 	// register peek function for syscall tracer
 	go am.RegisterPeekFunc(func(_ uint64) ([]string, error) {
 		return []string{"dup", "listen"}, nil
@@ -139,7 +138,6 @@ func TestApplicationProfileManager(t *testing.T) {
 	for _, expectedExec := range expectedExecs {
 		assert.Contains(t, reportedExecs, expectedExec)
 	}
-
 	assert.Equal(t, []v1beta1.OpenCalls{{Path: "/etc/passwd", Flags: []string{"O_RDONLY"}}}, storageClient.ApplicationProfiles[0].Spec.Containers[1].Opens)
 
 	expectedEndpoints := GetExcpectedEndpoints(t)

--- a/pkg/applicationprofilemanager/v1/endpoint_utils.go
+++ b/pkg/applicationprofilemanager/v1/endpoint_utils.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net"
 	"sort"
 	"strings"
@@ -44,7 +43,6 @@ func (am *ApplicationProfileManager) GetEndpointIdentifier(request *tracerhttpty
 	identifier := request.URL
 	headers := tracerhttphelper.ExtractConsistentHeaders(request.Headers)
 	if host, ok := headers["Host"]; ok {
-		fmt.Println("Host", host)
 		host := host[0]
 		_, port, err := net.SplitHostPort(host)
 		if err != nil {

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -192,7 +192,6 @@ func (ch *IGContainerWatcher) stopContainerCollection() {
 }
 
 func (ch *IGContainerWatcher) startTracers() error {
-
 	if ch.cfg.EnableApplicationProfile {
 		// Start syscall tracer
 		if err := ch.startSystemcallTracing(); err != nil {
@@ -276,8 +275,6 @@ func (ch *IGContainerWatcher) startTracers() error {
 			logger.L().Error("error starting http tracing", helpers.Error(err))
 			return err
 		}
-	} else {
-		logger.L().Debug("not starting http tracing")
 	}
 
 	return nil

--- a/pkg/storage/v1/applicationprofile.go
+++ b/pkg/storage/v1/applicationprofile.go
@@ -37,7 +37,6 @@ func (sc Storage) CreateApplicationProfile(profile *v1beta1.ApplicationProfile, 
 func (sc Storage) PatchApplicationProfile(name, namespace string, operations []utils.PatchOperation, channel chan error) error {
 	// split operations into max JSON operations batches
 	for _, chunk := range utils.ChunkBy(operations, sc.maxJsonPatchOperations) {
-
 		if err := sc.patchApplicationProfile(name, namespace, chunk, channel); err != nil {
 			return err
 		}
@@ -50,7 +49,6 @@ func (sc Storage) patchApplicationProfile(name, namespace string, operations []u
 	if err != nil {
 		return fmt.Errorf("marshal patch: %w", err)
 	}
-
 	profile, err := sc.StorageClient.ApplicationProfiles(namespace).Patch(context.Background(), sc.modifyName(name), types.JSONPatchType, patch, v1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("patch application profile: %w", err)

--- a/pkg/utils/applicationprofile.go
+++ b/pkg/utils/applicationprofile.go
@@ -2,11 +2,9 @@ package utils
 
 import (
 	"fmt"
-
 	"sort"
 
 	mapset "github.com/deckarep/golang-set/v2"
-
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
@@ -119,6 +117,7 @@ func EnrichApplicationProfileContainer(container *v1beta1.ApplicationProfileCont
 	}
 }
 
+// TODO make generic?
 func GetApplicationProfileContainer(object *v1beta1.ApplicationProfile, containerType ContainerType, containerIndex int) *v1beta1.ApplicationProfileContainer {
 	if object == nil {
 		return nil

--- a/pkg/watcher/cooldownqueue/cooldownqueue.go
+++ b/pkg/watcher/cooldownqueue/cooldownqueue.go
@@ -5,17 +5,20 @@ import (
 	"time"
 
 	"istio.io/pkg/cache"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-var (
-	DefaultExpiration = 5 * time.Second
-	EvictionInterval  = 1 * time.Second
+const (
+	defaultExpiration = 5 * time.Second
+	evictionInterval  = 1 * time.Second
 )
 
+// CooldownQueue is a queue that lets clients put events into it with a cooldown
+//
+// When a client puts an event into a queue, it waits for a cooldown period before
+// the event is forwarded to the consumer. If and event for the same key is put into the queue
+// again before the cooldown period is over, the event is overridden and the cooldown period is reset.
 type CooldownQueue struct {
 	closed     bool
 	seenEvents cache.ExpiringCache
@@ -31,7 +34,7 @@ func NewCooldownQueue() *CooldownQueue {
 	callback := func(key, value any) {
 		events <- value.(watch.Event)
 	}
-	c := cache.NewTTLWithCallback(DefaultExpiration, EvictionInterval, callback)
+	c := cache.NewTTLWithCallback(defaultExpiration, evictionInterval, callback)
 	return &CooldownQueue{
 		seenEvents: c,
 		innerChan:  events,
@@ -41,8 +44,7 @@ func NewCooldownQueue() *CooldownQueue {
 
 // makeEventKey creates a unique key for an event from a watcher
 func makeEventKey(e watch.Event) string {
-	object := e.Object.(runtime.Object)
-	gvk := object.GetObjectKind().GroupVersionKind()
+	gvk := e.Object.GetObjectKind().GroupVersionKind()
 	meta := e.Object.(metav1.Object)
 	return strings.Join([]string{gvk.Group, gvk.Version, gvk.Kind, meta.GetNamespace(), meta.GetName()}, "/")
 }


### PR DESCRIPTION
restoring some formatting changes and deleted comments that were part of the previous PR
adding restoring of endpoints in case of error
adding reporting of dropped http event
renaming some fields for consistency