### PR TITLE
Respect runtime detection when unregistering

### DIFF
--- a/pkg/containerwatcher/v2/container_watcher.go
+++ b/pkg/containerwatcher/v2/container_watcher.go
@@ -82,12 +82,13 @@ type ContainerWatcher struct {
 	thirdPartyContainerReceivers  mapset.Set[containerwatcher.ContainerReceiver]
 
 	// Cache and state
-	objectCache          objectcache.ObjectCache
-	ruleManagedPods      mapset.Set[string]
-	metrics              metricsmanager.MetricsManager
-	ruleBindingPodNotify *chan rulebindingmanager.RuleBindingNotify
-	runtime              *containerutilsTypes.RuntimeConfig
-	pool                 *workerpool.WorkerPool
+	objectCache             objectcache.ObjectCache
+	ruleManagedPods         mapset.Set[string]
+	ruleBindingsInitialized bool // tracks whether any rule binding notifications have been processed
+	metrics                 metricsmanager.MetricsManager
+	ruleBindingPodNotify    *chan rulebindingmanager.RuleBindingNotify
+	runtime                 *containerutilsTypes.RuntimeConfig
+	pool                    *workerpool.WorkerPool
 
 	// Lifecycle
 	gadgetRuntime                   runtime.Runtime

--- a/pkg/containerwatcher/v2/container_watcher_collection.go
+++ b/pkg/containerwatcher/v2/container_watcher_collection.go
@@ -129,6 +129,9 @@ func (cw *ContainerWatcher) startRunningContainers() {
 func (cw *ContainerWatcher) addRunningContainers(notf *rulebindingmanager.RuleBindingNotify) {
 	pod := notf.GetPod()
 
+	// Mark that we've received at least one rule binding notification
+	cw.ruleBindingsInitialized = true
+
 	// skip containers that should be ignored
 	if cw.cfg.IgnoreContainer(pod.GetNamespace(), pod.GetName(), pod.GetLabels()) {
 		logger.L().Debug("ContainerWatcher - skipping pod", helpers.String("namespace", pod.GetNamespace()), helpers.String("pod name", pod.GetName()))


### PR DESCRIPTION
Add ruleBindingsInitialized to ContainerWatcher to track whether any rule binding notifications have been processed. When runtime detection is enabled, only unregister containers after rule bindings have been initialized and the pod is not in ruleManagedPods. Update tests to exercise these cases.