### PR TITLE
chore: add package doc to dedupcache

### DIFF
--- a/pkg/dedupcache/dedup_cache.go
+++ b/pkg/dedupcache/dedup_cache.go
@@ -1,3 +1,5 @@
+// Package dedupcache provides a lock-free, fixed-size deduplication cache
+// for high-throughput eBPF event filtering before CEL rule evaluation.
 package dedupcache
 
 import (


### PR DESCRIPTION
Adds package-level documentation to the dedupcache package. Trigger for release.