### PR TITLE
Enhance R0002UnexpectedFileAccess rule to support include prefixes for file access checks

### DIFF
--- a/pkg/ruleengine/v1/r0002_unexpected_file_access_test.go
+++ b/pkg/ruleengine/v1/r0002_unexpected_file_access_test.go
@@ -172,4 +172,29 @@ func TestR0002UnexpectedFileAccess(t *testing.T) {
 	if ruleResult != nil {
 		t.Errorf("Expected ruleResult to be nil since file is ignored")
 	}
+
+	// Test with include prefixes
+	e.FullPath = "/var/test1"
+	includePrefixes := []interface{}{"/etc"}
+	r.SetParameters(map[string]interface{}{"ignoreMounts": false, "ignorePrefixes": ignorePrefixes, "includePrefixes": includePrefixes})
+	ruleResult = r.ProcessEvent(utils.OpenEventType, e, &objCache)
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since file is not included")
+	}
+
+	// Test the case where the path is included
+	e.FullPath = "/etc/passwd"
+	ruleResult = r.ProcessEvent(utils.OpenEventType, e, &objCache)
+	if ruleResult == nil {
+		t.Errorf("Expected ruleResult to not be nil since file is included")
+	}
+
+	// Test the case where the path is included but ignored
+	e.FullPath = "/etc/some/random/path/passwd"
+	ignorePrefixes = []interface{}{"/etc/some"}
+	r.SetParameters(map[string]interface{}{"ignoreMounts": false, "ignorePrefixes": ignorePrefixes, "includePrefixes": includePrefixes})
+	ruleResult = r.ProcessEvent(utils.OpenEventType, e, &objCache)
+	if ruleResult != nil {
+		t.Errorf("Expected ruleResult to be nil since file is ignored")
+	}
 }


### PR DESCRIPTION
This pull request enhances the behavior of the `R0002UnexpectedFileAccess` rule by introducing a new `includePrefixes` parameter, which allows more granular control over file access rules. It also updates the associated logic and tests to accommodate this new feature.

### Enhancements to `R0002UnexpectedFileAccess` rule:

* **Addition of `includePrefixes` parameter:**
  - Added a new `includePrefixes` field to the `R0002UnexpectedFileAccess` struct to specify paths that must be explicitly included.
  - Updated the `SetParameters` method to handle the `includePrefixes` parameter, ensuring it is correctly parsed and stored.

* **Logic update for event processing:**
  - Modified the `ProcessEvent` method to check whether the file path matches any of the `includePrefixes`. If no match is found, the event is ignored.

### Test updates:

* **New test cases for `includePrefixes`:**
  - Added test scenarios to validate the behavior of the `includePrefixes` parameter, including cases where paths are included, excluded, or both included and ignored.