### PR TITLE
feat(config): add EnableSslTracing / DSsl flags for the OpenSSL L7 gadget

### DIFF
--- a/configuration/config.json
+++ b/configuration/config.json
@@ -11,6 +11,7 @@
       "runtimeDetectionEnabled": "false",
       "nodeProfileServiceEnabled": "false",
       "httpDetectionEnabled": "false",
+      "sslTracingEnabled": "false",
       "nodeProfileInterval": "1m",
       "seccompServiceEnabled": "false",
       "enableEmbeddedSBOMs": "false",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	DRandomx                       bool                                 `mapstructure:"dRandomx"`
 	DSeccomp                       bool                                 `mapstructure:"dSeccomp"`
 	DSsh                           bool                                 `mapstructure:"dSsh"`
+	DSsl                           bool                                 `mapstructure:"dSsl"`
 	DSymlink                       bool                                 `mapstructure:"dSymlink"`
 	DTop                           bool                                 `mapstructure:"dTop"`
 	DUnshare                       bool                                 `mapstructure:"dUnshare"`
@@ -85,6 +86,7 @@ type Config struct {
 	EnableRuntimeDetection         bool                                 `mapstructure:"runtimeDetectionEnabled"`
 	EnableSbomGeneration           bool                                 `mapstructure:"sbomGenerationEnabled"`
 	EnableSeccomp                  bool                                 `mapstructure:"seccompServiceEnabled"`
+	EnableSslTracing               bool                                 `mapstructure:"sslTracingEnabled"`
 	HostMonitoringEnabled          bool                                 `mapstructure:"hostMonitoringEnabled"`
 	StandaloneMonitoringEnabled    bool                                 `mapstructure:"standaloneMonitoringEnabled"`
 	SeccompProfileBackend          string                               `mapstructure:"seccompProfileBackend"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -34,6 +34,7 @@ func TestLoadConfig(t *testing.T) {
 				EnableNetworkTracing:           false,
 				EnableNodeProfile:              false,
 				EnableHttpDetection:            false,
+				EnableSslTracing:               false,
 				EnableHostMalwareSensor:        false,
 				EnableHostNetworkSensor:        false,
 				EnableFIM:                      true,


### PR DESCRIPTION
## What

Adds two config flags to `config.Config`:

- **`EnableSslTracing`** (`sslTracingEnabled`) — enable the native OpenSSL TLS-capture (R-L7-1) gadget.
- **`DSsl`** (`dSsl`) — disable override, mirroring the existing `DHttp`/`dHttp` pair.

Both default to `false` (zero value), so **behavior is unchanged unless explicitly set**. `configuration/config.json` documents `sslTracingEnabled`, and `config_test.go` asserts the default.

## Why

`armosec/private-node-agent` ships a native OpenSSL uprobe gadget that captures decrypted TLS plaintext per-container and exports it as `R-L7-1` records. It needs an off-by-default toggle following the same pattern as HTTP detection (`EnableHttpDetection`/`DHttp`).

Because `config.Config` lives here (not in private-node-agent), that gadget currently gates on a local `ENABLE_SSL_TRACING` env var as a stopgap. Adding the field upstream lets the gate move to the standard config mechanism — a two-line swap on the consumer side (`cfg.EnableSslTracing` instead of the env helper) once this is released.

## Test

- `go build ./pkg/config/` ✓
- `go test ./pkg/config/` ✓ (the `DeepEqual` against the parsed `configuration/config.json` includes the new `sslTracingEnabled: false`)
- `gofmt` clean; `config.json` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new configuration option to enable SSL tracing capabilities, with the feature disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->