### PR TITLE
add process-name exclude prefilter options

### DIFF
--- a/pkg/rulemanager/extract_event_fields_test.go
+++ b/pkg/rulemanager/extract_event_fields_test.go
@@ -27,6 +27,23 @@ func TestExtractEventFields(t *testing.T) {
 			expect: prefilter.EventFields{Path: "/usr/bin/curl", Extracted: true},
 		},
 		{
+			name: "exec event extracts process fields for exclude prefilter",
+			event: &utils.StructEvent{
+				EventType:     utils.ExecveEventType,
+				ExePath:       "/usr/bin/rpm",
+				ParentExePath: "/usr/bin/inspector-ssm-plugin",
+				Comm:          "rpm",
+				Pcomm:         "inspectorssmplu",
+			},
+			expect: prefilter.EventFields{
+				Path:          "/usr/bin/rpm",
+				ParentExePath: "/usr/bin/inspector-ssm-plugin",
+				Comm:          "rpm",
+				Pcomm:         "inspectorssmplu",
+				Extracted:     true,
+			},
+		},
+		{
 			name:   "HTTP event extracts direction, method, port",
 			event:  &utils.StructEvent{EventType: utils.HTTPEventType, Direction: consts.Inbound, DstPort: 8080, Request: &http.Request{Method: "POST"}},
 			expect: prefilter.EventFields{Dir: prefilter.DirInbound, MethodBit: prefilter.MethodPOST, DstPort: 8080, Extracted: true},

--- a/pkg/rulemanager/prefilter/prefilter.go
+++ b/pkg/rulemanager/prefilter/prefilter.go
@@ -70,15 +70,20 @@ func methodToBit(method string) MethodMask {
 }
 
 // EventFields holds event data extracted once per event for pre-filtering.
-// Passed by value (stack-allocated, ~28 bytes) — extracted once before the
-// rule loop, reused across all rules.
+// Passed by value, stack-allocated, extracted once before the rule loop and
+// reused across all rules.
 type EventFields struct {
-	Path         string     // file/exec path (empty if not applicable)
-	DstPort      uint16     // destination port from network/SSH event
-	Dir          Direction  // pre-computed from HTTP direction string
-	MethodBit    MethodMask // pre-computed from HTTP method string
-	PortEligible bool       // true for SSH/network events (port filter applies)
-	Extracted    bool       // true after extractEventFields has run
+	Path string // file path (open) or exe path (exec); empty otherwise
+	// Exec-only fields; empty for other event types.
+	// Comm and Pcomm are kernel-truncated to 15 chars.
+	ParentExePath string
+	Comm          string
+	Pcomm         string
+	DstPort       uint16     // destination port from network/SSH event
+	Dir           Direction  // pre-computed from HTTP direction string
+	MethodBit     MethodMask // pre-computed from HTTP method string
+	PortEligible  bool       // true for SSH/network events (port filter applies)
+	Extracted     bool       // true after extractEventFields has run
 }
 
 // SetDirection converts a direction string to its compact representation.
@@ -91,25 +96,41 @@ func (f *EventFields) SetMethod(method string) {
 	f.MethodBit = methodToBit(method)
 }
 
+// processKey pairs a kernel-truncated process name with its full exe path.
+// Both fields must match for an exclude entry to suppress an event.
+type processKey struct {
+	Name string
+	Path string
+}
+
 // Params holds parsed, typed parameters for cheap pre-CEL filtering.
 // Parsed once at rule binding time. A non-nil *Params always has at least
 // one active filter.
 type Params struct {
-	IgnorePrefixes  []string   // open, exec — skip if path starts with prefix
-	IncludePrefixes []string   // open, exec — skip if path does NOT match any prefix
-	Ports           []uint16   // SSH, network — skip if port is NOT in list
-	Dir             Direction  // HTTP — DirInbound or DirOutbound
-	MethodMask      MethodMask // HTTP — bitmask of allowed methods
+	IgnorePrefixes         []string                // open, exec — skip if path starts with prefix
+	IncludePrefixes        []string                // open, exec — skip if path does NOT match any prefix
+	ExcludeProcesses       map[processKey]struct{} // exec — skip if (comm, exepath) matches
+	ExcludeParentProcesses map[processKey]struct{} // exec — skip if (pcomm, parent_exepath) matches
+	Ports                  []uint16                // SSH, network — skip if port is NOT in list
+	Dir                    Direction               // HTTP — DirInbound or DirOutbound
+	MethodMask             MethodMask              // HTTP — bitmask of allowed methods
+}
+
+type rawProcessEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
 }
 
 // rawParams is the JSON/YAML-decodable shape of pre-filter parameters.
 // encoding/json handles all numeric type coercion (float64, int, int64, etc.)
 type rawParams struct {
-	IgnorePrefixes  []string `json:"ignorePrefixes"`
-	IncludePrefixes []string `json:"includePrefixes"`
-	Ports           []uint16 `json:"ports"`
-	Direction       string   `json:"direction"`
-	Methods         []string `json:"methods"`
+	IgnorePrefixes         []string          `json:"ignorePrefixes"`
+	IncludePrefixes        []string          `json:"includePrefixes"`
+	Ports                  []uint16          `json:"ports"`
+	Direction              string            `json:"direction"`
+	Methods                []string          `json:"methods"`
+	ExcludeProcesses       []rawProcessEntry `json:"excludeProcesses"`
+	ExcludeParentProcesses []rawProcessEntry `json:"excludeParentProcesses"`
 }
 
 // ParseWithDefaults merges pre-filter parameters from two sources:
