### PR TITLE
Strip unused SBOM fields to reduce object size by ~52%

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/kubescape/backend v0.0.37
 	github.com/kubescape/go-logger v0.0.24
 	github.com/kubescape/k8s-interface v0.0.202
-	github.com/kubescape/storage v0.0.239
+	github.com/kubescape/storage v0.0.246
 	github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/oleiade/lane/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1503,8 +1503,8 @@ github.com/kubescape/go-logger v0.0.24 h1:JRNlblY16Ty7hD6MSYNPvWYDxNzVAufsDDX/sZ
 github.com/kubescape/go-logger v0.0.24/go.mod h1:sMPVCr3VpW/e+SeMaXig5kClGvmZbDXN8YktUeNU4nY=
 github.com/kubescape/k8s-interface v0.0.202 h1:yu9x+07crFQAgrBatFFU2WuuxMJfHUMHVuCzuHE9Q4M=
 github.com/kubescape/k8s-interface v0.0.202/go.mod h1:d4NVhL81bVXe8yEXlkT4ZHrt3iEppEIN39b8N1oXm5s=
-github.com/kubescape/storage v0.0.239 h1:hfuq1+CuEAKE7zCg9bB8gfU9vZoGMrJBgNh5tAD1rak=
-github.com/kubescape/storage v0.0.239/go.mod h1:f6u/Lt3SjUTBrmzOStb33IkKTtaqKM4pyfV5d1lUMiY=
+github.com/kubescape/storage v0.0.246 h1:4RJysHGxcJ286Aqj1wZEYEPvGfhVcnHyY4iPa0tDeTg=
+github.com/kubescape/storage v0.0.246/go.mod h1:huYJIFh7TUAlV0W3+cmOh7KoJnWRcbWtGw0kY9YIrjU=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf/go.mod h1:Il5baM40PV9cTt4OGdLMeTRRAai3TMfvImu31itIeCM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -340,6 +340,8 @@ func (s *SbomManager) processContainer(notif containercollection.PubSubEvent, mo
 		// TODO we could save the error in a status field
 		return
 	}
+	// strip the SBOM to reduce size
+	v1beta1.StripSBOM(syftSBOM)
 	// prepare the SBOM
 	delete(wipSbom.Annotations, NodeNameMetadataKey)
 	wipSbom.Spec.Metadata.Report.CreatedAt = wipSbom.CreationTimestamp


### PR DESCRIPTION
## Summary

This PR strips unnecessary fields from generated SBOMs at creation time to reduce memory consumption across the entire system (node-agent, etcd, synchronizer, storage, kubevuln).

**Size reduction:** ~3.6 MB / 52% for large images (tested with Elasticsearch 8.7.1: 6.89 MB → 3.29 MB)

## Changes

Fields stripped from `pkg/sbommanager/v1/sbom_manager.go`:

- **Package metadata and metadataType** (JAR manifests, dpkg file lists, pomProperties, etc) - saves ~3.19 MB / 46%
- **License locations** - saves ~228 KB / 3.2%
- **Location accessPath and annotations** - saves ~159 KB / 2.2%
- **Package foundBy** cataloger name - saves ~15 KB
- **Source metadata and descriptor configuration** - saves ~20 KB

## Why these fields are safe to remove

These fields are **not used** by:
- ✅ **Grype/kubevuln** for vulnerability matching (uses name, version, type, purl, cpes)
- ✅ **Third party backend** (already stripped by synchronizer before sending)
- ✅ **Relevancy scanning** (uses files and artifactRelationships which are preserved)

## Impact

This change reduces memory pressure in:
- node-agent (SBOM generation and storage)
- etcd (CRD storage)
- synchronizer (SBOM forwarding)
- kubevuln (vulnerability scanning)

## Testing

- Existing tests continue to pass (no conversion logic tests exist)
- Validated against ARMO backend field usage analysis
- Files and artifactRelationships preserved for relevancy feature
- CPEs preserved for Phase 2 (requires kubevuln changes)

## Related

This is **Phase 1** of a multi-phase optimization:
- **Phase 1** (this PR): Strip safe fields - saves 52%
- **Phase 2** (future): Enable CPE regeneration in kubevuln and strip CPEs - saves additional 11%
- **Phase 3** (future): Redesign relevancy feature to eliminate files/relationships - saves additional 32%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimization**
  * Reduced SBOM sizes by stripping non‑essential metadata and configuration from generated reports immediately after creation, producing smaller payloads and more efficient transfer and storage without changing public outputs or interfaces.

* **Chores**
  * Updated storage dependency to a newer release to support the build and runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->