### PR TITLE
Add ignored comms for /etc/shadow access

### DIFF
--- a/pkg/ruleengine/v1/r0010_unexpected_sensitive_file_access.go
+++ b/pkg/ruleengine/v1/r0010_unexpected_sensitive_file_access.go
@@ -133,16 +133,17 @@ func (rule *R0010UnexpectedSensitiveFileAccess) ProcessEvent(eventType utils.Eve
 		if err != nil {
 			return nil
 		}
+	} else {
+		// Running without application profile, to avoid false positives check if the process name is legitimate
+		for _, processName := range legitimateProcessNames {
+			if processName == openEvent.Comm {
+				return nil
+			}
+		}
 	}
 
 	if !utils.IsSensitivePath(openEvent.FullPath, rule.additionalPaths) {
 		return nil
-	}
-
-	for _, processName := range legitimateProcessNames {
-		if processName == openEvent.Comm {
-			return nil
-		}
 	}
 
 	if objCache != nil {

--- a/pkg/ruleengine/v1/r0010_unexpected_sensitive_file_access.go
+++ b/pkg/ruleengine/v1/r0010_unexpected_sensitive_file_access.go
@@ -48,6 +48,37 @@ func CreateRuleR0010UnexpectedSensitiveFileAccess() *R0010UnexpectedSensitiveFil
 	}
 }
 
+var legitimateProcessNames = []string{
+	"systemd",
+	"sudo",
+	"passwd",
+	"chpasswd",
+	"useradd",
+	"usermod",
+	"chage",
+	"sshd",
+	"login",
+	"su",
+	"groupadd",
+	"groupmod",
+	"dpkg",
+	"rpm",
+	"ansible",
+	"puppet-agent",
+	"chef-client",
+	"vipw",
+	"pwck",
+	"grpck",
+	"nscd",
+	"cron",
+	"crond",
+	"pam",
+	"snap",
+	"apk",
+	"yum",
+	"dnf",
+}
+
 func (rule *R0010UnexpectedSensitiveFileAccess) SetParameters(parameters map[string]interface{}) {
 	rule.BaseRule.SetParameters(parameters)
 
@@ -106,6 +137,12 @@ func (rule *R0010UnexpectedSensitiveFileAccess) ProcessEvent(eventType utils.Eve
 
 	if !utils.IsSensitivePath(openEvent.FullPath, rule.additionalPaths) {
 		return nil
+	}
+
+	for _, processName := range legitimateProcessNames {
+		if processName == openEvent.Comm {
+			return nil
+		}
 	}
 
 	if objCache != nil {


### PR DESCRIPTION
This pull request introduces new functionality to the `pkg/ruleengine/v1/r0010_unexpected_sensitive_file_access.go` file. The changes include adding a list of legitimate process names and modifying the event processing logic to ignore events from these processes.

Key changes:

* Added a list of legitimate process names to the `CreateRuleR0010UnexpectedSensitiveFileAccess` function.
* Updated the `ProcessEvent` function to skip processing events if they originate from any of the legitimate processes listed.