### PR TITLE
feat: propagate IsTriggerAlert field from rules to runtime alerts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/anchore/syft v1.32.0
 	github.com/aquilax/truncate v1.0.0
-	github.com/armosec/armoapi-go v0.0.654
+	github.com/armosec/armoapi-go v0.0.663
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.654 h1:ALtMYLhvv9gUxYd9I/nyoxb7Pzo+uscmKyxjKbdp5Lc=
-github.com/armosec/armoapi-go v0.0.654/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.663 h1:Ht8eBIY8y3VbFhtvfzdwjMsgiVX7K3dURp6qfBwz8Jo=
+github.com/armosec/armoapi-go v0.0.663/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -327,6 +327,7 @@ func (e *HTTPExporter) createRuleAlert(failedRule types.RuleFailure) apitypes.Ru
 		RuntimeAlertK8sDetails: k8sDetails,
 		RuleAlert:              failedRule.GetRuleAlert(),
 		RuleID:                 failedRule.GetRuleId(),
+		IsTriggerAlert:         failedRule.GetIsTriggerAlert(),
 		HttpRuleAlert:          httpDetails,
 	}
 }

--- a/pkg/rulemanager/ruleadapters/creator.go
+++ b/pkg/rulemanager/ruleadapters/creator.go
@@ -76,8 +76,9 @@ func (r *RuleFailureCreator) CreateRuleFailure(rule typesv1.Rule, enrichedEvent 
 		RuleAlert: apitypes.RuleAlert{
 			RuleDescription: message,
 		},
-		RuleID:        rule.ID,
-		AlertPlatform: apitypes.AlertSourcePlatformK8s,
+		RuleID:         rule.ID,
+		AlertPlatform:  apitypes.AlertSourcePlatformK8s,
+		IsTriggerAlert: rule.IsTriggerAlert,
 	}
 
 	eventAdapter.SetFailureMetadata(ruleFailure, enrichedEvent, state)

--- a/pkg/rulemanager/types/failure.go
+++ b/pkg/rulemanager/types/failure.go
@@ -23,6 +23,7 @@ type GenericRuleFailure struct {
 	CloudServices          []string
 	HttpRuleAlert          apitypes.HttpRuleAlert
 	Extra                  interface{}
+	IsTriggerAlert         bool
 }
 
 type RuleFailure interface {
@@ -69,6 +70,10 @@ type RuleFailure interface {
 	SetHttpRuleAlert(httpRuleAlert apitypes.HttpRuleAlert)
 	// Set Extra
 	SetExtra(extra interface{})
+	// Get IsTriggerAlert
+	GetIsTriggerAlert() bool
+	// Set IsTriggerAlert
+	SetIsTriggerAlert(isTriggerAlert bool)
 }
 
 func (rule *GenericRuleFailure) GetBaseRuntimeAlert() apitypes.BaseRuntimeAlert {
@@ -161,4 +166,12 @@ func (rule *GenericRuleFailure) SetHttpRuleAlert(httpRuleAlert apitypes.HttpRule
 
 func (rule *GenericRuleFailure) SetExtra(extra interface{}) {
 	rule.Extra = extra
+}
+
+func (rule *GenericRuleFailure) GetIsTriggerAlert() bool {
+	return rule.IsTriggerAlert
+}
+
+func (rule *GenericRuleFailure) SetIsTriggerAlert(isTriggerAlert bool) {
+	rule.IsTriggerAlert = isTriggerAlert
 }


### PR DESCRIPTION
## Summary

Propagate the `IsTriggerAlert` field from runtime rules through to runtime alerts. This allows downstream consumers to identify trigger alerts.

## Changes

- Update armoapi-go dependency to v0.0.663 (which includes `IsTriggerAlert` field in `RuntimeAlert`)
- Add `IsTriggerAlert` field to `GenericRuleFailure` struct
- Add `GetIsTriggerAlert()` and `SetIsTriggerAlert()` methods to `RuleFailure` interface
- Copy `IsTriggerAlert` from rule to failure in `CreateRuleFailure()`
- Copy `IsTriggerAlert` from failure to alert in `createRuleAlert()`

## Data Flow

```
RuntimeRule.IsTriggerAlert
    ↓
GenericRuleFailure.IsTriggerAlert (copied in CreateRuleFailure)
    ↓
RuntimeAlert.IsTriggerAlert (copied in createRuleAlert)
```

## Related PR

- armosec/armoapi-go#593 - Added `IsTriggerAlert` field to `RuntimeAlert` struct

## Backward Compatibility

- Uses `omitempty` tags so existing alerts without the field will continue to work
- The field defaults to `false` when not present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated the armoapi-go dependency to v0.0.663.

* **New Features**
  * Added trigger alert identification and tracking capabilities throughout the system. Trigger alert information is now properly identified, tracked, and propagated across the rule failure evaluation and alert notification pipeline, ensuring comprehensive handling and visibility of all alert events in your environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->