### PR TITLE
Pass alert platform to RuleFailureCreator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/anchore/syft v1.32.0
 	github.com/aquilax/truncate v1.0.0
-	github.com/armosec/armoapi-go v0.0.672
+	github.com/armosec/armoapi-go v0.0.678
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.672 h1:Js3yvV3GnqYCw3Dyq5HHo9br1mCthgrVwHuWCzNX/2w=
-github.com/armosec/armoapi-go v0.0.672/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.678 h1:trltW2KxO5OqrB2zHIPx8jqe82AFvdRryo2XgBEyJw8=
+github.com/armosec/armoapi-go v0.0.678/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=

--- a/pkg/rulemanager/rule_manager.go
+++ b/pkg/rulemanager/rule_manager.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	apitypes "github.com/armosec/armoapi-go/armotypes"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/goradd/maps"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
@@ -80,7 +81,7 @@ func CreateRuleManager(
 	celEvaluator cel.RuleEvaluator,
 	mntnsRegistry contextdetection.Registry,
 ) (*RuleManager, error) {
-	ruleFailureCreator := ruleadapters.NewRuleFailureCreator(enricher, dnsManager, adapterFactory)
+	ruleFailureCreator := ruleadapters.NewRuleFailureCreator(enricher, dnsManager, adapterFactory, apitypes.AlertSourcePlatformK8sAgent)
 	rulePolicyValidator := NewRulePolicyValidator(objectCache)
 	detectorManager := detectors.NewDetectorManager(mntnsRegistry)
 

--- a/pkg/rulemanager/ruleadapters/creator.go
+++ b/pkg/rulemanager/ruleadapters/creator.go
@@ -44,15 +44,17 @@ type RuleFailureCreator struct {
 	dnsManager       dnsmanager.DNSResolver
 	enricher         types.Enricher
 	hashCache        *expirable.LRU[string, *FileHashCache]
+	alertPlatform    apitypes.AlertSourcePlatform
 }
 
-func NewRuleFailureCreator(enricher types.Enricher, dnsManager dnsmanager.DNSResolver, adapterFactory *EventRuleAdapterFactory) *RuleFailureCreator {
+func NewRuleFailureCreator(enricher types.Enricher, dnsManager dnsmanager.DNSResolver, adapterFactory *EventRuleAdapterFactory, alertPlatform apitypes.AlertSourcePlatform) *RuleFailureCreator {
 	hashCache := expirable.NewLRU[string, *FileHashCache](hashCacheMaxSize, nil, hashCacheTTL)
 	return &RuleFailureCreator{
 		adapterFactory: adapterFactory,
 		dnsManager:     dnsManager,
 		enricher:       enricher,
 		hashCache:      hashCache,
+		alertPlatform:  alertPlatform,
 	}
 }
 
@@ -79,7 +81,7 @@ func (r *RuleFailureCreator) CreateRuleFailure(rule typesv1.Rule, enrichedEvent 
 			RuleDescription: message,
 		},
 		RuleID:         rule.ID,
-		AlertPlatform:  apitypes.AlertSourcePlatformK8s,
+		AlertPlatform:  r.alertPlatform,
 		IsTriggerAlert: rule.IsTriggerAlert,
 	}
 


### PR DESCRIPTION
Update github.com/armosec/armoapi-go to v0.0.678.

Pass AlertSourcePlatform to the constructor instead of hardcoding AlertSourcePlatformK8s. Set the value to AlertSourcePlatformK8sAgent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated Armosec armoapi-go dependency version

* **Improvements**
  * Enhanced alert platform configuration to dynamically support different source environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->