### PR TITLE
fix: support non-overlay snapshotters (ZFS, btrfs) in SBOM manager

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -166,6 +166,12 @@ func (s *SbomManager) getMountedVolumes(pid string) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get mounts: %w", err)
 	}
+	if len(mounts) == 0 {
+		// No overlay mount found — container is using a non-overlay snapshotter (e.g. ZFS, btrfs).
+		// /proc/<pid>/root is a kernel-provided path that exposes the container's merged root
+		// filesystem on the host regardless of the underlying snapshotter.
+		return []string{filepath.Join(s.procDir, pid, "root")}, nil
+	}
 	for _, option := range strings.Split(mounts[0].VFSOptions, ",") {
 		if strings.HasPrefix(option, "lowerdir=") {
 			var volumes []string


### PR DESCRIPTION
## Problem

When containerd is configured with the ZFS snapshotter (or any non-overlay snapshotter), container root filesystems are mounted as native ZFS datasets — there is no `overlay` entry in `/proc/<pid>/mountinfo`. The SBOM manager only knew how to find overlay mounts, causing a panic (index out of range) and then, after the previous partial fix, silently skipping SBOM generation entirely for affected containers.

Reported by users running containerd with `snapshotter = "zfs"` on Ubuntu 24 / bare metal clusters (see kubescape/helm-charts#806).

## Fix

When no overlay mount is found, fall back to `/proc/<pid>/root` — a kernel-provided path that exposes the container's merged root filesystem on the host regardless of the underlying snapshotter (ZFS, btrfs, native, etc.).

## Caveats

- With overlay, packages are attributed to specific image layers. With non-overlay snapshotters, all packages are attributed to a single layer (the merged root). SBOM content is correct; layer metadata is less granular.
- `/proc/<pid>/root` disappears if the container exits before scanning completes — same behavior as overlay lowerdirs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness in volume mount detection by adding fallback handling for edge cases where mount data is unavailable, preventing potential crashes and improving overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->