### PR TITLE
chore(config): remove unused Config fields with no readers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,12 +69,9 @@ type Config struct {
 	DTop                           bool                                 `mapstructure:"dTop"`
 	DUnshare                       bool                                 `mapstructure:"dUnshare"`
 	EnableApplicationProfile       bool                                 `mapstructure:"applicationProfileServiceEnabled"`
-	EnableBackendStorage           bool                                 `mapstructure:"backendStorageEnabled"`
 	EnableEmbeddedSboms            bool                                 `mapstructure:"enableEmbeddedSBOMs"`
 	EnableFIM                      bool                                 `mapstructure:"fimEnabled"`
 	EnableFullPathTracing          bool                                 `mapstructure:"fullPathTracingEnabled"`
-	EnableHostMalwareSensor        bool                                 `mapstructure:"hostMalwareSensorEnabled"`
-	EnableHostNetworkSensor        bool                                 `mapstructure:"hostNetworkSensorEnabled"`
 	EnableHttpDetection            bool                                 `mapstructure:"httpDetectionEnabled"`
 	EnableMalwareDetection         bool                                 `mapstructure:"malwareDetectionEnabled"`
 	EnableNetworkStreaming         bool                                 `mapstructure:"networkStreamingEnabled"`
@@ -118,7 +115,6 @@ type Config struct {
 	ProfilesCacheRefreshRate       time.Duration                        `mapstructure:"profilesCacheRefreshRate"`
 	StorageRPCBudget               time.Duration                        `mapstructure:"storageRPCBudget"`
 	RuleCoolDown                   rulecooldown.RuleCooldownConfig      `mapstructure:"ruleCooldown"`
-	TestMode                       bool                                 `mapstructure:"testMode"`
 	UpdateDataPeriod               time.Duration                        `mapstructure:"updateDataPeriod"`
 	WorkerChannelSize              int                                  `mapstructure:"workerChannelSize"`
 	WorkerPoolSize                 int                                  `mapstructure:"workerPoolSize"`
@@ -179,15 +175,12 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 	viper.SetDefault("namespaceName", os.Getenv(NamespaceEnvVar))
 	viper.SetDefault("nodeName", os.Getenv(NodeNameEnvVar))
 	viper.SetDefault("podName", os.Getenv(PodNameEnvVar))
-	viper.SetDefault("hostMalwareSensorEnabled", false)
-	viper.SetDefault("hostNetworkSensorEnabled", false)
 	viper.SetDefault("fimEnabled", false)
 	viper.SetDefault("networkStreamingEnabled", false)
 	viper.SetDefault("kubernetesMode", true)
 	viper.SetDefault("networkStreamingInterval", 2*time.Minute)
 	viper.SetDefault("workerPoolSize", 3000)
 	viper.SetDefault("eventBatchSize", 15000)
-	viper.SetDefault("testMode", false)
 	viper.SetDefault("enableEmbeddedSBOMs", false)
 	viper.SetDefault("profilesCacheRefreshRate", 1*time.Minute)
 	viper.SetDefault("ruleCooldown::ruleCooldownDuration", 1*time.Hour)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -34,8 +34,6 @@ func TestLoadConfig(t *testing.T) {
 				EnableNetworkTracing:           false,
 				EnableNodeProfile:              false,
 				EnableHttpDetection:            false,
-				EnableHostMalwareSensor:        false,
-				EnableHostNetworkSensor:        false,
 				EnableFIM:                      true,
 				EnableNetworkStreaming:         false,
 				EnableEmbeddedSboms:            false,


### PR DESCRIPTION
## What
Removes four `Config` fields (and their viper defaults) that are **not referenced anywhere in node-agent**:

- `backendStorageEnabled`
- `hostMalwareSensorEnabled`
- `hostNetworkSensorEnabled`
- `testMode`

## Why
Nothing in the codebase reads these fields, so they have no effect on behavior — they only add noise to the `Config` struct and the documented config surface. Dropping them keeps the config lean.

## Safety
- No behavioral change: `grep` shows zero readers of the struct fields or their mapstructure keys outside `pkg/config`.
- `go build ./...` and `go test ./pkg/config/...` pass.
- Reviewers: please confirm no out-of-tree consumer sets these keys before merging (they were public config keys). Opened as **draft** for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed several deprecated configuration options from the system settings to streamline configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->