### PR TITLE
get TemplateHashKey label directly from k8s-interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/inspektor-gadget/inspektor-gadget v0.39.0
 	github.com/kubescape/backend v0.0.25
 	github.com/kubescape/go-logger v0.0.23
-	github.com/kubescape/k8s-interface v0.0.192
+	github.com/kubescape/k8s-interface v0.0.193
 	github.com/kubescape/storage v0.0.158
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -705,8 +705,8 @@ github.com/kubescape/backend v0.0.25 h1:PLESA7KGJskebR5hiSqPeJ1cPQ8Ra+4yNYXKyIej
 github.com/kubescape/backend v0.0.25/go.mod h1:FpazfN+c3Ucuvv4jZYCnk99moSBRNMVIxl5aWCZAEBo=
 github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2P/570=
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
-github.com/kubescape/k8s-interface v0.0.192 h1:nbjxy8o3qOgQqbPkaE8316P0YxwiA/zsYf4B5a2S+WI=
-github.com/kubescape/k8s-interface v0.0.192/go.mod h1:j9snZbH+RxOaa1yG/bWgTClj90q7To0rGgQepxy4b+k=
+github.com/kubescape/k8s-interface v0.0.193 h1:pfAAXCZp0t84b1C24iR2qrCmm68psNyS+Njs/dWIWOI=
+github.com/kubescape/k8s-interface v0.0.193/go.mod h1:j9snZbH+RxOaa1yG/bWgTClj90q7To0rGgQepxy4b+k=
 github.com/kubescape/storage v0.0.158 h1:TbI1/rrRq+0gNbbPl8Z1weik0ShTWPJfy8lXjnzaDjw=
 github.com/kubescape/storage v0.0.158/go.mod h1:K3QWf+zcXmXxfeQ2HD0dd0bF4FJ5gbxLTRZ7nx4dHXw=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager.go
@@ -650,7 +650,6 @@ func (am *ApplicationProfileManager) startApplicationProfiling(ctx context.Conte
 		K8sContainerID:         k8sContainerID,
 		NsMntId:                container.Mntns,
 		InstanceID:             sharedData.InstanceID,
-		TemplateHash:           sharedData.TemplateHash,
 		Wlid:                   sharedData.Wlid,
 		ParentResourceVersion:  sharedData.ParentResourceVersion,
 		ContainerInfos:         sharedData.ContainerInfos,

--- a/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
+++ b/pkg/applicationprofilemanager/v1/applicationprofile_manager_test.go
@@ -51,8 +51,6 @@ func ensureInstanceID(container *containercollection.Container, watchedContainer
 			return fmt.Errorf("failed to set container info: %w", err)
 		}
 	}
-	// get pod template hash
-	watchedContainer.TemplateHash, _ = pod.GetLabel("pod-template-hash")
 	// find parentWlid
 	kind, name, err := k8sclient.CalculateWorkloadParentRecursive(pod)
 	if err != nil {

--- a/pkg/containerwatcher/v1/container_watcher_private.go
+++ b/pkg/containerwatcher/v1/container_watcher_private.go
@@ -148,8 +148,6 @@ func (ch *IGContainerWatcher) getSharedWatchedContainerData(container *container
 			return nil, fmt.Errorf("failed to set container info: %w", err)
 		}
 	}
-	// get pod template hash
-	watchedContainer.TemplateHash, _ = pod.GetPodLabel("pod-template-hash")
 	// find parentWlid
 	kind, name, err := ch.k8sClient.CalculateWorkloadParentRecursive(pod)
 	if err != nil {

--- a/pkg/networkmanager/v2/network_manager.go
+++ b/pkg/networkmanager/v2/network_manager.go
@@ -416,7 +416,6 @@ func (nm *NetworkManager) startNetworkMonitoring(ctx context.Context, container 
 		K8sContainerID:         k8sContainerID,
 		NsMntId:                container.Mntns,
 		InstanceID:             sharedData.InstanceID,
-		TemplateHash:           sharedData.TemplateHash,
 		Wlid:                   sharedData.Wlid,
 		ParentResourceVersion:  sharedData.ParentResourceVersion,
 		ContainerInfos:         sharedData.ContainerInfos,

--- a/pkg/networkmanager/v2/network_manager_test.go
+++ b/pkg/networkmanager/v2/network_manager_test.go
@@ -43,8 +43,6 @@ func ensureInstanceID(container *containercollection.Container, watchedContainer
 			return fmt.Errorf("failed to set container info: %w", err)
 		}
 	}
-	// get pod template hash
-	watchedContainer.TemplateHash, _ = pod.GetLabel("pod-template-hash")
 	// find parentWlid
 	kind, name, err := k8sclient.CalculateWorkloadParentRecursive(pod)
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -87,7 +87,6 @@ type WatchedContainerData struct {
 	ImageTag                                   string
 	ImageID                                    string
 	Wlid                                       string
-	TemplateHash                               string
 	K8sContainerID                             string
 	ContainerType                              ContainerType
 	ContainerIndex                             int
@@ -203,10 +202,6 @@ func GetLabels(watchedContainer *WatchedContainerData, stripContainer bool) map[
 	if watchedContainer.ParentResourceVersion != "" {
 		labels[helpersv1.ResourceVersionMetadataKey] = watchedContainer.ParentResourceVersion
 	}
-	if watchedContainer.TemplateHash != "" {
-		labels[helpersv1.TemplateHashKey] = watchedContainer.TemplateHash
-	}
-
 	return labels
 }
 


### PR DESCRIPTION
this is to get rid of https://github.com/kubescape/storage/pull/213 in a permanent manner