### PR TITLE
reduce per-call allocations in CEL FieldGetters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/panjf2000/ants/v2 v2.11.3
-	github.com/picatz/xcel v0.0.0-20250816143731-885b5f678a12
+	github.com/picatz/xcel v0.0.0-20260226001349-6958ffac5706
 	github.com/prometheus/alertmanager v0.27.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/procfs v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -1105,8 +1105,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
 github.com/petermattis/goid v0.0.0-20241211131331-93ee7e083c43 h1:ah1dvbqPMN5+ocrg/ZSgZ6k8bOk+kcZQ7fnyx6UvOm4=
 github.com/petermattis/goid v0.0.0-20241211131331-93ee7e083c43/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
-github.com/picatz/xcel v0.0.0-20250816143731-885b5f678a12 h1:RS7RxrC+OtnYpgI0li0NwvpE0cqYewsZGXUb6wAe0oQ=
-github.com/picatz/xcel v0.0.0-20250816143731-885b5f678a12/go.mod h1:jxNaYyVlWe+WPV3G45KzlMLvplS3PQdHLUsFePIcaEg=
+github.com/picatz/xcel v0.0.0-20260226001349-6958ffac5706 h1:xfPEUCHSHcjpu4WxgtC1lwBkP4Xa7R/pl8sXVF103Yg=
+github.com/picatz/xcel v0.0.0-20260226001349-6958ffac5706/go.mod h1:bFTXcuU+280rICoGMpVTk/06XNfgvfeplhjWWoLKPys=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pjbgf/sha1cd v0.4.0 h1:NXzbL1RvjTUi6kgYZCX3fPwwl27Q1LJndxtUDVfJGRY=

--- a/pkg/utils/cel.go
+++ b/pkg/utils/cel.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
 
@@ -10,6 +10,11 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/picatz/xcel"
 )
+
+// errCelObjectNil is returned by FieldGetter callbacks when the underlying
+// event is nil. Reused across all getters to avoid per-call error allocation
+// on the CEL hot path.
+var errCelObjectNil = errors.New("celval: object is nil")
 
 type CelEvent interface {
 	CapabilitiesEvent
@@ -63,7 +68,7 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			return x.Raw.GetArgs(), nil
 		}),
@@ -74,9 +79,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetAttrSize(), nil
+			return celtypes.Uint(x.Raw.GetAttrSize()), nil
 		}),
 	},
 	"capName": {
@@ -85,9 +90,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetCapability(), nil
+			return celtypes.String(x.Raw.GetCapability()), nil
 		}),
 	},
 	"cmd": {
@@ -96,9 +101,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetCmd(), nil
+			return celtypes.Uint(x.Raw.GetCmd()), nil
 		}),
 	},
 	"comm": {
@@ -107,9 +112,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetComm(), nil
+			return celtypes.String(x.Raw.GetComm()), nil
 		}),
 	},
 	"containerId": {
@@ -118,9 +123,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetContainerID(), nil
+			return celtypes.String(x.Raw.GetContainerID()), nil
 		}),
 	},
 	"containerName": {
@@ -129,9 +134,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetContainer(), nil
+			return celtypes.String(x.Raw.GetContainer()), nil
 		}),
 	},
 	"cwd": {
@@ -140,9 +145,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetCwd(), nil
+			return celtypes.String(x.Raw.GetCwd()), nil
 		}),
 	},
 	"dstAddr": {
@@ -151,9 +156,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetDstEndpoint().Addr, nil
+			return celtypes.String(x.Raw.GetDstEndpoint().Addr), nil
 		}),
 	},
 	"dstIp": {
@@ -162,9 +167,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetDstIP(), nil
+			return celtypes.String(x.Raw.GetDstIP()), nil
 		}),
 	},
 	"dstPort": {
@@ -173,9 +178,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return int(x.Raw.GetDstPort()), nil
+			return celtypes.Int(x.Raw.GetDstPort()), nil
 		}),
 	},
 	"exepath": {
@@ -184,9 +189,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetExePath(), nil
+			return celtypes.String(x.Raw.GetExePath()), nil
 		}),
 	},
 	"flags": {
@@ -195,7 +200,7 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			return x.Raw.GetFlags(), nil
 		}),
