### PR TITLE
fix(networkstream): fix timeout, mutex stall, and empty-stream skip

### DIFF
--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	timeoutDefaultSeconds = 5 // Default timeout for HTTP requests if not set in the config
+	timeoutDefaultSeconds = 30 // Default timeout for HTTP requests if not set in the config
 )
 
 type NetworkStream struct {
@@ -187,10 +187,8 @@ func (ns *NetworkStream) Start() {
 				// Remove process tree from events (to reduce size)
 				removeProcessTreeFromEvents(&ns.networkEventsStorage)
 
-				// Send the network events to the exporter
-				if err := ns.sendNetworkEvent(&ns.networkEventsStorage); err != nil {
-					logger.L().Error("NetworkStream - failed to send network events", helpers.Error(err))
-				}
+				// Snapshot for HTTP send — allows releasing the lock before the network call
+				snapshot := snapshotNetworkStream(&ns.networkEventsStorage)
 
 				// Clear the storage
 				for entityId := range ns.networkEventsStorage.Entities {
@@ -206,6 +204,11 @@ func (ns *NetworkStream) Start() {
 					Outbound: make(map[string]armotypes.NetworkStreamEvent),
 				}
 				ns.eventsStorageMutex.Unlock()
+
+				// Send the snapshot outside the lock so event recording is never stalled by I/O
+				if err := ns.sendNetworkEvent(snapshot); err != nil {
+					logger.L().Error("NetworkStream - failed to send network events", helpers.Error(err))
+				}
 				logger.L().Debug("NetworkStream - sent network events")
 			}
 		}
@@ -452,6 +455,7 @@ func (ns *NetworkStream) sendNetworkEvent(networkStream *armotypes.NetworkStream
 
 	if isEmptyNetworkStream(networkStream) {
 		logger.L().Debug("no events in network stream, skipping")
+		return nil
 	}
 
 	// create a GenericCRD with NetworkStream as Spec
@@ -524,6 +528,21 @@ func removeProcessTreeFromEvents(networkStream *armotypes.NetworkStream) {
 		}
 		networkStream.Entities[entityId] = entity
 	}
+}
+
+// snapshotNetworkStream returns a new NetworkStream with an independent Entities map so that
+// the caller can release eventsStorageMutex before the HTTP send. A new map is required because
+// the clearing loop replaces entity structs in the live Entities map; copying the entity structs
+// by value is sufficient because the clearing loop never mutates the old Inbound/Outbound maps
+// in place — it allocates new ones and assigns them to the new struct.
+func snapshotNetworkStream(src *armotypes.NetworkStream) *armotypes.NetworkStream {
+	dst := &armotypes.NetworkStream{
+		Entities: make(map[string]armotypes.NetworkStreamEntity, len(src.Entities)),
+	}
+	for entityID, entity := range src.Entities {
+		dst.Entities[entityID] = entity // struct copy; Inbound/Outbound map pointers are safe to share
+	}
+	return dst
 }
 
 func (ns *NetworkStream) getProcessTreeByPid(pid uint32, comm string, processTree *armotypes.ProcessTree) *armotypes.ProcessTree {


### PR DESCRIPTION
## Summary

- **Timeout**: Increase default HTTP client timeout from 5s to 30s. Both node-agent and synchronizer had the same 5s limit, causing a race where the synchronizer's `ReadTimeout` could close the connection before responding, producing spurious `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` errors — no high CPU required to trigger this.
- **Mutex stall**: `eventsStorageMutex` was held for the entire HTTP round-trip (up to 5s on timeout), blocking all `ReportEvent`/`handleNetworkEvent`/`handleDnsEvent` goroutines. Fixed by snapshotting under the lock and releasing before the HTTP call. A new `Entities` map with entity structs copied by value is sufficient — the clearing loop never mutates `Inbound`/`Outbound` maps in place, so the old maps become exclusively owned by the snapshot once the lock is released.
- **Empty-stream skip**: `sendNetworkEvent` logged "skipping" for empty streams but still sent the HTTP request. Added the missing `return nil`.

> **Deploy note**: the timeout fix requires the matching change in `kubescape/synchronizer` (raise `ReadTimeout` to 30s) to be deployed together.

## Test plan

- [ ] Verify no `context deadline exceeded` errors in node-agent logs after deploying both PRs together
- [ ] Confirm empty network stream intervals no longer generate HTTP requests to the synchronizer
- [ ] Confirm network/DNS event recording is not stalled during a synchronizer outage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP request timeout increased from 5 to 30 seconds for improved stability.

* **Performance**
  * Network event processing now skips unnecessary operations when no events are present.
  * Improved concurrency handling in network event storage and transmission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/node-agent/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->