### PR TITLE
allow specifying wl profiles in labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/joncrlsn/dque v0.0.0-20241024143830-7723fd131a64
 	github.com/kubescape/backend v0.0.25
 	github.com/kubescape/go-logger v0.0.24
-	github.com/kubescape/k8s-interface v0.0.198
+	github.com/kubescape/k8s-interface v0.0.200
 	github.com/kubescape/storage v0.0.200
 	github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -1389,8 +1389,8 @@ github.com/kubescape/backend v0.0.25 h1:PLESA7KGJskebR5hiSqPeJ1cPQ8Ra+4yNYXKyIej
 github.com/kubescape/backend v0.0.25/go.mod h1:FpazfN+c3Ucuvv4jZYCnk99moSBRNMVIxl5aWCZAEBo=
 github.com/kubescape/go-logger v0.0.24 h1:JRNlblY16Ty7hD6MSYNPvWYDxNzVAufsDDX/sZJayL0=
 github.com/kubescape/go-logger v0.0.24/go.mod h1:sMPVCr3VpW/e+SeMaXig5kClGvmZbDXN8YktUeNU4nY=
-github.com/kubescape/k8s-interface v0.0.198 h1:U7PNTyS9ZE9ZkSrLMclLO7Sz4grf/2CLbmpVT6Hc0nU=
-github.com/kubescape/k8s-interface v0.0.198/go.mod h1:j9snZbH+RxOaa1yG/bWgTClj90q7To0rGgQepxy4b+k=
+github.com/kubescape/k8s-interface v0.0.200 h1:Ff64dlDigg8dDYJuaeLFFjfTCHQNC1SStWNECWFRCYE=
+github.com/kubescape/k8s-interface v0.0.200/go.mod h1:j9snZbH+RxOaa1yG/bWgTClj90q7To0rGgQepxy4b+k=
 github.com/kubescape/storage v0.0.200 h1:gLCPiAPxDii03Jo326Ye0qx1cXOAz6KH+A9B0WuL1CE=
 github.com/kubescape/storage v0.0.200/go.mod h1:uv4LMQjcTYIn7bgyMFGc0UBZ3gxdl7MNixPSjALP08E=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=

--- a/pkg/containerprofilemanager/v1/lifecycle.go
+++ b/pkg/containerprofilemanager/v1/lifecycle.go
@@ -74,6 +74,18 @@ func (cpm *ContainerProfileManager) addContainer(container *containercollection.
 		return fmt.Errorf("failed to get shared data for container %s: %w", containerID, err)
 	}
 
+	// Check if the container should use a user-defined profile
+	if sharedData.UserDefinedProfile != "" {
+		logger.L().Debug("ignoring container with a user-defined profile",
+			helpers.String("containerID", containerID),
+			helpers.String("containerName", container.Runtime.ContainerName),
+			helpers.String("podName", container.K8s.PodName),
+			helpers.String("namespace", container.K8s.Namespace),
+			helpers.String("userDefinedProfile", sharedData.UserDefinedProfile))
+		cpm.removeContainerEntry(containerID)
+		return nil
+	}
+
 	// Ignore ephemeral containers
 	if sharedData.ContainerType == objectcache.EphemeralContainer {
 		logger.L().Debug("ignoring ephemeral container",

--- a/pkg/objectcache/shared_container_data.go
+++ b/pkg/objectcache/shared_container_data.go
@@ -77,6 +77,7 @@ type WatchedContainerData struct {
 	SeriesID                string
 	PreviousReportTimestamp time.Time
 	CurrentReportTimestamp  time.Time
+	UserDefinedProfile      string
 }
 
 type ContainerInfo struct {
@@ -136,6 +137,17 @@ func (watchedContainer *WatchedContainerData) SetCompletionStatus(newStatus Watc
 }
 
 func (watchedContainer *WatchedContainerData) SetContainerInfo(wl workloadinterface.IWorkload, containerName string) error {
+	labels := wl.GetPodLabels()
+	// check for user defined profile
+	if userDefinedProfile, ok := labels[helpersv1.UserDefinedProfileMetadataKey]; ok {
+		if userDefinedProfile != "" {
+			logger.L().Info("container has a user defined profile",
+				helpers.String("profile", userDefinedProfile),
+				helpers.String("container", containerName),
+				helpers.String("workload", wl.GetName()))
+			watchedContainer.UserDefinedProfile = userDefinedProfile
+		}
+	}
 	podSpec, err := wl.GetPodSpec()
 	if err != nil {
 		return fmt.Errorf("failed to get pod spec: %w", err)


### PR DESCRIPTION
This pull request introduces support for user-defined application profiles in the container profiling and caching logic. The main changes focus on detecting when a container is associated with a user-defined profile, retrieving and caching these profiles, and ensuring such containers are handled appropriately throughout the lifecycle management process.

User-defined profile support:

* Added a `UserDefinedProfile` field to both `WatchedContainerData` and `ContainerInfo` structs to track if a container uses a user-defined profile. [[1]](diffhunk://#diff-07982d187fb791a7f415ec6cdb93c303c1cfa2670919a8922e5251fef342fe62R80) [[2]](diffhunk://#diff-7033af70203ec0c7cabfa58ce543eee2aa32baea58ae8904c87db7c406b51f9bR34)
* Updated the `SetContainerInfo` method to extract the user-defined profile name from pod labels and set it in `WatchedContainerData`.
* Modified the `addContainer` method in `ApplicationProfileCacheImpl` to:
  * Detect user-defined profiles via pod labels.
  * Fetch and cache the user-defined profile from storage.
  * Log and update profile state on errors.
  * Set the `UserDefinedProfile` field in `ContainerInfo`.
* In the container profile manager, containers with user-defined profiles are now ignored for automatic profiling, with appropriate logging and cleanup.

Profile cache and state management:

* Ensured that a mapping for workload ID to profile state is always created, even for user-defined profiles, to maintain cache consistency.
* Clarified that missing workload IDs during profile updates can be expected for user-defined profiles and should be skipped.

Dependency update:

* Updated the `github.com/kubescape/k8s-interface` dependency to version `v0.0.200` in `go.mod`.

How to use:

* create an application profile in the same namespace as the workload, for example `nginx-user-defined`
* set a pod label pointing to it:
```
apiVersion: apps/v1                                                                                                                                                                                                                                           
kind: Deployment                                                                                                                                                                                                                                              
metadata:                                                                                                                                                                                                                                           
  labels:                                                                                                                                                                                                                                                     
    app: nginx                                                                                                                                                                                                                                                
  name: nginx                                                                                                                                                                                                                                                 
  namespace: default                                                                                                                                                                                                                
spec:                                                                                                                                                                                                                                  
  selector:                                                                                                                                                                                                                                                   
    matchLabels:                                                                                                                                                                                                                                              
      app: nginx                                                                                                                                                                                                                                     
  template:                                                                                                                                                                                                                                                   
    metadata:                                                                                                                                                                                                                               
      labels:                                                                                                                                                                                                                                                 
        app: nginx                                                                                                                                                                                                                                            
        kubescape.io/user-defined-profile: nginx-user-defined
    spec:
      containers:
      - image: nginx:latest
```