### PR TITLE
feat: add container meta-context for shared ECS/Kubernetes rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -174,7 +174,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
-	github.com/containerd/containerd v1.7.30 // indirect
+	github.com/containerd/containerd v1.7.32 // indirect
 	github.com/containerd/containerd/api v1.9.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/go-fonts/liberation v0.3.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
-	github.com/go-git/go-git/v5 v5.19.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-latex/latex v0.0.0-20231108140139-5c1ce85aa4ea // indirect
 	github.com/go-ldap/ldap/v3 v3.4.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/containerd/api v1.9.0 h1:HZ/licowTRazus+wt9fM6r/9BQO7S0vD5lMcWspGIg0=
 github.com/containerd/containerd/api v1.9.0/go.mod h1:GhghKFmTR3hNtyznBoQ0EMWr9ju5AqHjcZPsSpTKutI=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmm
 github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
-github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
+github.com/go-git/go-git/v5 v5.19.1 h1:nX27AnaU43/K5bKktKwgBmR9lawoYVe1Ckg0rgzzN00=
+github.com/go-git/go-git/v5 v5.19.1/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/contextdetection/types.go
+++ b/pkg/contextdetection/types.go
@@ -10,6 +10,7 @@ const (
 	Kubernetes EventSourceContext = "kubernetes"
 	Host       EventSourceContext = "host"
 	Standalone EventSourceContext = "standalone"
+	Container  EventSourceContext = "container"
 )
 
 type ContextInfo interface {

--- a/pkg/contextdetection/types.go
+++ b/pkg/contextdetection/types.go
@@ -11,6 +11,7 @@ const (
 	Host       EventSourceContext = "host"
 	Standalone EventSourceContext = "standalone"
 	Container  EventSourceContext = "container"
+	ECS        EventSourceContext = "ecs"
 )
 
 type ContextInfo interface {

--- a/pkg/rulemanager/ruleadapters/creator.go
+++ b/pkg/rulemanager/ruleadapters/creator.go
@@ -354,9 +354,9 @@ func (r *RuleFailureCreator) setContextSpecificFields(ruleFailure *types.Generic
 			k8sDetails.NodeName = hostname
 		}
 
-	case contextdetection.Standalone:
-		ruleFailure.SetSourceContext(contextdetection.Standalone)
-		// For Standalone context, populate container-specific fields in RuntimeAlertK8sDetails
+	case contextdetection.Standalone, contextdetection.Container, contextdetection.ECS:
+		ruleFailure.SetSourceContext(sourceContextType)
+		// For containerized contexts, populate container-specific fields in RuntimeAlertK8sDetails
 		if k8sDetails.ContainerID == "" {
 			k8sDetails.ContainerID = enrichedEvent.ContainerID
 		}

--- a/pkg/rulemanager/rulepolicy.go
+++ b/pkg/rulemanager/rulepolicy.go
@@ -42,8 +42,10 @@ func RuleAppliesToContext(rule *typesv1.Rule, contextInfo contextdetection.Conte
 		currentContext = contextInfo.Context()
 	}
 
-	// container is a meta-context that matches kubernetes and container contexts
-	isContainerContext := currentContext == contextdetection.Kubernetes || currentContext == contextdetection.Container
+	// container is a meta-context matching any containerized workload (kubernetes, container, ecs)
+	isContainerContext := currentContext == contextdetection.Kubernetes ||
+		currentContext == contextdetection.Container ||
+		currentContext == contextdetection.ECS
 
 	var hasContextTags bool
 	for _, tag := range rule.Tags {

--- a/pkg/rulemanager/rulepolicy.go
+++ b/pkg/rulemanager/rulepolicy.go
@@ -42,10 +42,16 @@ func RuleAppliesToContext(rule *typesv1.Rule, contextInfo contextdetection.Conte
 		currentContext = contextInfo.Context()
 	}
 
+	// container is a meta-context that matches kubernetes and container contexts
+	isContainerContext := currentContext == contextdetection.Kubernetes || currentContext == contextdetection.Container
+
 	var hasContextTags bool
 	for _, tag := range rule.Tags {
 		if ctx, found := strings.CutPrefix(tag, "context:"); found {
 			if ctx == string(currentContext) {
+				return true
+			}
+			if ctx == string(contextdetection.Container) && isContainerContext {
 				return true
 			}
 			hasContextTags = true

--- a/pkg/rulemanager/rulepolicy.go
+++ b/pkg/rulemanager/rulepolicy.go
@@ -42,8 +42,9 @@ func RuleAppliesToContext(rule *typesv1.Rule, contextInfo contextdetection.Conte
 		currentContext = contextInfo.Context()
 	}
 
-	// container is a meta-context matching any containerized workload (kubernetes, container, ecs)
+	// container is a meta-context matching any containerized workload (kubernetes, standalone, container, ecs)
 	isContainerContext := currentContext == contextdetection.Kubernetes ||
+		currentContext == contextdetection.Standalone ||
 		currentContext == contextdetection.Container ||
 		currentContext == contextdetection.ECS
 


### PR DESCRIPTION
## Summary

This PR introduces a `container` meta-context so that rules can be written once and fire on **any containerized workload** — both Kubernetes pods and ECS/standalone containers — without duplicating tags.

### What changed

- **`pkg/contextdetection/types.go`**: Added `Container EventSourceContext = "container"` alongside the existing `Kubernetes`, `Host`, and `Standalone` constants.

- **`pkg/rulemanager/rulepolicy.go`**: Updated `RuleAppliesToContext` to treat `context:container` as a meta-context that matches when the agent is running in either a `kubernetes` or a `container` context.

### How the meta-context works

```
context:container  →  matches kubernetes OR container runtime
context:kubernetes →  matches kubernetes only  (unchanged)
context:host       →  matches host only         (unchanged)
context:standalone →  matches standalone only   (unchanged)
```

A rule tagged only `context:container` will fire on Kubernetes AND on ECS/standalone container nodes. A rule that needs Kubernetes-specific behaviour still uses `context:kubernetes` exclusively.

### Backward compatibility

Rules that should fire on both Kubernetes and ECS nodes should carry **both** tags:

```yaml
tags:
  - context:container    # fires on any containerised workload (new agents)
  - context:kubernetes   # still fires on old node-agents that don't know "container"
```

Old node-agents that don't recognise `container` will skip that tag and match `context:kubernetes` as before, so no existing rule behaviour is broken.

### Logic walk-through

```go
isContainerContext := currentContext == Kubernetes || currentContext == Container

for _, tag := range rule.Tags {
    if ctx == string(currentContext)              { return true } // exact match (all contexts)
    if ctx == "container" && isContainerContext   { return true } // meta-context match
}
```

No-context rules continue to default to Kubernetes-only (unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ECS (Amazon Elastic Container Service) context detection.
  * Runtime alerts now include ECS-specific metadata (cluster, task, launch type, availability zone).
  * Improved rule matching to support Container context across Kubernetes, Standalone, Container, and ECS environments.

* **Chores**
  * Updated Go module dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/node-agent/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->