### PR TITLE
Remove perl from whitelist

### DIFF
--- a/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
+++ b/pkg/ruleengine/v1/r1000_exec_from_malicious_source.go
@@ -59,7 +59,6 @@ var whitelistedProcessesForMaliciousSource = []string{
 	"bash",
 	"dash",
 	"sh",
-	"perl",
 	"supervisord",
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `pkg/ruleengine/v1/r1000_exec_from_malicious_source.go` file. The change removes `perl` from the list of `whitelistedProcessesForMaliciousSource`.

* [`pkg/ruleengine/v1/r1000_exec_from_malicious_source.go`](diffhunk://#diff-00351ce4b75a85e267a68663f357265bbcc7721c2e461fa6112363fdfb2150c5L62): Removed `perl` from the `whitelistedProcessesForMaliciousSource` array.