### PR TITLE
Remove LocalManager.host parameter from gadget execution to fix host detection

### DIFF
--- a/pkg/containerwatcher/v2/tracers/bpf.go
+++ b/pkg/containerwatcher/v2/tracers/bpf.go
@@ -68,10 +68,7 @@ func (bt *BpfTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(bt.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := bt.runtime.RunGadget(bt.gadgetCtx, nil, params)
+		err := bt.runtime.RunGadget(bt.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", bt.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/capabilities.go
+++ b/pkg/containerwatcher/v2/tracers/capabilities.go
@@ -70,7 +70,6 @@ func (ct *CapabilitiesTracer) Start(ctx context.Context) error {
 		params := map[string]string{
 			"operator.oci.ebpf.collect-kstack": "false",
 			"operator.oci.ebpf.unique":         "true",
-			"operator.LocalManager.host":       "true", // don't error if container-collection is nil when using local manager
 		}
 		err := ct.runtime.RunGadget(ct.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/dns.go
+++ b/pkg/containerwatcher/v2/tracers/dns.go
@@ -74,8 +74,7 @@ func (dt *DNSTracer) Start(ctx context.Context) error {
 	)
 	go func() {
 		params := map[string]string{
-			"operator.oci.ebpf.paths":    "true", // CWD paths in events
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
+			"operator.oci.ebpf.paths": "true", // CWD paths in events
 		}
 		err := dt.runtime.RunGadget(dt.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/exec.go
+++ b/pkg/containerwatcher/v2/tracers/exec.go
@@ -69,8 +69,7 @@ func (et *ExecTracer) Start(ctx context.Context) error {
 	)
 	go func() {
 		params := map[string]string{
-			"operator.oci.ebpf.paths":    "true", // CWD paths in events
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
+			"operator.oci.ebpf.paths": "true", // CWD paths in events
 		}
 		err := et.runtime.RunGadget(et.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/exit.go
+++ b/pkg/containerwatcher/v2/tracers/exit.go
@@ -64,10 +64,7 @@ func (et *ExitTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(et.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := et.runtime.RunGadget(et.gadgetCtx, nil, params)
+		err := et.runtime.RunGadget(et.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", et.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/fork.go
+++ b/pkg/containerwatcher/v2/tracers/fork.go
@@ -64,10 +64,7 @@ func (ft *ForkTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(ft.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := ft.runtime.RunGadget(ft.gadgetCtx, nil, params)
+		err := ft.runtime.RunGadget(ft.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", ft.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/hardlink.go
+++ b/pkg/containerwatcher/v2/tracers/hardlink.go
@@ -68,10 +68,7 @@ func (ht *HardlinkTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(ht.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := ht.runtime.RunGadget(ht.gadgetCtx, nil, params)
+		err := ht.runtime.RunGadget(ht.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", ht.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/http.go
+++ b/pkg/containerwatcher/v2/tracers/http.go
@@ -82,10 +82,7 @@ func (ht *HTTPTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(ht.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := ht.runtime.RunGadget(ht.gadgetCtx, nil, params)
+		err := ht.runtime.RunGadget(ht.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", ht.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/iouring.go
+++ b/pkg/containerwatcher/v2/tracers/iouring.go
@@ -82,10 +82,7 @@ func (it *IoUringTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(it.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := it.runtime.RunGadget(it.gadgetCtx, nil, params)
+		err := it.runtime.RunGadget(it.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", it.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/kmod.go
+++ b/pkg/containerwatcher/v2/tracers/kmod.go
@@ -68,10 +68,7 @@ func (kt *KmodTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(kt.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := kt.runtime.RunGadget(kt.gadgetCtx, nil, params)
+		err := kt.runtime.RunGadget(kt.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", kt.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/network.go
+++ b/pkg/containerwatcher/v2/tracers/network.go
@@ -83,8 +83,7 @@ func (nt *NetworkTracer) Start(ctx context.Context) error {
 	)
 	go func() {
 		params := map[string]string{
-			"operator.oci.annotate":      "network:kubenameresolver.enable=true",
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
+			"operator.oci.annotate": "network:kubenameresolver.enable=true",
 		}
 		err := nt.runtime.RunGadget(nt.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/open.go
+++ b/pkg/containerwatcher/v2/tracers/open.go
@@ -70,8 +70,7 @@ func (ot *OpenTracer) Start(ctx context.Context) error {
 	)
 	go func() {
 		params := map[string]string{
-			"operator.oci.ebpf.paths":    strconv.FormatBool(ot.cfg.EnableFullPathTracing),
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
+			"operator.oci.ebpf.paths": strconv.FormatBool(ot.cfg.EnableFullPathTracing),
 		}
 		err := ot.runtime.RunGadget(ot.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/ptrace.go
+++ b/pkg/containerwatcher/v2/tracers/ptrace.go
@@ -64,10 +64,7 @@ func (pt *PtraceTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(pt.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := pt.runtime.RunGadget(pt.gadgetCtx, nil, params)
+		err := pt.runtime.RunGadget(pt.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", pt.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/randomx.go
+++ b/pkg/containerwatcher/v2/tracers/randomx.go
@@ -65,10 +65,7 @@ func (rt *RandomXTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(rt.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := rt.runtime.RunGadget(rt.gadgetCtx, nil, params)
+		err := rt.runtime.RunGadget(rt.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", rt.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/ssh.go
+++ b/pkg/containerwatcher/v2/tracers/ssh.go
@@ -69,10 +69,7 @@ func (st *SSHTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(st.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := st.runtime.RunGadget(st.gadgetCtx, nil, params)
+		err := st.runtime.RunGadget(st.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", st.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/symlink.go
+++ b/pkg/containerwatcher/v2/tracers/symlink.go
@@ -68,10 +68,7 @@ func (st *SymlinkTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(st.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := st.runtime.RunGadget(st.gadgetCtx, nil, params)
+		err := st.runtime.RunGadget(st.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", st.gadgetCtx.Name()), helpers.Error(err))
 		}

--- a/pkg/containerwatcher/v2/tracers/syscall.go
+++ b/pkg/containerwatcher/v2/tracers/syscall.go
@@ -68,7 +68,6 @@ func (st *SyscallTracer) Start(ctx context.Context) error {
 		params := map[string]string{
 			"operator.oci.ebpf.map-fetch-count":    "0",
 			"operator.oci.ebpf.map-fetch-interval": "30s",
-			"operator.LocalManager.host":           "true", // don't error if container-collection is nil when using local manager
 		}
 		err := st.runtime.RunGadget(st.gadgetCtx, nil, params)
 		if err != nil {

--- a/pkg/containerwatcher/v2/tracers/unshare.go
+++ b/pkg/containerwatcher/v2/tracers/unshare.go
@@ -68,10 +68,7 @@ func (ut *UnshareTracer) Start(ctx context.Context) error {
 		gadgetcontext.WithOrasReadonlyTarget(ut.ociStore),
 	)
 	go func() {
-		params := map[string]string{
-			"operator.LocalManager.host": "true", // don't error if container-collection is nil when using local manager
-		}
-		err := ut.runtime.RunGadget(ut.gadgetCtx, nil, params)
+		err := ut.runtime.RunGadget(ut.gadgetCtx, nil, nil)
 		if err != nil {
 			logger.L().Error("Error running gadget", helpers.String("gadget", ut.gadgetCtx.Name()), helpers.Error(err))
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified runtime parameter configuration across multiple tracer implementations, removing environment-specific settings to streamline gadget initialization across process monitoring, network tracing, file operation tracking, and system call analysis features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->