@@ -206,9 +211,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return int(x.Raw.GetFlagsRaw()), nil
+			return celtypes.Int(x.Raw.GetFlagsRaw()), nil
 		}),
 	},
 	"module": {
@@ -217,9 +222,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetModule(), nil
+			return celtypes.String(x.Raw.GetModule()), nil
 		}),
 	},
 	"name": {
@@ -228,9 +233,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetDNSName(), nil
+			return celtypes.String(x.Raw.GetDNSName()), nil
 		}),
 	},
 	"namespace": {
@@ -239,9 +244,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetNamespace(), nil
+			return celtypes.String(x.Raw.GetNamespace()), nil
 		}),
 	},
 	"newPath": {
@@ -250,9 +255,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetNewPath(), nil
+			return celtypes.String(x.Raw.GetNewPath()), nil
 		}),
 	},
 	"oldPath": {
@@ -261,9 +266,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetOldPath(), nil
+			return celtypes.String(x.Raw.GetOldPath()), nil
 		}),
 	},
 	"opcode": {
@@ -272,9 +277,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetOpcode(), nil
+			return celtypes.Int(x.Raw.GetOpcode()), nil
 		}),
 	},
 	"path": {
@@ -283,9 +288,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPath(), nil
+			return celtypes.String(x.Raw.GetPath()), nil
 		}),
 	},
 	"pcomm": {
@@ -294,9 +299,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPcomm(), nil
+			return celtypes.String(x.Raw.GetPcomm()), nil
 		}),
 	},
 	"pid": {
@@ -305,9 +310,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPID(), nil
+			return celtypes.Uint(x.Raw.GetPID()), nil
 		}),
 	},
 	"pktType": {
@@ -316,9 +321,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPktType(), nil
+			return celtypes.String(x.Raw.GetPktType()), nil
 		}),
 	},
 	"podName": {
@@ -327,9 +332,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPod(), nil
+			return celtypes.String(x.Raw.GetPod()), nil
 		}),
 	},
 	"ppid": {
@@ -338,9 +343,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPpid(), nil
+			return celtypes.Uint(x.Raw.GetPpid()), nil
 		}),
 	},
 	"proto": {
@@ -349,9 +354,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetProto(), nil
+			return celtypes.String(x.Raw.GetProto()), nil
 		}),
 	},
 	"pupperlayer": {
@@ -360,9 +365,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetPupperLayer(), nil
+			return celtypes.Bool(x.Raw.GetPupperLayer()), nil
 		}),
 	},
 	"srcPort": {
@@ -371,9 +376,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return int(x.Raw.GetSrcPort()), nil
+			return celtypes.Int(x.Raw.GetSrcPort()), nil
 		}),
 	},
 	"syscallName": {
@@ -382,9 +387,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetSyscall(), nil
+			return celtypes.String(x.Raw.GetSyscall()), nil
 		}),
 	},
 	"upperlayer": {
@@ -393,9 +398,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return x.Raw.GetUpperLayer(), nil
+			return celtypes.Bool(x.Raw.GetUpperLayer()), nil
 		}),
 	},
 	"uid": {
@@ -404,7 +409,7 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			return x.Raw.GetUid(), nil
 		}),
@@ -419,7 +424,7 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			return target, nil
 		}),
@@ -430,9 +435,9 @@ var CelFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
-			return string(x.Raw.GetDirection()), nil
+			return celtypes.String(x.Raw.GetDirection()), nil
 		}),
 	},
 }
@@ -445,7 +450,7 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			req := x.Raw.GetRequest()
 			if req != nil {
@@ -460,13 +465,13 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			req := x.Raw.GetRequest()
 			if req != nil {
-				return req.Host, nil
+				return celtypes.String(req.Host), nil
 			}
-			return "", nil
+			return celtypes.String(""), nil
 		}),
 	},
 	"method": {
@@ -475,13 +480,13 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			req := x.Raw.GetRequest()
 			if req != nil {
-				return req.Method, nil
+				return celtypes.String(req.Method), nil
 			}
-			return "", nil
+			return celtypes.String(""), nil
 		}),
 	},
 	"url": {
@@ -490,13 +495,13 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			req := x.Raw.GetRequest()
 			if req != nil && req.URL != nil {
-				return req.URL.String(), nil
+				return celtypes.String(req.URL.String()), nil
 			}
-			return "", nil
+			return celtypes.String(""), nil
 		}),
 	},
 	"path": {
@@ -505,13 +510,13 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			req := x.Raw.GetRequest()
 			if req != nil && req.URL != nil {
-				return req.URL.Path, nil
+				return celtypes.String(req.URL.Path), nil
 			}
-			return "", nil
+			return celtypes.String(""), nil
 		}),
 	},
 	"body": {
@@ -520,12 +525,12 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 		GetFrom: ref.FieldGetter(func(target any) (any, error) {
 			x := target.(*xcel.Object[CelEvent])
 			if x.Raw == nil {
-				return nil, fmt.Errorf("celval: object is nil")
+				return nil, errCelObjectNil
 			}
 			// Try GetBuf() first (for eBPF events)
 			buf := x.Raw.GetBuf()
 			if len(buf) > 0 {
-				return string(buf), nil
+				return celtypes.String(buf), nil
 			}
 			// Fallback to reading from Request.Body (for test events)
 			req := x.Raw.GetRequest()
@@ -539,9 +544,9 @@ var HttpRequestFields = map[string]*celtypes.FieldType{
 				if err != nil {
 					return "", err
 				}
-				return string(bodyBytes), nil
+				return celtypes.String(bodyBytes), nil
 			}
-			return "", nil
+			return celtypes.String(""), nil
 		}),
 	},
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependency to a newer version.

* **Performance**
  * Optimized internal CEL field retrieval operations to reduce memory allocations and improve type handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->