### PR TITLE
feat(sbommanager): key SBOM name on (digest, syftVersion)

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -247,8 +247,11 @@ func (s *SbomManager) processContainer(notif containercollection.PubSubEvent, mo
 }
 
 func (s *SbomManager) processContainerWithMetadata(notif containercollection.PubSubEvent, mounts []string, imageStatus *runtime.ImageStatusResponse, imageTag, imageID string) {
-	// prepare SBOM name
-	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	// prepare SBOM name — keyed on (digest, syftVersion). Two tag aliases of
+	// the same image (different tags, same digest) collapse to one SBOM; the
+	// original tag is preserved as the ImageTagMetadataKey annotation below.
+	normalizedID := normalizeImageID(imageTag, imageID)
+	sbomName, err := names.ImageInfoToSlug(s.version, normalizedID)
 	if err != nil {
 		logger.L().Ctx(s.ctx).Error("SbomManager - failed to generate SBOM name",
 			helpers.Error(err),
@@ -260,7 +263,6 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		return
 	}
 	// try to create a SBOM with initializing status to reserve our slot
-	normalizedID := normalizeImageID(imageTag, imageID)
 	wipSbom := &v1beta1.SBOMSyft{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: sbomName,


### PR DESCRIPTION
## Summary

Aligns `sbom_manager`'s reservation contract with content-addressed storage: the SBOMSyft resource name is now derived from `(imageDigest, syftVersion)` rather than `(imageTag, imageID)`. The tag becomes metadata via the existing `ImageTagMetadataKey` annotation.

## Why

Two tag aliases of the same image (e.g. `myapp:v1` + `myapp:latest` with identical digest) currently produce different SBOM names and get tracked as independent reservations — even though the underlying SBOM content is byte-identical. Downstream backends that store SBOMs content-addressed (e.g. `kubescape/backend`'s gRPC `PutSBOMStream` keyed on `(image_digest, syft_version)`) can't faithfully implement the slug-scoped contract, so the adapter has to either dedupe across tags (which masks per-slug state) or layer machinery to maintain a slug→key index.

Per the discussion on armosec/private-node-agent#316: "Make the contract digest-scoped end to end in `node-agent` too (`digest + syftVersion` as the real key, tag/name only as metadata)."

## What changes

`pkg/sbommanager/v1/sbom_manager.go`:
- `normalizedID := normalizeImageID(...)` is computed first.
- `sbomName, err := names.ImageInfoToSlug(s.version, normalizedID)` — last 6 chars of the digest hex provide the image identity, the sanitized syft version distinguishes tool-version upgrades.
- The tag continues to be set on `Annotations[ImageTagMetadataKey]` for traceability.

No interface changes (`SbomClient` signatures unchanged); no in-cluster Storage impl changes; no mock changes. The semantic shift lives entirely in how `sbomName` is composed.

## Behavioral notes

- **Same image, different tags, same digest** → one SBOMSyft. (was: two)
- **Same image, same digest, different syft versions** → two SBOMSyfts. (unchanged)
- **Tool-version upgrade** still creates a new resource (different name).
- **TooLarge / Learning / NodeName branching** in `processContainerWithMetadata` keeps the same shape because the annotations on the existing row carry that state.

## Test plan

- [ ] Existing `pkg/sbommanager/v1/...` tests pass.
- [ ] Manual: two pods referencing the same digest under different tags produce a single SBOM row.
- [ ] Manual: bumping syft version produces a new SBOM row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SBOM name generation to use normalized image identifiers, eliminating redundant computations during container processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/node-agent/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->