### PR TITLE
fix(deps): resolve concurrent map writes panic in inspektor-gadget

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -467,7 +467,7 @@ require (
 	zombiezen.com/go/sqlite v1.4.0 // indirect
 )
 
-replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260421100818-fd383d3d7db4
+replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260513134836-aa8a4c2613db
 
 replace github.com/cilium/ebpf => github.com/matthyx/ebpf v0.0.0-20260421101317-8a32d06def6c
 

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/matthyx/ebpf v0.0.0-20260421101317-8a32d06def6c h1:ZCCeIMu86h4NhF0UfSm9Kdy1AHVWPogk86MdQD6OvPM=
 github.com/matthyx/ebpf v0.0.0-20260421101317-8a32d06def6c/go.mod h1:pzLjFymM+uZPLk/IXZUL63xdx5VXEo+enTzxkZXdycw=
-github.com/matthyx/inspektor-gadget v0.0.0-20260421100818-fd383d3d7db4 h1:+10X5NKBH8AOfLSqKqet2pyMvduv4gHImvYHVohyB/I=
-github.com/matthyx/inspektor-gadget v0.0.0-20260421100818-fd383d3d7db4/go.mod h1:V4TgEmWo37K72pQvC7XuRQssysrxIIkrNX4TtEkgiE0=
+github.com/matthyx/inspektor-gadget v0.0.0-20260513134836-aa8a4c2613db h1:li+4y/XuMY5X4ICzp4cGdFE5eQzYae6KRAkIUsZkeFE=
+github.com/matthyx/inspektor-gadget v0.0.0-20260513134836-aa8a4c2613db/go.mod h1:V4TgEmWo37K72pQvC7XuRQssysrxIIkrNX4TtEkgiE0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
Closes https://github.com/kubescape/node-agent/issues/825. Update inspektor-gadget dependency to use the version from your fork with the concurrent map writes fix.