### PR TITLE
use k8s-interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/joncrlsn/dque v0.0.0-20241024143830-7723fd131a64
 	github.com/kubescape/backend v0.0.25
 	github.com/kubescape/go-logger v0.0.24
-	github.com/kubescape/k8s-interface v0.0.201
+	github.com/kubescape/k8s-interface v0.0.202
 	github.com/kubescape/storage v0.0.221
 	github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf
 	github.com/moby/sys/mountinfo v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -1469,8 +1469,8 @@ github.com/kubescape/backend v0.0.25 h1:PLESA7KGJskebR5hiSqPeJ1cPQ8Ra+4yNYXKyIej
 github.com/kubescape/backend v0.0.25/go.mod h1:FpazfN+c3Ucuvv4jZYCnk99moSBRNMVIxl5aWCZAEBo=
 github.com/kubescape/go-logger v0.0.24 h1:JRNlblY16Ty7hD6MSYNPvWYDxNzVAufsDDX/sZJayL0=
 github.com/kubescape/go-logger v0.0.24/go.mod h1:sMPVCr3VpW/e+SeMaXig5kClGvmZbDXN8YktUeNU4nY=
-github.com/kubescape/k8s-interface v0.0.201 h1:gBONxCiRr3xcllsSjZDd/gNM6vpIKM8mPffnfVYmmfk=
-github.com/kubescape/k8s-interface v0.0.201/go.mod h1:d4NVhL81bVXe8yEXlkT4ZHrt3iEppEIN39b8N1oXm5s=
+github.com/kubescape/k8s-interface v0.0.202 h1:yu9x+07crFQAgrBatFFU2WuuxMJfHUMHVuCzuHE9Q4M=
+github.com/kubescape/k8s-interface v0.0.202/go.mod h1:d4NVhL81bVXe8yEXlkT4ZHrt3iEppEIN39b8N1oXm5s=
 github.com/kubescape/storage v0.0.221 h1:HLWnNokkKgKo9ka/p797fFQdsbzKxSXT5/RpUWrKWzI=
 github.com/kubescape/storage v0.0.221/go.mod h1:L/fF3teor8cUj80TVujqy9E1rKsf+Dox2hZtkS1vjOU=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=

--- a/pkg/hostsensormanager/sensor_cloudprovider.go
+++ b/pkg/hostsensormanager/sensor_cloudprovider.go
@@ -3,6 +3,8 @@ package hostsensormanager
 import (
 	"net/http"
 	"time"
+
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 // CloudProviderInfoSensor implements the Sensor interface for cloud provider info data
@@ -19,12 +21,12 @@ func NewCloudProviderInfoSensor(nodeName string) *CloudProviderInfoSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *CloudProviderInfoSensor) GetKind() string {
-	return "CloudProviderInfo"
+	return string(hostsensor.CloudProviderInfo)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *CloudProviderInfoSensor) GetPluralKind() string {
-	return "cloudproviderinfos"
+	return hostsensor.MapResourceToPlural(hostsensor.CloudProviderInfo)
 }
 
 // Sense collects the cloud provider info data from the host

--- a/pkg/hostsensormanager/sensor_cni.go
+++ b/pkg/hostsensormanager/sensor_cni.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/kubescape/go-logger"
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 // CNIInfoSensor implements the Sensor interface for CNI info data
@@ -20,12 +21,12 @@ func NewCNIInfoSensor(nodeName string) *CNIInfoSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *CNIInfoSensor) GetKind() string {
-	return "CNIInfo"
+	return string(hostsensor.CNIInfo)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *CNIInfoSensor) GetPluralKind() string {
-	return "cniinfos"
+	return hostsensor.MapResourceToPlural(hostsensor.CNIInfo)
 }
 
 // Sense collects the CNI info data from the host

--- a/pkg/hostsensormanager/sensor_controlplane.go
+++ b/pkg/hostsensormanager/sensor_controlplane.go
@@ -2,6 +2,8 @@ package hostsensormanager
 
 import (
 	"context"
+
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -34,12 +36,12 @@ func NewControlPlaneInfoSensor(nodeName string) *ControlPlaneInfoSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *ControlPlaneInfoSensor) GetKind() string {
-	return "ControlPlaneInfo"
+	return string(hostsensor.ControlPlaneInfo)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *ControlPlaneInfoSensor) GetPluralKind() string {
-	return "controlplaneinfos"
+	return hostsensor.MapResourceToPlural(hostsensor.ControlPlaneInfo)
 }
 
 // Sense collects the control plane info data from the host

--- a/pkg/hostsensormanager/sensor_kernelvars.go
+++ b/pkg/hostsensormanager/sensor_kernelvars.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -29,12 +30,12 @@ func NewLinuxKernelVariablesSensor(nodeName string) *LinuxKernelVariablesSensor 
 
 // GetKind returns the CRD kind for this sensor
 func (s *LinuxKernelVariablesSensor) GetKind() string {
-	return "LinuxKernelVariables"
+	return string(hostsensor.LinuxKernelVariables)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *LinuxKernelVariablesSensor) GetPluralKind() string {
-	return "linuxkernelvariables"
+	return hostsensor.MapResourceToPlural(hostsensor.LinuxKernelVariables)
 }
 
 // Sense collects the kernel variables data from the host

