### PR TITLE
feat(config): add alertDeduplication.bypass master switch

### DIFF
--- a/docs/features/alert-deduplication-bypass.md
+++ b/docs/features/alert-deduplication-bypass.md
@@ -2,9 +2,13 @@
 
 `alertDeduplication.bypass` (config key `alertDeduplication::bypass`, default `false`)
 is a master switch that disables **all** sensor-side alert suppression. When `true`,
-config loading forces `eventDedup.enabled=false` (no raw eBPF event dedup) and
-`ruleCooldown.ruleCooldownOnProfileFailure=false` (no per-signature rule cooldown), so
-every rule firing is exported.
+config loading forces every suppression switch off:
+
+- `eventDedup.enabled=false` — no raw eBPF event dedup
+- `ruleCooldown.ruleCooldownDisabled=true` — no per-signature rule cooldown
+- `fim.dedupConfig.dedupEnabled=false` — no host file-integrity (FIM) event dedup
+
+so every rule firing is exported.
 
 It is intended only for high-volume security-testing (DAST) scenarios where every
 alert must surface. Under load it increases export volume and agent CPU — the intended

--- a/docs/features/alert-deduplication-bypass.md
+++ b/docs/features/alert-deduplication-bypass.md
@@ -1,0 +1,11 @@
+# Alert Deduplication Bypass
+
+`alertDeduplication.bypass` (config key `alertDeduplication::bypass`, default `false`)
+is a master switch that disables **all** sensor-side alert suppression. When `true`,
+config loading forces `eventDedup.enabled=false` (no raw eBPF event dedup) and
+`ruleCooldown.ruleCooldownOnProfileFailure=false` (no per-signature rule cooldown), so
+every rule firing is exported.
+
+It is intended only for high-volume security-testing (DAST) scenarios where every
+alert must surface. Under load it increases export volume and agent CPU — the intended
+trade-off. Leave it off for all normal deployments.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -248,7 +248,7 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 
 	if err := viper.ReadInConfig(); err != nil {
 		var notFound viper.ConfigFileNotFoundError
-		if !(errors.As(err, &notFound) && !errNotFound) {
+		if !errors.As(err, &notFound) || errNotFound {
 			return Config{}, err
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,13 @@ type EventDedupConfig struct {
 	SlotsExponent uint8 `mapstructure:"slotsExponent"`
 }
 
+// AlertDeduplicationConfig is a master switch that bypasses all sensor-side alert
+// deduplication and cooldown. Off by default; intended for high-volume
+// security-testing (DAST) use cases.
+type AlertDeduplicationConfig struct {
+	Bypass bool `mapstructure:"bypass"`
+}
+
 type Config struct {
 	BlockEvents                    bool                                 `mapstructure:"blockEvents"`
 	CelConfigCache                 cache.FunctionCacheConfig            `mapstructure:"celConfigCache"`
@@ -86,6 +93,7 @@ type Config struct {
 	StandaloneMonitoringEnabled    bool                                 `mapstructure:"standaloneMonitoringEnabled"`
 	SeccompProfileBackend          string                               `mapstructure:"seccompProfileBackend"`
 	EventBatchSize                 int                                  `mapstructure:"eventBatchSize"`
+	AlertDeduplication             AlertDeduplicationConfig             `mapstructure:"alertDeduplication"`
 	EventDedup                     EventDedupConfig                     `mapstructure:"eventDedup"`
 	ExcludeJsonPaths               []string                             `mapstructure:"excludeJsonPaths"`
 	ExcludeLabels                  map[string][]string                  `mapstructure:"excludeLabels"`
@@ -204,6 +212,7 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 
 	viper.SetDefault("eventDedup::enabled", true)
 	viper.SetDefault("eventDedup::slotsExponent", 18)
+	viper.SetDefault("alertDeduplication::bypass", false)
 	viper.SetDefault("dnsCacheSize", 50000)
 	viper.SetDefault("seccompProfileBackend", "storage") // "storage" or "crd"
 	viper.SetDefault("containerEolNotificationBuffer", 100)
@@ -254,6 +263,14 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 		config.SeccompProfileBackend != SeccompBackendCRD {
 		return Config{}, fmt.Errorf("invalid seccompProfileBackend value: %q (must be %q or %q)",
 			config.SeccompProfileBackend, SeccompBackendStorage, SeccompBackendCRD)
+	}
+
+	// High-volume security testing (DAST): a single master switch that bypasses ALL sensor-side suppression.
+	// It forces the existing event-dedup and rule-cooldown switches off, so the
+	// downstream code paths (container watcher, rule manager) need no changes.
+	if config.AlertDeduplication.Bypass {
+		config.EventDedup.Enabled = false
+		config.RuleCoolDown.OnProfileFailure = false
 	}
 
 	// Validate eventDedup slotsExponent range

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -191,6 +191,7 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 	viper.SetDefault("eventBatchSize", 15000)
 	viper.SetDefault("enableEmbeddedSBOMs", false)
 	viper.SetDefault("profilesCacheRefreshRate", 1*time.Minute)
+	viper.SetDefault("ruleCooldown::ruleCooldownDisabled", false)
 	viper.SetDefault("ruleCooldown::ruleCooldownDuration", 1*time.Hour)
 	viper.SetDefault("ruleCooldown::ruleCooldownAfterCount", 1)
 	viper.SetDefault("ruleCooldown::ruleCooldownOnProfileFailure", true) // NOTE: this is deprecated.
@@ -266,11 +267,13 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 	}
 
 	// High-volume security testing (DAST): a single master switch that bypasses ALL sensor-side suppression.
-	// It forces the existing event-dedup and rule-cooldown switches off, so the
-	// downstream code paths (container watcher, rule manager) need no changes.
+	// It forces every suppression switch off — eBPF event dedup, rule cooldown, and
+	// host-FIM event dedup — so the downstream code paths (container watcher, rule
+	// manager, FIM sensor) need no changes.
 	if config.AlertDeduplication.Bypass {
 		config.EventDedup.Enabled = false
-		config.RuleCoolDown.OnProfileFailure = false
+		config.RuleCoolDown.Disabled = true
+		config.FIM.DedupConfig.DedupEnabled = false
 	}
 
 	// Validate eventDedup slotsExponent range

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -586,7 +586,7 @@ func TestGetFIMPathConfigs(t *testing.T) {
 func TestLoadConfig_AlertDeduplicationBypass(t *testing.T) {
 	viper.Reset()
 	dir := t.TempDir()
-	cfg := `{"alertDeduplication": {"bypass": true}, "eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}}`
+	cfg := `{"alertDeduplication": {"bypass": true}, "eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}, "fim": {"dedupConfig": {"dedupEnabled": true}}}`
 	require.NoError(t, os.WriteFile(dir+"/config.json", []byte(cfg), 0644))
 
 	config, err := LoadConfigOptional(dir, false)
@@ -594,13 +594,14 @@ func TestLoadConfig_AlertDeduplicationBypass(t *testing.T) {
 
 	assert.True(t, config.AlertDeduplication.Bypass)
 	assert.False(t, config.EventDedup.Enabled, "bypass must disable event dedup")
-	assert.False(t, config.RuleCoolDown.OnProfileFailure, "bypass must disable rule cooldown")
+	assert.True(t, config.RuleCoolDown.Disabled, "bypass must disable rule cooldown")
+	assert.False(t, config.FIM.DedupConfig.DedupEnabled, "bypass must disable host-FIM event dedup")
 }
 
 func TestLoadConfig_NoBypassByDefault(t *testing.T) {
 	viper.Reset()
 	dir := t.TempDir()
-	cfg := `{"eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}}`
+	cfg := `{"eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}, "fim": {"dedupConfig": {"dedupEnabled": true}}}`
 	require.NoError(t, os.WriteFile(dir+"/config.json", []byte(cfg), 0644))
 
 	config, err := LoadConfigOptional(dir, false)
@@ -608,7 +609,9 @@ func TestLoadConfig_NoBypassByDefault(t *testing.T) {
 
 	assert.False(t, config.AlertDeduplication.Bypass)
 	assert.True(t, config.EventDedup.Enabled)
+	assert.False(t, config.RuleCoolDown.Disabled)
 	assert.True(t, config.RuleCoolDown.OnProfileFailure)
+	assert.True(t, config.FIM.DedupConfig.DedupEnabled, "without bypass, configured suppression is preserved")
 }
 
 func TestGetFIMExportersConfig(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -610,7 +610,7 @@ func TestLoadConfig_NoBypassByDefault(t *testing.T) {
 	assert.False(t, config.AlertDeduplication.Bypass)
 	assert.True(t, config.EventDedup.Enabled)
 	assert.False(t, config.RuleCoolDown.Disabled)
-	assert.True(t, config.RuleCoolDown.OnProfileFailure)
+	assert.True(t, config.RuleCoolDown.OnProfileFailure) //nolint:staticcheck // SA1019: intentionally asserting deprecated field is preserved for backward compatibility
 	assert.True(t, config.FIM.DedupConfig.DedupEnabled, "without bypass, configured suppression is preserved")
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -583,6 +583,34 @@ func TestGetFIMPathConfigs(t *testing.T) {
 	assert.False(t, pathConfig.OnMove)
 }
 
+func TestLoadConfig_AlertDeduplicationBypass(t *testing.T) {
+	viper.Reset()
+	dir := t.TempDir()
+	cfg := `{"alertDeduplication": {"bypass": true}, "eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}}`
+	require.NoError(t, os.WriteFile(dir+"/config.json", []byte(cfg), 0644))
+
+	config, err := LoadConfigOptional(dir, false)
+	require.NoError(t, err)
+
+	assert.True(t, config.AlertDeduplication.Bypass)
+	assert.False(t, config.EventDedup.Enabled, "bypass must disable event dedup")
+	assert.False(t, config.RuleCoolDown.OnProfileFailure, "bypass must disable rule cooldown")
+}
+
+func TestLoadConfig_NoBypassByDefault(t *testing.T) {
+	viper.Reset()
+	dir := t.TempDir()
+	cfg := `{"eventDedup": {"enabled": true, "slotsExponent": 18}, "ruleCooldown": {"ruleCooldownOnProfileFailure": true}}`
+	require.NoError(t, os.WriteFile(dir+"/config.json", []byte(cfg), 0644))
+
+	config, err := LoadConfigOptional(dir, false)
+	require.NoError(t, err)
+
+	assert.False(t, config.AlertDeduplication.Bypass)
+	assert.True(t, config.EventDedup.Enabled)
+	assert.True(t, config.RuleCoolDown.OnProfileFailure)
+}
+
 func TestGetFIMExportersConfig(t *testing.T) {
 	// Create a temporary config file
 	tempDir := t.TempDir()
@@ -639,4 +667,16 @@ func TestGetFIMExportersConfig(t *testing.T) {
 	assert.Equal(t, "udp://syslog:514", exportersConfig.SyslogExporter)
 	assert.Len(t, exportersConfig.AlertManagerExporterUrls, 1)
 	assert.Equal(t, "http://alertmanager:9093", exportersConfig.AlertManagerExporterUrls[0])
+}
+
+func TestLoadConfig_BypassSkipsSlotsExponentValidation(t *testing.T) {
+	viper.Reset()
+	dir := t.TempDir()
+	// slotsExponent 5 is out of range, but bypass disables eventDedup, so load must succeed.
+	cfg := `{"alertDeduplication": {"bypass": true}, "eventDedup": {"enabled": true, "slotsExponent": 5}}`
+	require.NoError(t, os.WriteFile(dir+"/config.json", []byte(cfg), 0644))
+
+	config, err := LoadConfigOptional(dir, false)
+	require.NoError(t, err, "bypass must skip slotsExponent validation")
+	assert.False(t, config.EventDedup.Enabled)
 }

--- a/pkg/rulemanager/rulecooldown/rulecooldown.go
+++ b/pkg/rulemanager/rulecooldown/rulecooldown.go
@@ -8,10 +8,16 @@ import (
 )
 
 type RuleCooldownConfig struct {
+	// Disabled is the master kill-switch for rule cooldown. When true, cooldown is
+	// bypassed entirely regardless of the other fields. Zero value (false) preserves
+	// the historical behavior of being governed by OnProfileFailure.
+	Disabled           bool          `mapstructure:"ruleCooldownDisabled"`
 	CooldownDuration   time.Duration `mapstructure:"ruleCooldownDuration"`
 	CooldownAfterCount int           `mapstructure:"ruleCooldownAfterCount"`
-	OnProfileFailure   bool          `mapstructure:"ruleCooldownOnProfileFailure"`
-	MaxSize            int           `mapstructure:"ruleCooldownMaxSize"`
+	// Deprecated: retained for backward compatibility. Setting it false still disables
+	// cooldown, but new callers should use Disabled as the explicit master switch.
+	OnProfileFailure bool `mapstructure:"ruleCooldownOnProfileFailure"`
+	MaxSize          int  `mapstructure:"ruleCooldownMaxSize"`
 }
 
 type RuleCooldown struct {
@@ -35,7 +41,9 @@ func NewRuleCooldown(config RuleCooldownConfig) *RuleCooldown {
 func (rc *RuleCooldown) ShouldCooldown(uniqueID string, containerID string, ruleID string) (bool, int) {
 	key := uniqueID + containerID + ruleID
 
-	if !rc.cooldownConfig.OnProfileFailure {
+	// Disabled is the explicit master switch; OnProfileFailure is retained for
+	// backward compatibility and still disables cooldown when false.
+	if rc.cooldownConfig.Disabled || !rc.cooldownConfig.OnProfileFailure {
 		return false, 1
 	}
 

--- a/pkg/rulemanager/rulecooldown/rulecooldown_test.go
+++ b/pkg/rulemanager/rulecooldown/rulecooldown_test.go
@@ -133,6 +133,28 @@ func TestShouldCooldown(t *testing.T) {
 			iterations:       3,
 			profileFailure:   true,
 		},
+		{
+			name: "no cooldown when Disabled is true",
+			config: RuleCooldownConfig{
+				Disabled:           true,
+				CooldownDuration:   1 * time.Hour,
+				CooldownAfterCount: 3,
+				OnProfileFailure:   true,
+				MaxSize:            1000,
+			},
+			ruleFailure: &types.GenericRuleFailure{
+				BaseRuntimeAlert: armotypes.BaseRuntimeAlert{
+					UniqueID: "test-alert-disabled",
+				},
+				RuntimeProcessDetails: armotypes.ProcessTree{
+					ContainerID: "test-container-disabled",
+				},
+			},
+			expectedCooldown: false,
+			expectedCount:    1,
+			iterations:       5,
+			profileFailure:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Adds `alertDeduplication.bypass` — a single, off-by-default config switch that disables all sensor-side alert suppression.

When `true`, config loading forces:
- `eventDedup.enabled=false` (no raw eBPF event deduplication)
- `ruleCooldown.ruleCooldownOnProfileFailure=false` (no per-signature rule cooldown)

so every rule firing is exported.

## Why

High-volume security-testing (DAST) scenarios need every alert to surface rather than being collapsed by deduplication/cooldown. This provides one clearly-scoped switch instead of toggling several low-level knobs.

## Notes
- Default `false` → no behavior change for existing deployments.
- Applied before `eventDedup.slotsExponent` validation, so an out-of-range exponent doesn't cause a spurious load error when bypass is on.
- Includes `pkg/config` unit tests and a feature doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `alertDeduplication.bypass` master switch (default `false`) to disable sensor-side alert suppression, ensuring all rule firings are exported.
  * Added `ruleCooldownDisabled` kill-switch for bypassing rule cooldown regardless of other cooldown settings.
* **Documentation**
  * Updated documentation to explain the bypass behavior, intent, and trade-offs (higher export volume/CPU).
* **Bug Fixes**
  * When bypass is enabled, related validation is skipped to prevent out-of-range values from failing config load.
* **Tests**
  * Added unit tests covering bypass behavior and bypass-related validation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->