### PR TITLE
fix: remove job-level permissions from benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -31,9 +31,6 @@ concurrency:
 jobs:
   benchmark:
     runs-on: ubuntu-large
-    permissions:
-      pull-requests: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -130,6 +127,7 @@ jobs:
       - name: Comment on PR
         uses: peter-evans/create-or-update-comment@v4
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: report.md


### PR DESCRIPTION
The benchmark job declared `pull-requests: write` which conflicts with the release pipeline (`incluster-comp-pr-merged.yaml`) that only grants `pull-requests: read`, causing a `startup_failure` on merge.

Removes the job-level permissions block so the workflow inherits caller permissions. The PR comment step already guards with `if: github.event_name == 'pull_request'` and now has `continue-on-error` for safety.

Fixes: https://github.com/kubescape/node-agent/actions/runs/24457924116