### PR TITLE
fix(utils): restore NormalizePath to fix headless /proc and dot paths

### DIFF
--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -397,7 +397,7 @@ func (e *DatasourceEvent) GetEventType() EventType {
 
 func (e *DatasourceEvent) GetExePath() string {
 	exepath, _ := e.getFieldAccessor("exepath").String(e.Data)
-	return exepath
+	return NormalizePath(exepath)
 }
 
 func (e *DatasourceEvent) GetExitCode() uint32 {
@@ -439,7 +439,7 @@ func (e *DatasourceEvent) GetFullPath() string {
 	if path == "" {
 		path, _ = e.getFieldAccessor("fname").String(e.Data)
 	}
-	return path
+	return NormalizePath(path)
 }
 
 func (e *DatasourceEvent) GetGid() *uint32 {
@@ -490,7 +490,7 @@ func (e *DatasourceEvent) GetNamespace() string {
 
 func (e *DatasourceEvent) GetNewPath() string {
 	newPath, _ := e.getFieldAccessor("newpath").String(e.Data)
-	return newPath
+	return NormalizePath(newPath)
 }
 
 func (e *DatasourceEvent) GetNumAnswers() int {
@@ -500,7 +500,7 @@ func (e *DatasourceEvent) GetNumAnswers() int {
 
 func (e *DatasourceEvent) GetOldPath() string {
 	oldPath, _ := e.getFieldAccessor("oldpath").String(e.Data)
-	return oldPath
+	return NormalizePath(oldPath)
 }
 
 func (e *DatasourceEvent) GetOpcode() int {
@@ -526,7 +526,7 @@ func (e *DatasourceEvent) GetPath() string {
 		return e.GetFullPath()
 	}
 	path, _ := e.getFieldAccessor("fname").String(e.Data)
-	return path
+	return NormalizePath(path)
 }
 
 func (e *DatasourceEvent) GetPcomm() string {

--- a/pkg/utils/normalize_path_test.go
+++ b/pkg/utils/normalize_path_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty path",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "dot path",
+			input:    ".",
+			expected: "/",
+		},
+		{
+			name:     "absolute path",
+			input:    "/etc/passwd",
+			expected: "/etc/passwd",
+		},
+		{
+			name:     "headless proc path (task)",
+			input:    "/46/task/46/fd",
+			expected: "/proc/46/task/46/fd",
+		},
+		{
+			name:     "headless proc path (fd)",
+			input:    "/46/fd/3",
+			expected: "/proc/46/fd/3",
+		},
+		{
+			name:     "already absolute proc path",
+			input:    "/proc/46/fd/3",
+			expected: "/proc/46/fd/3",
+		},
+		{
+			name:     "relative path (not dot)",
+			input:    "usr/bin/ls",
+			expected: "/usr/bin/ls",
+		},
+		{
+			name:     "relative path with ./",
+			input:    "./config",
+			expected: "/config",
+		},
+		{
+			name:     "path with redundant slashes",
+			input:    "/etc//passwd",
+			expected: "/etc/passwd",
+		},
+		{
+			name:     "path with dot components",
+			input:    "/usr/./bin/../lib",
+			expected: "/usr/lib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizePath(tt.input); got != tt.expected {
+				t.Errorf("NormalizePath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/utils/normalize_path_test.go
+++ b/pkg/utils/normalize_path_test.go
@@ -41,6 +41,16 @@ func TestNormalizePath(t *testing.T) {
 			expected: "/proc/46/fd/3",
 		},
 		{
+			name:     "terminal headless proc fd path",
+			input:    "/46/fd",
+			expected: "/proc/46/fd",
+		},
+		{
+			name:     "terminal headless proc task path",
+			input:    "/46/task",
+			expected: "/proc/46/task",
+		},
+		{
 			name:     "relative path (not dot)",
 			input:    "usr/bin/ls",
 			expected: "/usr/bin/ls",

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"path"
+	"regexp"
+	"strings"
+)
+
+var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd)/`)
+
+// NormalizePath normalizes a path by:
+// 1. Prepending "/proc" to "headless" proc paths (e.g. /46/task/46/fd -> /proc/46/task/46/fd)
+// 2. Ensuring it starts with "/" if it's not empty
+// 3. Converting "." to "/"
+// 4. Cleaning the path (removing redundant slashes, dot-dots, etc.)
+func NormalizePath(p string) string {
+	if p == "" {
+		return ""
+	}
+
+	if p == "." {
+		return "/"
+	}
+
+	if headlessProcRegex.MatchString(p) {
+		p = "/proc" + p
+	}
+
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+
+	return path.Clean(p)
+}

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd)/`)
+var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd)(/|$)`)
 
 // NormalizePath normalizes a path by:
 // 1. Prepending "/proc" to "headless" proc paths (e.g. /46/task/46/fd -> /proc/46/task/46/fd)

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -227,7 +227,7 @@ func (e *StructEvent) GetEventType() EventType {
 }
 
 func (e *StructEvent) GetExePath() string {
-	return e.ExePath
+	return NormalizePath(e.ExePath)
 }
 
 func (e *StructEvent) GetExitCode() uint32 {
@@ -247,7 +247,7 @@ func (e *StructEvent) GetFlagsRaw() uint32 {
 }
 
 func (e *StructEvent) GetFullPath() string {
-	return e.FullPath
+	return NormalizePath(e.FullPath)
 }
 
 func (e *StructEvent) GetGid() *uint32 {
@@ -279,7 +279,7 @@ func (e *StructEvent) GetNamespace() string {
 }
 
 func (e *StructEvent) GetNewPath() string {
-	return e.NewPath
+	return NormalizePath(e.NewPath)
 }
 
 func (e *StructEvent) GetNumAnswers() int {
@@ -287,7 +287,7 @@ func (e *StructEvent) GetNumAnswers() int {
 }
 
 func (e *StructEvent) GetOldPath() string {
-	return e.OldPath
+	return NormalizePath(e.OldPath)
 }
 
 func (e *StructEvent) GetOpcode() int {
@@ -311,7 +311,7 @@ func (e *StructEvent) GetPath() string {
 	if e.FullPathTracing {
 		return e.GetFullPath()
 	}
-	return e.Path
+	return NormalizePath(e.Path)
 }
 
 func (e *StructEvent) GetPcomm() string {


### PR DESCRIPTION
## Overview
Commit https://github.com/kubescape/node-agent/commit/9597da4b9e30eac0f6149695049e104cd1b6642b refactored datasource_event.go to suppress verbose field
length warnings, but silently dropped the NormalizePath() calls that were
introduced in https://github.com/kubescape/node-agent/commit/eafe0666684df07fd3a86041458b2a2baf81dc3b. This caused raw eBPF paths to be surfaced without
normalization, resulting in:

    Headless /proc paths: /46/task/46/fd instead of /proc/46/task/46/fd
    runc paths reported as . instead of /
    Relative paths missing a leading /

This PR restores pkg/utils/path.go with the NormalizePath() function and
re-wires it into the GetPath, GetFullPath, GetExePath, GetNewPath, and
GetOldPath getter methods in both DatasourceEvent and StructEvent.

Testing -
Deploy the node-agent and inspect open events or an ApplicationProfile.
Paths should be fully absolute (e.g. /proc/46/task/46/fd) with no bare .
entries.

Unit tests can be run locally with:
go test ./pkg/utils/...

This fixes #721 

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ x] If it is a core feature, I have added thorough tests.
- [ x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of file path handling by normalizing all returned paths across event tracking
  * Fixed path handling for edge cases including relative paths and special filesystem formats

* **Tests**
  * Added comprehensive test coverage for path normalization logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->