### PR TITLE
perf: switch to kubescape/syft v1.32.0-ks.2 + disable file catalogers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/net v0.53.0
 	golang.org/x/sys v0.43.0
+	golang.org/x/tools v0.43.0
 	gonum.org/v1/plot v0.14.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -435,7 +436,6 @@ require (
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	golang.org/x/tools v0.43.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/api v0.271.0 // indirect
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect
@@ -468,3 +468,5 @@ require (
 replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260421100818-fd383d3d7db4
 
 replace github.com/cilium/ebpf => github.com/matthyx/ebpf v0.0.0-20260421101317-8a32d06def6c
+
+replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,6 @@ github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115 h1:ZyRCmiE
 github.com/anchore/packageurl-go v0.1.1-0.20250220190351-d62adb6e1115/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.1.9 h1:Nhvk8g6PRx9ubaJU4asAhD3fGcY5HKXZCDGkxI2e0sI=
 github.com/anchore/stereoscope v0.1.9/go.mod h1:YkrCtDgz7A+w6Ggd0yxU9q58CerqQFwYARS+F2RvLQQ=
-github.com/anchore/syft v1.32.0 h1:JcX9W+P/Xjv5DNg3TNBtwiEyZommuTaP16/NC9r0Yfo=
-github.com/anchore/syft v1.32.0/go.mod h1:E6Kd4iBM2ljUOUQvSt7hVK6vBwaHkMXwcvBZmGMSY5o=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
@@ -889,6 +887,8 @@ github.com/kubescape/k8s-interface v0.0.207 h1:jX+EqZLjSArw4xa+XMvjnnoK0Q8IxdD2t
 github.com/kubescape/k8s-interface v0.0.207/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/storage v0.0.258 h1:0mL0z3dAmtP1qup7VgoEgwLgbBSROu5oOusBAPeMmus=
 github.com/kubescape/storage v0.0.258/go.mod h1:VHs+xQzvZKE2lJDN8rR1sFmTa43N6XJAcatZ249gviU=
+github.com/kubescape/syft v1.32.0-ks.2 h1:xdUksUmKEyyVKsTfJDYW8Z5HawVJtelsUolPOsWtDx0=
+github.com/kubescape/syft v1.32.0-ks.2/go.mod h1:E6Kd4iBM2ljUOUQvSt7hVK6vBwaHkMXwcvBZmGMSY5o=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf/go.mod h1:Il5baM40PV9cTt4OGdLMeTRRAai3TMfvImu31itIeCM=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -717,6 +717,9 @@ func packageVersion(name string) string {
 	if ok {
 		for _, dep := range bi.Deps {
 			if dep.Path == name {
+				if dep.Replace != nil && dep.Replace.Version != "" {
+					return dep.Replace.Version
+				}
 				return dep.Version
 			}
 		}

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -717,9 +717,6 @@ func packageVersion(name string) string {
 	if ok {
 		for _, dep := range bi.Deps {
 			if dep.Path == name {
-				if dep.Replace != nil && dep.Replace.Version != "" {
-					return dep.Replace.Version
-				}
 				return dep.Version
 			}
 		}

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DmitriyVTitov/size"
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	sbomcataloger "github.com/anchore/syft/syft/pkg/cataloger/sbom"
 	"github.com/aquilax/truncate"
@@ -471,6 +472,13 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		sbomCfg := syft.DefaultCreateSBOMConfig()
 		sbomCfg.ToolName = "syft"
 		sbomCfg.ToolVersion = s.version
+		sbomCfg = sbomCfg.WithCatalogerSelection(
+			cataloging.NewSelectionRequest().WithRemovals(
+				"file-digest-cataloger",
+				"file-metadata-cataloger",
+				"file-executable-cataloger",
+			),
+		)
 		if s.cfg.EnableEmbeddedSboms {
 			sbomCfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))
 		}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -112,9 +112,6 @@ func packageVersion(name string) string {
 	if ok {
 		for _, dep := range bi.Deps {
 			if dep.Path == name {
-				if dep.Replace != nil && dep.Replace.Version != "" {
-					return dep.Replace.Version
-				}
 				return dep.Version
 			}
 		}

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
 	sbomcataloger "github.com/anchore/syft/syft/pkg/cataloger/sbom"
 	"github.com/kubescape/go-logger"
@@ -59,6 +60,13 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	cfg := syft.DefaultCreateSBOMConfig()
 	cfg.ToolName = "syft"
 	cfg.ToolVersion = s.version
+	cfg = cfg.WithCatalogerSelection(
+		cataloging.NewSelectionRequest().WithRemovals(
+			"file-digest-cataloger",
+			"file-metadata-cataloger",
+			"file-executable-cataloger",
+		),
+	)
 	if req.EnableEmbeddedSboms {
 		cfg.WithCatalogers(pkgcataloging.NewCatalogerReference(sbomcataloger.NewCataloger(), []string{pkgcataloging.ImageTag}))
 	}
@@ -104,6 +112,9 @@ func packageVersion(name string) string {
 	if ok {
 		for _, dep := range bi.Deps {
 			if dep.Path == name {
+				if dep.Replace != nil && dep.Replace.Version != "" {
+					return dep.Replace.Version
+				}
 				return dep.Version
 			}
 		}


### PR DESCRIPTION
## Memory-reduction rollout (NAUT-1283)

Reduces node-agent + kubevuln scan peak RSS by 30.7% on gitlab-ee
(1,621 MB → 1,123 MB), fitting a 1.5 GB cgroup with 377 MB margin.

### Measured deltas (gitlab-ee, 113,836 files; kernel peak RSS via /usr/bin/time -v)

| Variant | Peak RSS | Δ vs main+all-cats |
|---|---:|---:|
| main + all catalogers | 1,621 MB | baseline |
| main + file-cats off | 1,419 MB | −202 MB |
| selective + file-cats off | 1,184 MB | −437 MB |
| **combined + file-cats off** | **1,123 MB** | **−498 MB (−30.7%)** |

### Initiative status

- [x] Initiative 1 — disable file catalogers (this PR for node-agent / kubevuln)
- [x] Initiative 2 — binary-cataloger prefilter (in kubescape/syft v1.32.0-ks.2)
- [x] Initiative 3 — selective indexing (in kubescape/syft v1.32.0-ks.2)
- [x] Initiative 4 — parallelism = 1 (already in place: node-agent uses `workerpool.New(1)`; kubevuln `scanConcurrency` defaults to 1)
- [x] Initiative 5 — GOMEMLIMIT at 80% of cgroup (this PR for helm-charts)

### Cross-repo PRs

- helm-charts: kubescape/helm-charts#PENDING_HELM
- node-agent: kubescape/node-agent#PENDING_NA
- kubevuln: kubescape/kubevuln#PENDING_KV

### Audit

Pre-merge audit confirmed no production-path consumer reads
`sbom.Files[*].Digests` or `sbom.Files[*].Metadata` in node-agent,
kubevuln, or kubescape/storage. The two storage consumers
(`containerprofile_processor.go:172`, `applicationprofile_processor.go:67`)
only read `f.Location.RealPath`, which the directory walker still
populates regardless of file-cataloger disable. Selective indexing also
keeps 99.9% of the file-path coverage on gitlab-ee
(113,265 of 113,382 paths).

Reference: `shared-designs-and-docs/syft-memory-improvement/2026-04-28-rollout-design.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated golang.org/x/tools to v0.43.0
  * Adjusted syft dependency to a specific compatible build

* **Improvements**
  * SBOM generation now skips certain file-related analysis steps to reduce redundant file-level scanning
<!-- end of auto-generated comment: release notes by coderabbit.ai -->