### PR TITLE
fix: record exec path symmetric with rule-side resolver (fexecve/AT_EMPTY_PATH)

### DIFF
--- a/pkg/containerprofilemanager/v1/event_reporting.go
+++ b/pkg/containerprofilemanager/v1/event_reporting.go
@@ -32,17 +32,33 @@ func (cpm *ContainerProfileManager) ReportCapability(containerID, capability str
 	cpm.logEventError(err, "capability", containerID)
 }
 
+// resolveExecPath derives the path to record for an exec event. It is kept
+// symmetric with the rule-side resolver in
+// pkg/rulemanager/cel/libraries/parse/parse.go (parse.get_exec_path): prefer
+// the kernel-authoritative exepath, then argv[0] when non-empty, then comm.
+// Using args[0] unconditionally produces an empty Path when the syscall has
+// an empty pathname (fexecve / execveat AT_EMPTY_PATH — the libpam helper
+// invocation pattern), while the rule-side resolver falls back to comm —
+// leaving the AP entry unreachable to ap.was_executed and producing spurious
+// "Unexpected process launched" alerts.
+func resolveExecPath(exepath, comm string, args []string) string {
+	if exepath != "" {
+		return exepath
+	}
+	if len(args) > 0 && args[0] != "" {
+		return args[0]
+	}
+	return comm
+}
+
 // ReportFileExec reports a file execution event for a container
 func (cpm *ContainerProfileManager) ReportFileExec(containerID string, event utils.ExecEvent) {
 	err := cpm.withContainer(containerID, func(data *containerData) (int, error) {
 		if data.execs == nil {
 			data.execs = &maps.SafeMap[string, []string]{}
 		}
-		path := event.GetComm()
 		args := event.GetArgs()
-		if len(args) > 0 {
-			path = args[0]
-		}
+		path := resolveExecPath(event.GetExePath(), event.GetComm(), args)
 
 		// Use SHA256 hash of the exec to identify it uniquely
 		execIdentifier := utils.CalculateSHA256FileExecHash(path, args)

--- a/pkg/containerprofilemanager/v1/event_reporting_test.go
+++ b/pkg/containerprofilemanager/v1/event_reporting_test.go
@@ -1,0 +1,57 @@
+package containerprofilemanager
+
+import "testing"
+
+func TestResolveExecPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		exepath string
+		comm    string
+		args    []string
+		want    string
+	}{
+		{
+			name:    "exepath present (canonical exec)",
+			exepath: "/usr/sbin/unix_chkpwd",
+			comm:    "unix_chkpwd",
+			args:    []string{"/usr/sbin/unix_chkpwd", "root"},
+			want:    "/usr/sbin/unix_chkpwd",
+		},
+		{
+			name:    "fexecve / execveat AT_EMPTY_PATH — pathname empty, argv[0] non-empty",
+			exepath: "",
+			comm:    "unix_chkpwd",
+			args:    []string{"unix_chkpwd", "root"},
+			want:    "unix_chkpwd",
+		},
+		{
+			name:    "fexecve with empty argv[0] (older PAM convention)",
+			exepath: "",
+			comm:    "unix_chkpwd",
+			args:    []string{"", "root"},
+			want:    "unix_chkpwd",
+		},
+		{
+			name:    "no exepath, no args — fall back to comm",
+			exepath: "",
+			comm:    "some_proc",
+			args:    nil,
+			want:    "some_proc",
+		},
+		{
+			name:    "exepath wins even when argv[0] disagrees (argv[0] spoofing)",
+			exepath: "/usr/bin/curl",
+			comm:    "curl",
+			args:    []string{"sshd", "-i"},
+			want:    "/usr/bin/curl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveExecPath(tt.exepath, tt.comm, tt.args)
+			if got != tt.want {
+				t.Errorf("resolveExecPath(%q, %q, %v) = %q, want %q", tt.exepath, tt.comm, tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The application-profile recorder (`ReportFileExec` in `pkg/containerprofilemanager/v1/event_reporting.go`) derives the path it stores into the AP from `args[0]`, while the rule-side resolver (`parse.get_exec_path` in `pkg/rulemanager/cel/libraries/parse/parse.go`) falls back to `comm` when `args[0]` is empty. The asymmetry causes any rule built on `ap.was_executed` (R0001 *Unexpected process launched* and friends) to fire on processes that ARE present in the application profile.

## Trigger: `fexecve` / `execveat` with `AT_EMPTY_PATH`

Modern libpam (≥ 1.5) invokes its helpers (`unix_chkpwd`, `unix_update`, …) via `fexecve` to avoid TOCTOU on the helper path. The kernel implements `fexecve` as `execveat(fd, "", argv, envp, AT_EMPTY_PATH)` — **pathname is empty by design**.

Inspektor Gadget's `trace_exec` puts the syscall's `pathname` into `args[0]` and reads `argv` from index 1 (`gadgets/trace_exec/program.bpf.c:146-153`). For `fexecve`/`execveat`-with-empty-pathname this produces `args = ["", argv[1]]` in the agent's exec event.

The current recorder then does:

```go
path := event.GetComm()
args := event.GetArgs()        // ["", "root"]
if len(args) > 0 {
    path = args[0]             // overwrites with ""
}
```

→ AP entry: `Path: "", Args: ["", "root"]`.

At runtime, the rule's `parse.get_exec_path` falls back to `comm = "unix_chkpwd"` (because `argsList[0] == ""`). `ap.was_executed("unix_chkpwd")` then walks the AP execs comparing `exec.Path == "unix_chkpwd"` — never finds the empty-path entry — and the rule fires.

## Fix

Make the recorder symmetric with the rule-side resolver:

1. Prefer `event.GetExePath()` — the kernel-authoritative path (`task->mm->exe_file` in BPF, immune to `argv[0]` spoofing too).
2. Fall back to `args[0]` when non-empty.
3. Fall back to `comm` otherwise.

Extracted into a small `resolveExecPath` helper so the logic is unit-testable.

## Concrete impact

In a Bonial customer snapshot, **408 of 1976 R0001 incidents (20.6%)** on `scoring-api` production workloads are exactly this case — cron user-context setup invokes `pam_unix` → `unix_chkpwd` via `fexecve`, the AP records `Path: ""` with `Args: ["", "root"]`, and the rule fires every time. With this fix the recorded entry becomes `Path: /usr/sbin/unix_chkpwd, Args: ["", "root"]` and matches what the rule looks up.

Same pattern applies to any rule using `ap.was_executed`.

## Reproducer

Confirmed locally on a kind cluster with kubescape + node-agent. A pod that loops between `execve` (control: `pathname` non-empty) and `execveat`-with-`AT_EMPTY_PATH` (bug: `pathname=""`) reproduces both AP entry shapes on the unfixed code; with the fix applied, both produce a usable `Path` field.

Note: Python's `os.execv` rejects empty `argv[0]` — bypass with `ctypes` direct libc, or call `execveat` via `syscall(__NR_execveat, fd, "", ...)` from C.

## Test

Added `resolveExecPath` unit tests covering canonical exec, fexecve with non-empty `argv[0]`, fexecve with empty `argv[0]` (older PAM convention), bare-comm fallback, and an `argv[0]`-spoofing case where `exepath` correctly wins.

```
go test -run TestResolveExecPath ./pkg/containerprofilemanager/v1/
ok  github.com/kubescape/node-agent/pkg/containerprofilemanager/v1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved executable path identification logic in event reporting for more accurate exec path tracking and enrichment across different execution scenarios.

* **Tests**
  * Added comprehensive test coverage for executable path resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->