### PR TITLE
feat: add image provenance attestation to local workflow and caller permissions

### DIFF
--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -72,6 +72,7 @@ jobs:
       packages: write
       contents: read
       pull-requests: read
+      attestations: write  # required by actions/attest-build-provenance
 
     steps:
       # - name: Exit if not on master branch
@@ -117,6 +118,7 @@ jobs:
           password: ${{ secrets.QUAYIO_REGISTRY_PASSWORD }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -127,6 +129,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-name: ${{ inputs.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Install cosign
         uses: sigstore/cosign-installer@main

--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -131,7 +131,7 @@ jobs:
           push: true
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-name: ${{ inputs.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -33,6 +33,7 @@ jobs:
       packages: write
       contents: write
       pull-requests: read
+      attestations: write  # required by actions/attest-build-provenance in the shared workflow
     uses: ./.github/workflows/incluster-comp-pr-merged.yaml
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/node-agent


### PR DESCRIPTION
## Overview

node-agent uses a local copy of `incluster-comp-pr-merged.yaml` instead of the shared `kubescape/workflows` version, so both files needed updating here unlike the other repos.

Changes:
- Adds `attestations: write` to `pr-merged.yaml` caller permissions
- Adds `id: build` to the build-push step to capture the image digest
- Adds `actions/attest-build-provenance` step to the local workflow copy

## Additional Information

All other repos (operator, kubevuln, storage, synchronizer, http-request, prometheus-exporter) only needed the caller permission update since they use the shared workflow from kubescape/workflows which already has the attestation step added.

## Related issues/PRs

* Part of kubescape/kubescape#1033
* Requires kubescape/workflows#89

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes