### PR TITLE
fix(cache): release RBCache mutex lock before sending notifications

### DIFF
--- a/pkg/containerwatcher/v2/ordered_event_queue.go
+++ b/pkg/containerwatcher/v2/ordered_event_queue.go
@@ -36,6 +36,22 @@ func (oeq *OrderedEventQueue) GetFullQueueAlertChannel() <-chan struct{} {
 }
 
 func (oeq *OrderedEventQueue) AddEventDirect(eventType utils.EventType, event utils.K8sEvent, containerID string, processID uint32) {
+	if int(oeq.eventQueue.Size()) >= oeq.maxBufferSize {
+		logger.L().Warning("Ordered event queue - Event queue full, dropping event to prevent OOM",
+			helpers.String("eventType", string(eventType)),
+			helpers.String("containerID", containerID),
+			helpers.Int("queueSize", int(oeq.eventQueue.Size())),
+			helpers.Int("maxBufferSize", oeq.maxBufferSize))
+
+		select {
+		case oeq.fullQueueAlert <- struct{}{}:
+		default:
+		}
+
+		event.Release()
+		return
+	}
+
 	timestamp := time.Unix(0, int64(event.GetTimestamp()))
 
 	eventEntry := EventEntry{
@@ -48,17 +64,6 @@ func (oeq *OrderedEventQueue) AddEventDirect(eventType utils.EventType, event ut
 
 	priority := timestamp.UnixNano()
 	oeq.eventQueue.Push(eventEntry, priority)
-
-	if oeq.eventQueue.Size() >= uint(oeq.maxBufferSize) {
-		logger.L().Warning("Ordered event queue - Event queue full, sending processing alert",
-			helpers.Int("queueSize", int(oeq.eventQueue.Size())),
-			helpers.Int("maxBufferSize", oeq.maxBufferSize))
-
-		select {
-		case oeq.fullQueueAlert <- struct{}{}:
-		default:
-		}
-	}
 }
 
 func (oeq *OrderedEventQueue) PopEvent() (EventEntry, bool) {

--- a/pkg/containerwatcher/v2/ordered_event_queue_test.go
+++ b/pkg/containerwatcher/v2/ordered_event_queue_test.go
@@ -119,8 +119,8 @@ func TestOrderedEventQueue_FullQueueAlert(t *testing.T) {
 		t.Fatal("Expected full queue alert but didn't receive one")
 	}
 
-	// Verify all events are still in queue (including overflow event)
-	assert.Equal(t, 4, queue.Size())
+	// Verify queue size remains capped (overflow event is dropped)
+	assert.Equal(t, 3, queue.Size())
 }
 
 func TestOrderedEventQueue_BasicOperations(t *testing.T) {

--- a/pkg/rulebindingmanager/cache/cache.go
+++ b/pkg/rulebindingmanager/cache/cache.go
@@ -31,34 +31,63 @@ import (
 var _ rulebindingmanager.RuleBindingCache = (*RBCache)(nil)
 var _ watcher.Adaptor = (*RBCache)(nil)
 
+type pendingNotification struct {
+	notifiers []*chan rulebindingmanager.RuleBindingNotify
+	events    []rulebindingmanager.RuleBindingNotify
+}
+
 type RBCache struct {
-	config         config.Config
-	nodeName       string
-	k8sClient      k8sclient.K8sClientInterface
-	allPods        mapset.Set[string]                                    // set of all pods (also pods without rules)
-	podToRBNames   maps.SafeMap[string, mapset.Set[string]]              // podID -> []rule binding names
-	rbNameToRB     maps.SafeMap[string, typesv1.RuntimeAlertRuleBinding] // rule binding name -> rule binding
-	rbNameToRules  maps.SafeMap[string, []rulemanagertypesv1.Rule]       // rule binding name -> []created rules
-	rbNameToPods   maps.SafeMap[string, mapset.Set[string]]              // rule binding name -> podIDs
-	ruleCreator    rulecreator.RuleCreator
-	watchResources []watcher.WatchResource
-	notifiers      []*chan rulebindingmanager.RuleBindingNotify
-	mutex          sync.RWMutex
-	rulesForPod    *expirable.LRU[string, []rulemanagertypesv1.Rule]
+	config            config.Config
+	nodeName          string
+	k8sClient         k8sclient.K8sClientInterface
+	allPods           mapset.Set[string]                                    // set of all pods (also pods without rules)
+	podToRBNames      maps.SafeMap[string, mapset.Set[string]]              // podID -> []rule binding names
+	rbNameToRB        maps.SafeMap[string, typesv1.RuntimeAlertRuleBinding] // rule binding name -> rule binding
+	rbNameToRules     maps.SafeMap[string, []rulemanagertypesv1.Rule]       // rule binding name -> []created rules
+	rbNameToPods      maps.SafeMap[string, mapset.Set[string]]              // rule binding name -> podIDs
+	ruleCreator       rulecreator.RuleCreator
+	watchResources    []watcher.WatchResource
+	notifiers         []*chan rulebindingmanager.RuleBindingNotify
+	mutex             sync.RWMutex
+	rulesForPod       *expirable.LRU[string, []rulemanagertypesv1.Rule]
+	notificationQueue chan pendingNotification
 }
 
 func NewCache(config config.Config, k8sClient k8sclient.K8sClientInterface, ruleCreator rulecreator.RuleCreator) *RBCache {
-	return &RBCache{
-		config:         config,
-		nodeName:       config.NodeName,
-		k8sClient:      k8sClient,
-		ruleCreator:    ruleCreator,
-		allPods:        mapset.NewSet[string](),
-		rbNameToRB:     maps.SafeMap[string, typesv1.RuntimeAlertRuleBinding]{},
-		podToRBNames:   maps.SafeMap[string, mapset.Set[string]]{},
-		rbNameToPods:   maps.SafeMap[string, mapset.Set[string]]{},
-		watchResources: resourcesToWatch(config.NodeName),
-		rulesForPod:    expirable.NewLRU[string, []rulemanagertypesv1.Rule](1000, nil, 5*time.Second),
+	c := &RBCache{
+		config:            config,
+		nodeName:          config.NodeName,
+		k8sClient:         k8sClient,
+		ruleCreator:       ruleCreator,
+		allPods:           mapset.NewSet[string](),
+		rbNameToRB:        maps.SafeMap[string, typesv1.RuntimeAlertRuleBinding]{},
+		podToRBNames:      maps.SafeMap[string, mapset.Set[string]]{},
+		rbNameToPods:      maps.SafeMap[string, mapset.Set[string]]{},
+		watchResources:    resourcesToWatch(config.NodeName),
+		rulesForPod:       expirable.NewLRU[string, []rulemanagertypesv1.Rule](1000, nil, 5*time.Second),
+		notificationQueue: make(chan pendingNotification, 10000),
+	}
+	go c.processNotifications()
+	return c
+}
+
+func (c *RBCache) processNotifications() {
+	for pn := range c.notificationQueue {
+		for _, n := range pn.notifiers {
+			for _, event := range pn.events {
+				select {
+				case *n <- event:
+				default:
+					timer := time.NewTimer(100 * time.Millisecond)
+					select {
+					case *n <- event:
+						timer.Stop()
+					case <-timer.C:
+						logger.L().Error("RBCache - notifier is slow or blocked, dropping notification", helpers.Interface("event", event))
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -137,10 +166,14 @@ func (c *RBCache) AddHandler(ctx context.Context, obj runtime.Object) {
 		}
 		rbs = c.addRuleBinding(ruleBinding)
 	}
-	// notify
-	for n := range c.notifiers {
-		for i := range rbs {
-			*c.notifiers[n] <- rbs[i]
+
+	if len(c.notifiers) > 0 && len(rbs) > 0 {
+		notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))
+		copy(notifiers, c.notifiers)
+		select {
+		case c.notificationQueue <- pendingNotification{notifiers: notifiers, events: rbs}:
+		default:
+			logger.L().Error("RBCache - notification queue full, dropping notifications", helpers.Int("size", len(c.notificationQueue)))
 		}
 	}
 }
@@ -164,10 +197,14 @@ func (c *RBCache) ModifyHandler(ctx context.Context, obj runtime.Object) {
 		}
 		rbs = c.modifiedRuleBinding(ruleBinding)
 	}
-	// notify
-	for n := range c.notifiers {
-		for i := range rbs {
-			*c.notifiers[n] <- rbs[i]
+
+	if len(c.notifiers) > 0 && len(rbs) > 0 {
+		notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))
+		copy(notifiers, c.notifiers)
+		select {
+		case c.notificationQueue <- pendingNotification{notifiers: notifiers, events: rbs}:
+		default:
+			logger.L().Error("RBCache - notification queue full, dropping notifications", helpers.Int("size", len(c.notificationQueue)))
 		}
 	}
 }
@@ -184,28 +221,35 @@ func (c *RBCache) DeleteHandler(_ context.Context, obj runtime.Object) {
 		rbs = c.deleteRuleBinding(uniqueName(un))
 	}
 
-	// notify
-	for n := range c.notifiers {
-		for i := range rbs {
-			*c.notifiers[n] <- rbs[i]
+	if len(c.notifiers) > 0 && len(rbs) > 0 {
+		notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))
+		copy(notifiers, c.notifiers)
+		select {
+		case c.notificationQueue <- pendingNotification{notifiers: notifiers, events: rbs}:
+		default:
+			logger.L().Error("RBCache - notification queue full, dropping notifications", helpers.Int("size", len(c.notificationQueue)))
 		}
 	}
 }
 
 func (c *RBCache) RefreshRuleBindingsRules() {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	for _, rbName := range c.rbNameToRB.Keys() {
 		rb := c.rbNameToRB.Get(rbName)
 		c.rbNameToRules.Set(rbName, c.createRules(rb.Spec.Rules))
 	}
 	logger.L().Info("RBCache - refreshed rule bindings rules", helpers.Int("ruleBindings", len(c.rbNameToRB.Keys())))
-	// Snapshot notifiers while holding the lock, then release before sending to
-	// avoid blocking cache operations if any notifier channel is full.
-	notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))
-	copy(notifiers, c.notifiers)
-	c.mutex.Unlock()
-	for _, n := range notifiers {
-		*n <- rulebindingmanager.RuleBindingNotify{}
+
+	if len(c.notifiers) > 0 {
+		notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))
+		copy(notifiers, c.notifiers)
+		select {
+		case c.notificationQueue <- pendingNotification{notifiers: notifiers, events: []rulebindingmanager.RuleBindingNotify{{}}}:
+		default:
+			logger.L().Error("RBCache - notification queue full, dropping refresh notification")
+		}
 	}
 }
 

--- a/pkg/rulebindingmanager/cache/mock.go
+++ b/pkg/rulebindingmanager/cache/mock.go
@@ -12,13 +12,16 @@ import (
 )
 
 func NewCacheMock(nodeName string) *RBCache {
-	return &RBCache{
-		nodeName:     nodeName,
-		allPods:      mapset.NewSet[string](),
-		k8sClient:    k8sinterface.NewKubernetesApiMock(),
-		ruleCreator:  &rulecreator.RuleCreatorMock{},
-		podToRBNames: maps.SafeMap[string, mapset.Set[string]]{},
-		rbNameToPods: maps.SafeMap[string, mapset.Set[string]]{},
-		rulesForPod:  expirable.NewLRU[string, []rulemanagertypesv1.Rule](1000, nil, 60*time.Second),
+	c := &RBCache{
+		nodeName:          nodeName,
+		allPods:           mapset.NewSet[string](),
+		k8sClient:         k8sinterface.NewKubernetesApiMock(),
+		ruleCreator:       &rulecreator.RuleCreatorMock{},
+		podToRBNames:      maps.SafeMap[string, mapset.Set[string]]{},
+		rbNameToPods:      maps.SafeMap[string, mapset.Set[string]]{},
+		rulesForPod:       expirable.NewLRU[string, []rulemanagertypesv1.Rule](1000, nil, 60*time.Second),
+		notificationQueue: make(chan pendingNotification, 10000),
 	}
+	go c.processNotifications()
+	return c
 }


### PR DESCRIPTION
## Summary

This PR addresses the critical eBPF agent deadlock and secondary OOM crashes under high load.

### Key Improvements

1. **Deadlock Resolution:**
   - Decoupled `RBCache` mutation from notifier channel sends by introducing an internal `notificationQueue` (capacity 10,000). This breaks the circular dependency (`RBCache.mutex` write lock blocking while sending, while readers are blocked on `RLock`), eliminating the deadlock entirely.

2. **FIFO Ordered Notifications:**
   - Notifications are queued **inside the write lock** using a fast, non-blocking `select` write. This guarantees that notifications are queued in the exact chronological order of cache mutations, preserving strict FIFO delivery to downstream consumers (like `ContainerWatcher.startRunningContainers`) and preventing race conditions/state desynchronization.
   - The background queue processor uses a highly optimized non-blocking fast-path to prevent channel allocation/timer overhead, falling back to a `100ms` timeout to defensively isolate slow/stalled notifiers without blocking healthy ones.

3. **Event Queue OOM Protection:**
   - Capped the unbounded `OrderedEventQueue` at `maxBufferSize` (100,000 events) and added event dropping.
   - Dropped events are cleanly returned to the memory pool using `event.Release()` to prevent memory leaks and cgroup OOM kills under high system loads.
