### PR TITLE
pass component prerelease image tag to E2E tests

### DIFF
--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -202,9 +202,9 @@ jobs:
             -f "client_payload[systests_branch]=${{ inputs.SYSTEM_TESTS_BRANCH }}" \
             -f "client_payload[in_cluster_chart_branch]=${{ inputs.HELM_BRANCH }}" \
             -f "client_payload[ks_branch]=release" \
-            -f "client_payload[charts_name]=kubescape-operator" \
-            -f "client_payload[charts_repo]=kubescape/helm-charts"
-          
+            -f "client_payload[charts_repo]=kubescape/helm-charts" \
+            -f "client_payload[component_image_tags]=${{ inputs.COMPONENT_NAME }}-tag=${{ needs.docker-build.outputs.IMAGE_TAG_PRERELEASE }}"
+
           echo "Dispatch completed"
 
       - name: Find E2E workflow run


### PR DESCRIPTION
## Summary
- Pass the prerelease image tag via `component_image_tags` in the E2E dispatch payload (local workflow copy)
- Same change as kubescape/workflows but for node-agent's local `incluster-comp-pr-merged.yaml`
- Removes `charts_name` from dispatch (receiver defaults it) to stay within GitHub's 10 key limit on `client_payload`

## How it works
The dispatch now includes `component_image_tags=nodeAgent-tag=<prerelease-version>`. The receiver forwards it to system tests which override the helm chart image tag.

## Test plan
- [ ] Merge armosec/shared-workflows companion PR first
- [ ] Trigger a node-agent PR merge and verify E2E tests use the prerelease image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow dispatch for test runs: removed a hard-coded chart identifier and added explicit component image tag information so automated tests receive built artifact details more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->