### PR TITLE
get services from API, removing sidecar requirement

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -395,7 +395,11 @@ func main() {
 
 	// Create scan failure reporter (sends SBOM failures to careportreceiver for user notifications)
 	var failureReporter sbommanager.SbomFailureReporter
-	if services, svcErr := config.LoadServiceURLs("/etc/config/services.json"); svcErr == nil && services.GetReportReceiverHttpUrl() != "" {
+	apiURL := os.Getenv("API_URL")
+	if apiURL == "" {
+		apiURL = "api.armosec.io"
+	}
+	if services, svcErr := config.LoadServiceURLs(apiURL); svcErr == nil && services.GetReportReceiverHttpUrl() != "" {
 		failureReporter = sbommanagerv1.NewHTTPSbomFailureReporter(services.GetReportReceiverHttpUrl(), accessKey, clusterData.AccountID, clusterData.ClusterName)
 		logger.L().Info("scan failure reporting enabled", helpers.String("eventReceiverURL", services.GetReportReceiverHttpUrl()))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/kubescape/backend/pkg/servicediscovery"
 	"github.com/kubescape/backend/pkg/servicediscovery/schema"
-	servicediscoveryv2 "github.com/kubescape/backend/pkg/servicediscovery/v2"
+	servicediscoveryv3 "github.com/kubescape/backend/pkg/servicediscovery/v3"
 	"github.com/kubescape/node-agent/pkg/exporters"
 	"github.com/kubescape/node-agent/pkg/hostfimsensor/v1"
 	processtreecreator "github.com/kubescape/node-agent/pkg/processtree/config"
@@ -289,13 +289,12 @@ func (c *Config) SkipNamespace(ns string) bool {
 	return false
 }
 
-func LoadServiceURLs(filePath string) (schema.IBackendServices, error) {
-	if pathFromEnv, present := os.LookupEnv("SERVICES"); present {
-		filePath = pathFromEnv
+func LoadServiceURLs(apiURL string) (schema.IBackendServices, error) {
+	client, err := servicediscoveryv3.NewServiceDiscoveryClientV3(apiURL)
+	if err != nil {
+		return nil, err
 	}
-	return servicediscovery.GetServices(
-		servicediscoveryv2.NewServiceDiscoveryFileV2(filePath),
-	)
+	return servicediscovery.GetServices(client)
 }
 
 type OrderedEventQueueConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -289,12 +289,39 @@ func (c *Config) SkipNamespace(ns string) bool {
 	return false
 }
 
+const serviceDiscoveryTimeout = 10 * time.Second
+
 func LoadServiceURLs(apiURL string) (schema.IBackendServices, error) {
+	// Preserve backward compatibility with sidecar/file-based deployments.
+	// SERVICES env var or the default mount path takes priority over API discovery.
+	filePath := "/etc/config/services.json"
+	if pathFromEnv, present := os.LookupEnv("SERVICES"); present {
+		filePath = pathFromEnv
+	}
+	if _, statErr := os.Stat(filePath); statErr == nil {
+		return servicediscovery.GetServices(servicediscoveryv3.NewServiceDiscoveryFileV3(filePath))
+	}
+
 	client, err := servicediscoveryv3.NewServiceDiscoveryClientV3(apiURL)
 	if err != nil {
 		return nil, err
 	}
-	return servicediscovery.GetServices(client)
+
+	type result struct {
+		svc schema.IBackendServices
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		svc, svcErr := servicediscovery.GetServices(client)
+		ch <- result{svc, svcErr}
+	}()
+	select {
+	case r := <-ch:
+		return r.svc, r.err
+	case <-time.After(serviceDiscoveryTimeout):
+		return nil, fmt.Errorf("service discovery timed out after %s", serviceDiscoveryTimeout)
+	}
 }
 
 type OrderedEventQueueConfig struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Service discovery now supports the `API_URL` environment variable for dynamic endpoint configuration, defaulting to `api.armosec.io` when unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->