### PR TITLE
fix: remove DNS events from dedup cache

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -99,7 +99,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python dependencies
-        run: pip install -r benchmark/requirements.txt
+        run: pip install -r benchmark/requirements.txt || pip install -r benchmark/requirements.txt
 
       - name: Run benchmark
         env:

--- a/pkg/containerwatcher/v2/event_handler_factory.go
+++ b/pkg/containerwatcher/v2/event_handler_factory.go
@@ -49,7 +49,6 @@ func (ma *ManagerAdapter) ReportEvent(eventType utils.EventType, event utils.K8s
 const (
 	dedupTTLOpen         uint16 = 156 // 10s
 	dedupTTLNetwork      uint16 = 78  // 5s
-	dedupTTLDNS          uint16 = 156 // 10s
 	dedupTTLCapabilities uint16 = 156 // 10s
 	dedupTTLHTTP         uint16 = 31  // 2s
 	dedupTTLSSH          uint16 = 156 // 10s
@@ -228,10 +227,9 @@ func computeEventDedupKey(enrichedEvent *events.EnrichedEvent) (key uint64, ttl 
 			dst := e.GetDstEndpoint()
 			return dedupcache.ComputeNetworkKey(mntns, pid, dst.Addr, e.GetDstPort(), e.GetProto()), dedupTTLNetwork, true
 		}
-	case utils.DnsEventType:
-		if e, ok := event.(utils.DNSEvent); ok {
-			return dedupcache.ComputeDNSKey(mntns, e.GetDNSName()), dedupTTLDNS, true
-		}
+	// DNS events are not deduplicated: the system resolver cache already
+	// limits DNS traffic at the network layer, so events reaching the eBPF
+	// tracer are almost always unique.
 	case utils.CapabilitiesEventType:
 		if e, ok := event.(utils.CapabilitiesEvent); ok {
 			pid := uint32(0)


### PR DESCRIPTION
DNS events don't benefit from deduplication — the system resolver cache already limits DNS traffic at the network layer, so events reaching the eBPF tracer are almost always unique. Benchmark data confirms 0% dedup ratio for DNS.

Removes the DNS case from `computeEventDedupKey` and the unused `dedupTTLDNS` constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified DNS event handling to prevent unintended deduplication, allowing DNS events to be processed individually rather than consolidated through the deduplication cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->