### PR TITLE
Generating release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docker-build-only:
 docker-build: gadgets
 	docker buildx build --platform linux/amd64 -t $(IMAGE):$(TAG) -f $(DOCKERFILE_PATH) --load .
 
-docker-push:
+docker-push: docker-build
 	docker push $(IMAGE):$(TAG)
 
 gadgets:


### PR DESCRIPTION
This pull request updates the `Makefile` to ensure that the Docker image is built before attempting to push it. Now, running the `docker-push` target will automatically trigger the `docker-build` target first, preventing push errors due to missing images.

- Makefile improvements:
  * Modified the `docker-push` target to depend on `docker-build`, ensuring the image is built before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal build system updates with no user-facing changes.

* **Chores**
  * Updated build process dependencies to ensure proper execution order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->