### PR TITLE
KUBELET_ROOT not uses HOST_ROOT setting when generating seccomp directory

### DIFF
--- a/pkg/seccompmanager/v1/seccomp_manager.go
+++ b/pkg/seccompmanager/v1/seccomp_manager.go
@@ -114,6 +114,9 @@ func getProfilesDir() (string, error) {
 	kubeletRoot, exists := os.LookupEnv("KUBELET_ROOT")
 	if !exists {
 		kubeletRoot = "/var/lib/kubelet"
+	} else {
+		// if KUBELET_ROOT is set, we don't need to use HOST_ROOT, this enables using two different mounts in the container (one is RO, one is RW)
+		hostRoot = ""
 	}
 	// use securejoin to join the two, add seccomp and store in seccompProfilesDir
 	seccompProfilesDir, err := securejoin.SecureJoin(hostRoot, filepath.Join(kubeletRoot, "seccomp"))

--- a/pkg/seccompmanager/v1/seccomp_manager_test.go
+++ b/pkg/seccompmanager/v1/seccomp_manager_test.go
@@ -121,14 +121,14 @@ func Test_getProfilesDir(t *testing.T) {
 		{
 			name:        "set KUBELET_ROOT",
 			kubeletRoot: "/var/lib/kubelet2",
-			want:        "/host/var/lib/kubelet2/seccomp",
+			want:        "/var/lib/kubelet2/seccomp",
 			wantErr:     assert.NoError,
 		},
 		{
 			name:        "set HOST_ROOT and KUBELET_ROOT",
 			hostRoot:    "/host2",
 			kubeletRoot: "/var/lib/kubelet2",
-			want:        "/host2/var/lib/kubelet2/seccomp",
+			want:        "/var/lib/kubelet2/seccomp",
 			wantErr:     assert.NoError,
 		},
 	}


### PR DESCRIPTION
This pull request modifies the behavior of the `getProfilesDir` function and its corresponding tests in the `seccomp_manager` package. The changes ensure that when the `KUBELET_ROOT` environment variable is set, the `HOST_ROOT` variable is disregarded, simplifying the directory structure for seccomp profiles.

### Functional Changes:

* [`pkg/seccompmanager/v1/seccomp_manager.go`](diffhunk://#diff-cd4989954c656e90504eb5310c731881b3a9f0f0c1e6f0a7407ff6a40d82cd0eR117-R119): Updated the `getProfilesDir` function to set `hostRoot` to an empty string when `KUBELET_ROOT` is defined, allowing the use of separate mounts in the container without relying on `HOST_ROOT`.

### Test Updates:

* [`pkg/seccompmanager/v1/seccomp_manager_test.go`](diffhunk://#diff-afcc9c1eccc8eaa25d1a930dd7387470ffd4f28ed7b5d8b58653b3807457ac1aL124-R131): Adjusted test cases for `getProfilesDir` to reflect the updated behavior, where the resulting paths no longer include `HOST_ROOT` when `KUBELET_ROOT` is set.