### PR TITLE
fix: deep-copy Data in MakeHttpEvent to prevent nil pointer panic

### DIFF
--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -778,7 +778,7 @@ func (e *DatasourceEvent) IsDir() bool {
 
 func (e *DatasourceEvent) MakeHttpEvent(request *http.Request, direction consts.NetworkDirection) HttpEvent {
 	return &DatasourceEvent{
-		Data:       e.Data,
+		Data:       e.Datasource.DeepCopy(e.Data),
 		Datasource: e.Datasource,
 		Direction:  direction,
 		EventType:  e.EventType,


### PR DESCRIPTION
## Summary

- `MakeHttpEvent` was assigning `e.Data` directly to the new `DatasourceEvent`, sharing the same pooled `*data` pointer
- When `Release()` was called on the original `bpfEvent`, it zeroed the inner `Data *DataElement` field of the shared `*data` and returned the object to the pool
- Any `HttpEvent` stored in the HTTP tracer's `eventsMap` then held a stale reference; `transmitOrphanRequests` subsequently called `GetTimestamp()` → `d.payload()` → `d.Data.Payload` where `d.Data == nil` → **SIGSEGV at addr=0x8**

Fix: call `e.Datasource.DeepCopy(e.Data)` so the returned `HttpEvent` owns an independent copy of the data, completely decoupled from the original event's release lifecycle.

## Stack trace

```
goroutine 988 [running]:
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*data).payload(...)
    datasource/data.go:83 +0x4           ← d.Data is nil after Release()
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*fieldAccessor).Get(...)
    datasource/accessors.go:217 +0x42
github.com/inspektor-gadget/inspektor-gadget/pkg/datasource.(*fieldAccessor).Uint64(...)
    datasource/accessors.go:463 +0x26
github.com/kubescape/node-agent/pkg/utils.(*DatasourceEvent).GetTimestamp(...)
    pkg/utils/datasource_event.go:740 +0xaf
(*HTTPTracer).transmitOrphanRequests(...)
    tracers/http.go:179 +0x124
```

## Test plan

- [ ] Verify build passes: `go build ./pkg/utils/... ./pkg/containerwatcher/...`
- [ ] Run HTTP tracer under load and confirm no nil pointer panics in `transmitOrphanRequests`
- [ ] Confirm orphan request timestamps are valid (non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)