### PR TITLE
fix http body parsing to respect Content-Length

### DIFF
--- a/pkg/containerwatcher/v2/tracers/httpparse.go
+++ b/pkg/containerwatcher/v2/tracers/httpparse.go
@@ -145,6 +145,12 @@ func ParseHttpResponse(data []byte, req *http.Request) (*http.Response, error) {
 	// Set body directly without re-reading.
 	// See ParseHttpRequest for why we need the Content-Length guard.
 	bodyData := data[headerEnd:]
+	if len(resp.TransferEncoding) > 0 && resp.TransferEncoding[0] == "chunked" {
+		decodedBody, err := io.ReadAll(httputil.NewChunkedReader(bytes.NewReader(bodyData)))
+		if err == nil {
+			bodyData = decodedBody
+		}
+	}
 	if resp.ContentLength >= 0 && resp.ContentLength < int64(len(bodyData)) {
 		bodyData = bodyData[:resp.ContentLength]
 	}

--- a/pkg/containerwatcher/v2/tracers/httpparse_test.go
+++ b/pkg/containerwatcher/v2/tracers/httpparse_test.go
@@ -73,6 +73,23 @@ func TestBPFBufferGarbageResponse(t *testing.T) {
 	assert.Equal(t, "OK", string(body))
 }
 
+func TestBPFBufferGarbageResponse_Chunked(t *testing.T) {
+	dummyReq, err := ParseHttpRequest([]byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+	require.NoError(t, err)
+
+	httpData := "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n"
+	buf := makeBPFBuffer(httpData)
+
+	cleaned := FromCString(buf)
+	assert.Equal(t, bpfBufSize, len(cleaned))
+
+	resp, err := ParseHttpResponse(cleaned, dummyReq)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "Wikipedia", string(body), "chunked response body should be decoded and should ignore trailing garbage")
+}
+
 func TestBPFBufferGarbageRequest_ContentLengthZero(t *testing.T) {
 	httpData := "GET / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n"
 	buf := makeBPFBuffer(httpData)


### PR DESCRIPTION
Truncate HTTP body to Content-Length in ParseHttpRequest and ParseHttpResponse to avoid BPF buffer garbage in parsed bodies.

Note: this only fixes the case where Content-Length is present. The proper fix is adding a buf_len field to the HTTP BPF gadget (syscall return value) so we can truncate at the source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request and response bodies now honor Content-Length and properly decode chunked Transfer-Encoding, trimming excess buffer data so payloads no longer include stray bytes.

* **Tests**
  * Added comprehensive parsing tests that simulate fixed-size buffer garbage and cover requests/responses across Content-Length scenarios (zero, absent, truncated, oversized) and chunked decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->