### PR TITLE
fix rule eval

### DIFF
--- a/pkg/rulemanager/cel/cel.go
+++ b/pkg/rulemanager/cel/cel.go
@@ -183,7 +183,7 @@ func (c *CEL) EvaluateRule(event *events.EnrichedEvent, expressions []typesv1.Ru
 
 		// Skip if program compilation failed (cached as nil)
 		if out == nil {
-			continue
+			return false, nil
 		}
 
 		boolVal, ok := out.Value().(bool)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rule evaluation error handling. When a rule fails to compile, evaluation now stops immediately instead of continuing to process remaining expressions, reducing unnecessary computation and preventing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->