--- a/pkg/hostsensormanager/sensor_kernelversion.go
+++ b/pkg/hostsensormanager/sensor_kernelversion.go
@@ -3,6 +3,8 @@ package hostsensormanager
 import (
 	"fmt"
 	"path"
+
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -23,12 +25,12 @@ func NewKernelVersionSensor(nodeName string) *KernelVersionSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *KernelVersionSensor) GetKind() string {
-	return "KernelVersion"
+	return string(hostsensor.KernelVersion)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *KernelVersionSensor) GetPluralKind() string {
-	return "kernelversions"
+	return hostsensor.MapResourceToPlural(hostsensor.KernelVersion)
 }
 
 // Sense collects the kernel version data from the host

--- a/pkg/hostsensormanager/sensor_kubelet.go
+++ b/pkg/hostsensormanager/sensor_kubelet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -38,12 +39,12 @@ func NewKubeletInfoSensor(nodeName string) *KubeletInfoSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *KubeletInfoSensor) GetKind() string {
-	return "KubeletInfo"
+	return string(hostsensor.KubeletInfo)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *KubeletInfoSensor) GetPluralKind() string {
-	return "kubeletinfos"
+	return hostsensor.MapResourceToPlural(hostsensor.KubeletInfo)
 }
 
 // Sense collects the kubelet info data from the host

--- a/pkg/hostsensormanager/sensor_kubeproxy.go
+++ b/pkg/hostsensormanager/sensor_kubeproxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -25,12 +26,12 @@ func NewKubeProxyInfoSensor(nodeName string) *KubeProxyInfoSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *KubeProxyInfoSensor) GetKind() string {
-	return "KubeProxyInfo"
+	return string(hostsensor.KubeProxyInfo)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *KubeProxyInfoSensor) GetPluralKind() string {
-	return "kubeproxyinfos"
+	return hostsensor.MapResourceToPlural(hostsensor.KubeProxyInfo)
 }
 
 // Sense collects the kube-proxy info data from the host

--- a/pkg/hostsensormanager/sensor_network.go
+++ b/pkg/hostsensormanager/sensor_network.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/hostsensor"
 	"github.com/weaveworks/procspy"
 )
 
@@ -33,12 +34,12 @@ func NewOpenPortsSensor(nodeName string) *OpenPortsSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *OpenPortsSensor) GetKind() string {
-	return "OpenPorts"
+	return string(hostsensor.OpenPortsList)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *OpenPortsSensor) GetPluralKind() string {
-	return "openports"
+	return hostsensor.MapResourceToPlural(hostsensor.OpenPortsList)
 }
 
 // Sense collects the open ports data from the host

--- a/pkg/hostsensormanager/sensor_osrelease.go
+++ b/pkg/hostsensormanager/sensor_osrelease.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -29,12 +30,12 @@ func NewOsReleaseSensor(nodeName string) *OsReleaseSensor {
 
 // GetKind returns the CRD kind for this sensor
 func (s *OsReleaseSensor) GetKind() string {
-	return "OsReleaseFile"
+	return string(hostsensor.OsReleaseFile)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *OsReleaseSensor) GetPluralKind() string {
-	return "osreleasefiles"
+	return hostsensor.MapResourceToPlural(hostsensor.OsReleaseFile)
 }
 
 // Sense collects the OS release data from the host

--- a/pkg/hostsensormanager/sensor_security.go
+++ b/pkg/hostsensormanager/sensor_security.go
@@ -2,6 +2,8 @@ package hostsensormanager
 
 import (
 	"os"
+
+	"github.com/kubescape/k8s-interface/hostsensor"
 )
 
 const (
@@ -23,12 +25,12 @@ func NewLinuxSecurityHardeningSensor(nodeName string) *LinuxSecurityHardeningSen
 
 // GetKind returns the CRD kind for this sensor
 func (s *LinuxSecurityHardeningSensor) GetKind() string {
-	return "LinuxSecurityHardening"
+	return string(hostsensor.LinuxSecurityHardeningStatus)
 }
 
 // GetPluralKind returns the plural and lowercase form of CRD kind for this sensor
 func (s *LinuxSecurityHardeningSensor) GetPluralKind() string {
-	return "linuxsecurityhardenings"
+	return hostsensor.MapResourceToPlural(hostsensor.LinuxSecurityHardeningStatus)
 }
 
 // Sense collects the security hardening data from the host


### PR DESCRIPTION
Replace inner logic for plural forms to use imported k8s-interface as shared package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `github.com/kubescape/k8s-interface` dependency from v0.0.201 to v0.0.202.
  * Improved internal resource type handling consistency across sensor components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->