@@ -176,10 +197,47 @@ func ParseWithDefaults(ruleState map[string]any, bindingParams map[string]any) *
 		}
 	}
 
+	if m := buildProcessMap(raw.ExcludeProcesses, "excludeProcesses"); m != nil {
+		p.ExcludeProcesses = m
+		hasFilter = true
+	}
+
+	if m := buildProcessMap(raw.ExcludeParentProcesses, "excludeParentProcesses"); m != nil {
+		p.ExcludeParentProcesses = m
+		hasFilter = true
+	}
+
 	if !hasFilter {
 		return nil
 	}
 	return p
+}
+
+// buildProcessMap converts a list of (name, path) entries to a lookup map.
+// Entries missing either field are dropped; a single aggregated warning is
+// emitted if any were dropped. Returns nil when no valid entries remain.
+func buildProcessMap(entries []rawProcessEntry, field string) map[processKey]struct{} {
+	if len(entries) == 0 {
+		return nil
+	}
+	m := make(map[processKey]struct{}, len(entries))
+	dropped := 0
+	for _, entry := range entries {
+		if entry.Name == "" || entry.Path == "" {
+			dropped++
+			continue
+		}
+		m[processKey{Name: entry.Name, Path: entry.Path}] = struct{}{}
+	}
+	if dropped > 0 {
+		logger.L().Warning("prefilter: dropped entries with empty name or path",
+			helpers.String("field", field),
+			helpers.Int("dropped", dropped))
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 // ShouldSkip returns true if the event should be skipped.
@@ -209,6 +267,18 @@ func (p *Params) ShouldSkip(e EventFields) bool {
 
 	if e.PortEligible && len(p.Ports) > 0 && !slices.Contains(p.Ports, e.DstPort) {
 		return true
+	}
+
+	if len(p.ExcludeProcesses) > 0 && e.Comm != "" && e.Path != "" {
+		if _, ok := p.ExcludeProcesses[processKey{Name: e.Comm, Path: e.Path}]; ok {
+			return true
+		}
+	}
+
+	if len(p.ExcludeParentProcesses) > 0 && e.Pcomm != "" && e.ParentExePath != "" {
+		if _, ok := p.ExcludeParentProcesses[processKey{Name: e.Pcomm, Path: e.ParentExePath}]; ok {
+			return true
+		}
 	}
 
 	return false

--- a/pkg/rulemanager/prefilter/prefilter.go
+++ b/pkg/rulemanager/prefilter/prefilter.go
@@ -241,9 +241,9 @@ func buildProcessMap(entries []rawProcessEntry, field string) map[processKey]str
 }
 
 // ShouldSkip returns true if the event should be skipped.
-// Hot path — integer/bitmask comparisons only, no allocations.
+// Hot path — takes *EventFields to avoid copying the struct per call.
 // Safe to call on nil receiver (returns false).
-func (p *Params) ShouldSkip(e EventFields) bool {
+func (p *Params) ShouldSkip(e *EventFields) bool {
 	if p == nil {
 		return false
 	}

--- a/pkg/rulemanager/prefilter/prefilter.go
+++ b/pkg/rulemanager/prefilter/prefilter.go
@@ -7,6 +7,7 @@ import (
 
 	logger "github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/node-agent/pkg/utils"
 )
 
 // Direction represents an HTTP traffic direction as a compact integer.
@@ -214,8 +215,9 @@ func ParseWithDefaults(ruleState map[string]any, bindingParams map[string]any) *
 }
 
 // buildProcessMap converts a list of (name, path) entries to a lookup map.
-// Entries missing either field are dropped; a single aggregated warning is
-// emitted if any were dropped. Returns nil when no valid entries remain.
+// Entries with a missing name or a path that normalizes to empty or "/" are
+// dropped; a single aggregated warning is emitted if any were dropped.
+// Returns nil when no valid entries remain.
 func buildProcessMap(entries []rawProcessEntry, field string) map[processKey]struct{} {
 	if len(entries) == 0 {
 		return nil
@@ -223,14 +225,15 @@ func buildProcessMap(entries []rawProcessEntry, field string) map[processKey]str
 	m := make(map[processKey]struct{}, len(entries))
 	dropped := 0
 	for _, entry := range entries {
-		if entry.Name == "" || entry.Path == "" {
+		normalized := utils.NormalizePath(entry.Path)
+		if entry.Name == "" || normalized == "" || normalized == "/" {
 			dropped++
 			continue
 		}
-		m[processKey{Name: entry.Name, Path: entry.Path}] = struct{}{}
+		m[processKey{Name: entry.Name, Path: normalized}] = struct{}{}
 	}
 	if dropped > 0 {
-		logger.L().Warning("prefilter: dropped entries with empty name or path",
+		logger.L().Warning("prefilter: dropped entries with missing name or invalid path",
 			helpers.String("field", field),
 			helpers.Int("dropped", dropped))
 	}

--- a/pkg/rulemanager/prefilter/prefilter_test.go
+++ b/pkg/rulemanager/prefilter/prefilter_test.go
@@ -113,6 +113,38 @@ func TestParseWithDefaults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "excludeProcesses path normalized (trailing slash, missing leading slash, redundant segments)",
+			bindingParams: map[string]any{
+				"excludeProcesses": []interface{}{
+					map[string]interface{}{"name": "dockerd", "path": "/usr/bin/dockerd/"},
+					map[string]interface{}{"name": "rpm", "path": "usr/bin/rpm"},
+					map[string]interface{}{"name": "curl", "path": "/usr/./bin/curl"},
+				},
+			},
+			expect: &Params{
+				ExcludeProcesses: map[processKey]struct{}{
+					{Name: "dockerd", Path: "/usr/bin/dockerd"}: {},
+					{Name: "rpm", Path: "/usr/bin/rpm"}:         {},
+					{Name: "curl", Path: "/usr/bin/curl"}:       {},
+				},
+			},
+		},
+		{
+			name: "excludeProcesses path that normalizes to root is dropped",
+			bindingParams: map[string]any{
+				"excludeProcesses": []interface{}{
+					map[string]interface{}{"name": "wildcard", "path": "."},
+					map[string]interface{}{"name": "root", "path": "/"},
+					map[string]interface{}{"name": "dockerd", "path": "/usr/bin/dockerd"},
+				},
+			},
+			expect: &Params{
+				ExcludeProcesses: map[processKey]struct{}{
+					{Name: "dockerd", Path: "/usr/bin/dockerd"}: {},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/rulemanager/prefilter/prefilter_test.go
+++ b/pkg/rulemanager/prefilter/prefilter_test.go
@@ -258,7 +258,8 @@ func TestShouldSkip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.params.ShouldSkip(tt.event))
+			event := tt.event
+			assert.Equal(t, tt.want, tt.params.ShouldSkip(&event))
 		})
 	}
 }
@@ -272,7 +273,7 @@ func BenchmarkShouldSkip_EarlyExit(b *testing.B) {
 	e := EventFields{Path: "/etc/passwd", Dir: DirOutbound, MethodBit: MethodGET}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p.ShouldSkip(e)
+		p.ShouldSkip(&e)
 	}
 }
 
@@ -285,6 +286,6 @@ func BenchmarkShouldSkip_FullScan(b *testing.B) {
 	e := EventFields{Path: "/etc/passwd", Dir: DirInbound, MethodBit: MethodPOST}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		p.ShouldSkip(e)
+		p.ShouldSkip(&e)
 	}
 }

--- a/pkg/rulemanager/prefilter/prefilter_test.go
+++ b/pkg/rulemanager/prefilter/prefilter_test.go
@@ -71,6 +71,48 @@ func TestParseWithDefaults(t *testing.T) {
 			bindingParams: map[string]any{"ignorePrefixes": []interface{}{"/tmp"}},
 			expect:        &Params{IgnorePrefixes: []string{"/tmp"}},
 		},
+		{
+			name: "excludeProcesses parsed",
+			bindingParams: map[string]any{
+				"excludeProcesses": []interface{}{
+					map[string]interface{}{"name": "dockerd", "path": "/usr/bin/dockerd"},
+				},
+			},
+			expect: &Params{
+				ExcludeProcesses: map[processKey]struct{}{
+					{Name: "dockerd", Path: "/usr/bin/dockerd"}: {},
+				},
+			},
+		},
+		{
+			name: "excludeParentProcesses parsed with multiple entries",
+			bindingParams: map[string]any{
+				"excludeParentProcesses": []interface{}{
+					map[string]interface{}{"name": "inspectorssmplu", "path": "/usr/bin/inspector-ssm-plugin"},
+					map[string]interface{}{"name": "ssm-agent-worke", "path": "/usr/bin/ssm-agent-worker"},
+				},
+			},
+			expect: &Params{
+				ExcludeParentProcesses: map[processKey]struct{}{
+					{Name: "inspectorssmplu", Path: "/usr/bin/inspector-ssm-plugin"}: {},
+					{Name: "ssm-agent-worke", Path: "/usr/bin/ssm-agent-worker"}:     {},
+				},
+			},
+		},
+		{
+			name: "excludeProcesses mixed valid and invalid entries",
+			bindingParams: map[string]any{
+				"excludeProcesses": []interface{}{
+					map[string]interface{}{"name": "", "path": "/usr/bin/foo"},
+					map[string]interface{}{"name": "dockerd", "path": "/usr/bin/dockerd"},
+				},
+			},
+			expect: &Params{
+				ExcludeProcesses: map[processKey]struct{}{
+					{Name: "dockerd", Path: "/usr/bin/dockerd"}: {},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,6 +184,76 @@ func TestShouldSkip(t *testing.T) {
 		{"file: not in include", &Params{IncludePrefixes: []string{"/etc"}, IgnorePrefixes: []string{"/etc/default"}}, EventFields{Path: "/tmp/foo"}, true},
 		{"file: in include but ignored", &Params{IncludePrefixes: []string{"/etc"}, IgnorePrefixes: []string{"/etc/default"}}, EventFields{Path: "/etc/default/grub"}, true},
 		{"file: in include not ignored", &Params{IncludePrefixes: []string{"/etc"}, IgnorePrefixes: []string{"/etc/default"}}, EventFields{Path: "/etc/shadow"}, false},
+
+		// --- excludeProcesses (comm + exepath pair) ---
+		{
+			"excludeProcesses: both match",
+			&Params{ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}}},
+			EventFields{Comm: "dockerd", Path: "/usr/bin/dockerd"},
+			true,
+		},
+		{
+			"excludeProcesses: comm matches but path differs (anti-spoof)",
+			&Params{ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}}},
+			EventFields{Comm: "dockerd", Path: "/tmp/attacker/dockerd"},
+			false,
+		},
+		{
+			"excludeProcesses: path matches but comm differs",
+			&Params{ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}}},
+			EventFields{Comm: "rpm", Path: "/usr/bin/dockerd"},
+			false,
+		},
+		{
+			"excludeProcesses: empty comm on event (no skip)",
+			&Params{ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}}},
+			EventFields{Path: "/usr/bin/dockerd"},
+			false,
+		},
+		{
+			"excludeProcesses: empty path on event (no skip)",
+			&Params{ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}}},
+			EventFields{Comm: "dockerd"},
+			false,
+		},
+
+		// --- excludeParentProcesses (pcomm + parent_exepath pair) ---
+		{
+			"excludeParentProcesses: both match (R1058 ssm-agent-worker)",
+			&Params{ExcludeParentProcesses: map[processKey]struct{}{{Name: "ssm-agent-worke", Path: "/usr/bin/ssm-agent-worker"}: {}}},
+			EventFields{Pcomm: "ssm-agent-worke", ParentExePath: "/usr/bin/ssm-agent-worker"},
+			true,
+		},
+		{
+			"excludeParentProcesses: pcomm matches but parent path differs",
+			&Params{ExcludeParentProcesses: map[processKey]struct{}{{Name: "ssm-agent-worke", Path: "/usr/bin/ssm-agent-worker"}: {}}},
+			EventFields{Pcomm: "ssm-agent-worke", ParentExePath: "/tmp/fake"},
+			false,
+		},
+		{
+			"excludeParentProcesses: empty pcomm on event (no skip)",
+			&Params{ExcludeParentProcesses: map[processKey]struct{}{{Name: "ssm-agent-worke", Path: "/usr/bin/ssm-agent-worker"}: {}}},
+			EventFields{ParentExePath: "/usr/bin/ssm-agent-worker"},
+			false,
+		},
+		{
+			"excludeProcesses and excludeParentProcesses: neither matches",
+			&Params{
+				ExcludeProcesses:       map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}},
+				ExcludeParentProcesses: map[processKey]struct{}{{Name: "ssm-agent-worke", Path: "/usr/bin/ssm-agent-worker"}: {}},
+			},
+			EventFields{Comm: "rpm", Path: "/usr/bin/rpm", Pcomm: "bash", ParentExePath: "/bin/bash"},
+			false,
+		},
+		{
+			"excludeProcesses does not fire when path is an unrelated file (open event shape)",
+			&Params{
+				IgnorePrefixes:   []string{"/tmp"},
+				ExcludeProcesses: map[processKey]struct{}{{Name: "dockerd", Path: "/usr/bin/dockerd"}: {}},
+			},
+			EventFields{Path: "/etc/passwd", Comm: "rpm"},
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/rulemanager/rule_manager.go
+++ b/pkg/rulemanager/rule_manager.go
@@ -235,7 +235,7 @@ func (rm *RuleManager) ReportEnrichedEvent(enrichedEvent *events.EnrichedEvent) 
 			if !eventFields.Extracted {
 				eventFields = extractEventFields(enrichedEvent.Event)
 			}
-			if rule.Prefilter.ShouldSkip(eventFields) {
+			if rule.Prefilter.ShouldSkip(&eventFields) {
 				rm.metrics.ReportRulePrefiltered(rule.Name)
 				continue
 			}

--- a/pkg/rulemanager/rule_manager.go
+++ b/pkg/rulemanager/rule_manager.go
@@ -485,6 +485,9 @@ func extractEventFields(event utils.K8sEvent) prefilter.EventFields {
 	case utils.ExecveEventType:
 		if e, ok := event.(utils.ExecEvent); ok {
 			f.Path = e.GetExePath()
+			f.ParentExePath = e.GetParentExePath()
+			f.Comm = e.GetComm()
+			f.Pcomm = e.GetPcomm()
 		}
 	case utils.HTTPEventType:
 		if e, ok := event.(utils.HttpEvent); ok {

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -400,6 +400,11 @@ func (e *DatasourceEvent) GetExePath() string {
 	return NormalizePath(exepath)
 }
 
+func (e *DatasourceEvent) GetParentExePath() string {
+	exepath, _ := e.getFieldAccessor("parent_exepath").String(e.Data)
+	return NormalizePath(exepath)
+}
+
 func (e *DatasourceEvent) GetExitCode() uint32 {
 	exitCode, _ := e.getFieldAccessor("exit_code").Uint32(e.Data)
 	return exitCode

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -95,6 +95,7 @@ type ExecEvent interface {
 	GetArgs() []string
 	GetCwd() string
 	GetExePath() string
+	GetParentExePath() string
 	GetPupperLayer() bool
 	GetUpperLayer() bool
 }

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -59,6 +59,7 @@ type StructEvent struct {
 	Pod                  string                  `json:"pod,omitempty" yaml:"pod,omitempty"`
 	PodHostIP            string                  `json:"podHostIP,omitempty" yaml:"podHostIP,omitempty"`
 	PodLabels            map[string]string       `json:"podLabels,omitempty" yaml:"podLabels,omitempty"`
+	ParentExePath        string                  `json:"parentExePath,omitempty" yaml:"parentExePath,omitempty"`
 	Ppid                 uint32                  `json:"ppid,omitempty" yaml:"ppid,omitempty"`
 	Proto                string                  `json:"proto,omitempty" yaml:"proto,omitempty"`
 	Ptid                 uint64                  `json:"ptid,omitempty" yaml:"ptid,omitempty"`
@@ -228,6 +229,10 @@ func (e *StructEvent) GetEventType() EventType {
 
 func (e *StructEvent) GetExePath() string {
 	return NormalizePath(e.ExePath)
+}
+
+func (e *StructEvent) GetParentExePath() string {
+	return NormalizePath(e.ParentExePath)
 }
 
 func (e *StructEvent) GetExitCode() uint32 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process and parent-process exclusion filters to pre-filters that require both process name and executable path to match (paths are normalized); exec events now include parent process context so filters can use it.
* **Tests**
  * Added/expanded tests covering parsing, normalization, invalid-entry handling, and runtime skip behavior for the new exclusion settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->