### PR TITLE
fix: correct IgnoreRuleBindings handling for container monitoring

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -160,7 +160,7 @@ correlation is an upgrade, not a dependency.
 | `fullPathTracingEnabled` | bool | `true` | Include full executable paths |
 | `enableEmbeddedSBOMs` | bool | `false` | Use embedded SBOMs from images |
 | `partialProfileGenerationEnabled` | bool | `true` | Allow partial profile generation |
-| `ignoreRuleBindings` | bool | `false` | Apply all rules regardless of bindings |
+| `ignoreRuleBindings` | bool | `false` | Apply all rules to all pods regardless of bindings. When enabled, RuntimeAlertRuleBinding objects are not watched, every monitored container is kept for runtime detection, and per-pod binding bookkeeping is skipped (rules are resolved directly from the rule creator). |
 
 ### Timing & Performance
 

--- a/pkg/containerwatcher/v2/container_watcher_private_test.go
+++ b/pkg/containerwatcher/v2/container_watcher_private_test.go
@@ -133,6 +133,7 @@ func TestUnregisterContainer(t *testing.T) {
 		expectedContainers      []string
 		enableRuntimeDetection  bool
 		ruleBindingsInitialized bool
+		ignoreRuleBindings      bool
 	}{
 		{
 			name:                    "Test unregister container with runtime detection enabled and bindings initialized",
@@ -223,12 +224,28 @@ func TestUnregisterContainer(t *testing.T) {
 			enableRuntimeDetection:  true,
 			ruleBindingsInitialized: true,
 		},
+		{
+			name:                    "Test keep container when rule bindings are ignored",
+			unregisterContainer:     "container1",
+			unregisterContainersPod: "pod1",
+			podToContainers: map[string][]string{
+				"pod1": {"container1"},
+				"pod2": {"container2"},
+			},
+			// pod is not rule-managed and bindings are initialized, but IgnoreRuleBindings
+			// means all rules apply to all pods, so the container must be kept.
+			preRuleManagedPods:      []string{},
+			expectedContainers:      []string{"container1", "container2"},
+			enableRuntimeDetection:  true,
+			ruleBindingsInitialized: true,
+			ignoreRuleBindings:      true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ncw := ContainerWatcher{
-				cfg:                     config.Config{EnableRuntimeDetection: tt.enableRuntimeDetection},
+				cfg:                     config.Config{EnableRuntimeDetection: tt.enableRuntimeDetection, IgnoreRuleBindings: tt.ignoreRuleBindings},
 				ruleManagedPods:         mapset.NewSet[string](tt.preRuleManagedPods...),
 				ruleBindingsInitialized: tt.ruleBindingsInitialized,
 				containerCollection:     &containercollection.ContainerCollection{},

--- a/pkg/containerwatcher/v2/containercallback.go
+++ b/pkg/containerwatcher/v2/containercallback.go
@@ -31,7 +31,8 @@ func (cw *ContainerWatcher) containerCallback(notif containercollection.PubSubEv
 			helpers.String("containerID", notif.Container.Runtime.ContainerID))
 		// avoid loops when the container is being removed
 		if notif.Type == containercollection.EventTypeAddContainer {
-			cw.unregisterContainer(notif.Container)
+			// ignored containers must be dropped regardless of rule bindings / runtime detection
+			cw.removeContainer(notif.Container)
 		}
 		return
 	}
@@ -196,6 +197,15 @@ func (cw *ContainerWatcher) unregisterContainer(container *containercollection.C
 	// 1. Runtime detection is disabled, OR
 	// 2. Rule bindings have been initialized AND this pod is not in ruleManagedPods
 	if cw.cfg.EnableRuntimeDetection {
+		// When rule bindings are ignored, every pod is effectively rule-managed
+		// (all rules apply to all pods), so the container must keep being monitored.
+		if cw.cfg.IgnoreRuleBindings {
+			logger.L().Debug("ContainerWatcher - container should still be monitored for runtime detection (rule bindings ignored)",
+				helpers.String("container ID", container.Runtime.ContainerID),
+				helpers.String("namespace", container.K8s.Namespace), helpers.String("PodName", container.K8s.PodName), helpers.String("ContainerName", container.K8s.ContainerName),
+			)
+			return
+		}
 		// If the pod is currently in ruleManagedPods, it should still be monitored
 		if cw.ruleManagedPods.Contains(k8sPodID) {
 			logger.L().Debug("ContainerWatcher - container should still be monitored for runtime detection (in ruleManagedPods)",
@@ -217,6 +227,13 @@ func (cw *ContainerWatcher) unregisterContainer(container *containercollection.C
 		// meaning rule bindings exist but don't apply to this pod - proceed with unregistration
 	}
 
+	cw.removeContainer(container)
+}
+
+// removeContainer removes a container from monitoring unconditionally, releasing
+// its collection entry and shared cache data. Use this when the container must be
+// dropped regardless of rule bindings or runtime detection (e.g. ignored containers).
+func (cw *ContainerWatcher) removeContainer(container *containercollection.Container) {
 	logger.L().Debug("ContainerWatcher - stopping to monitor on container", helpers.String("container ID", container.Runtime.ContainerID), helpers.String("namespace", container.K8s.Namespace), helpers.String("PodName", container.K8s.PodName), helpers.String("ContainerName", container.K8s.ContainerName))
 
 	cw.containerCollection.RemoveContainer(container.Runtime.ContainerID)

--- a/pkg/rulebindingmanager/cache/cache.go
+++ b/pkg/rulebindingmanager/cache/cache.go
@@ -63,7 +63,7 @@ func NewCache(config config.Config, k8sClient k8sclient.K8sClientInterface, rule
 		rbNameToRB:        maps.SafeMap[string, typesv1.RuntimeAlertRuleBinding]{},
 		podToRBNames:      maps.SafeMap[string, mapset.Set[string]]{},
 		rbNameToPods:      maps.SafeMap[string, mapset.Set[string]]{},
-		watchResources:    resourcesToWatch(config.NodeName),
+		watchResources:    resourcesToWatch(config.NodeName, config.IgnoreRuleBindings),
 		rulesForPod:       expirable.NewLRU[string, []rulemanagertypesv1.Rule](1000, nil, 5*time.Second),
 		notificationQueue: make(chan pendingNotification, 10000),
 	}
@@ -154,6 +154,11 @@ func (c *RBCache) AddHandler(ctx context.Context, obj runtime.Object) {
 	var rbs []rulebindingmanager.RuleBindingNotify
 
 	if pod, ok := obj.(*corev1.Pod); ok {
+		// When rule bindings are ignored, pod->binding bookkeeping is never read
+		// (ListRulesForPod resolves rules directly from the rule creator), so skip it.
+		if c.config.IgnoreRuleBindings {
+			return
+		}
 		rbs = c.addPod(ctx, pod)
 	} else if un, ok := obj.(*unstructured.Unstructured); ok {
 		if un.GetKind() != "" && un.GetKind() != rbtypes.RuntimeRuleBindingAlertKind {
@@ -185,6 +190,11 @@ func (c *RBCache) ModifyHandler(ctx context.Context, obj runtime.Object) {
 	var rbs []rulebindingmanager.RuleBindingNotify
 
 	if pod, ok := obj.(*corev1.Pod); ok {
+		// When rule bindings are ignored, pod->binding bookkeeping is never read
+		// (ListRulesForPod resolves rules directly from the rule creator), so skip it.
+		if c.config.IgnoreRuleBindings {
+			return
+		}
 		rbs = c.addPod(ctx, pod)
 	} else if un, ok := obj.(*unstructured.Unstructured); ok {
 		if un.GetKind() != "" && un.GetKind() != rbtypes.RuntimeRuleBindingAlertKind {
@@ -216,6 +226,10 @@ func (c *RBCache) DeleteHandler(_ context.Context, obj runtime.Object) {
 	var rbs []rulebindingmanager.RuleBindingNotify
 
 	if pod, ok := obj.(*corev1.Pod); ok {
+		// When rule bindings are ignored, pod->binding bookkeeping is never populated, so skip it.
+		if c.config.IgnoreRuleBindings {
+			return
+		}
 		c.deletePod(uniqueName(pod))
 	} else if un, ok := obj.(*unstructured.Unstructured); ok {
 		rbs = c.deleteRuleBinding(uniqueName(un))
@@ -236,11 +250,17 @@ func (c *RBCache) RefreshRuleBindingsRules() {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for _, rbName := range c.rbNameToRB.Keys() {
-		rb := c.rbNameToRB.Get(rbName)
-		c.rbNameToRules.Set(rbName, c.createRules(rb.Spec.Rules))
+	// When rule bindings are ignored, ListRulesForPod resolves rules directly from
+	// the rule creator (CreateAllRules), so there are no per-binding rules to rebuild.
+	// We still notify downstream consumers so they react to the underlying rule change
+	// (e.g. RuleManager recompiling the profile projection spec).
+	if !c.config.IgnoreRuleBindings {
+		for _, rbName := range c.rbNameToRB.Keys() {
+			rb := c.rbNameToRB.Get(rbName)
+			c.rbNameToRules.Set(rbName, c.createRules(rb.Spec.Rules))
+		}
+		logger.L().Info("RBCache - refreshed rule bindings rules", helpers.Int("ruleBindings", len(c.rbNameToRB.Keys())))
 	}
-	logger.L().Info("RBCache - refreshed rule bindings rules", helpers.Int("ruleBindings", len(c.rbNameToRB.Keys())))
 
 	if len(c.notifiers) > 0 {
 		notifiers := make([]*chan rulebindingmanager.RuleBindingNotify, len(c.notifiers))

--- a/pkg/rulebindingmanager/cache/helpers.go
+++ b/pkg/rulebindingmanager/cache/helpers.go
@@ -55,7 +55,7 @@ func unstructuredToRuleBinding(obj *unstructured.Unstructured) (*typesv1.Runtime
 	return rb, nil
 }
 
-func resourcesToWatch(nodeName string) []watcher.WatchResource {
+func resourcesToWatch(nodeName string, ignoreRuleBindings bool) []watcher.WatchResource {
 	var w []watcher.WatchResource
 
 	// add pod
@@ -70,9 +70,13 @@ func resourcesToWatch(nodeName string) []watcher.WatchResource {
 	)
 	w = append(w, p)
 
-	// add rule binding
-	rb := watcher.NewWatchResource(typesv1.RuleBindingAlertGvr, metav1.ListOptions{})
-	w = append(w, rb)
+	// When rule bindings are ignored, all rules apply to all pods, so there is no
+	// reason to watch (and react to) RuntimeAlertRuleBinding objects.
+	if !ignoreRuleBindings {
+		// add rule binding
+		rb := watcher.NewWatchResource(typesv1.RuleBindingAlertGvr, metav1.ListOptions{})
+		w = append(w, rb)
+	}
 
 	return w
 }

--- a/pkg/rulebindingmanager/cache/helpers_test.go
+++ b/pkg/rulebindingmanager/cache/helpers_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestResourcesToWatch(t *testing.T) {
 	tests := []struct {
-		name     string
-		nodeName string
+		name               string
+		nodeName           string
+		ignoreRuleBindings bool
 	}{
 		{
 			name:     "Test with valid node name",
@@ -24,19 +25,29 @@ func TestResourcesToWatch(t *testing.T) {
 			name:     "Test with empty node name",
 			nodeName: "",
 		},
+		{
+			name:               "Test with rule bindings ignored",
+			nodeName:           "node-1",
+			ignoreRuleBindings: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resourcesToWatch(tt.nodeName)
-
-			assert.Equal(t, 2, len(result))
+			result := resourcesToWatch(tt.nodeName, tt.ignoreRuleBindings)
 
 			podResource := result[0]
 			assert.Equal(t, "v1", podResource.GroupVersionResource().Version)
 			assert.Equal(t, "pods", podResource.GroupVersionResource().Resource)
 			assert.Equal(t, "spec.nodeName="+tt.nodeName, podResource.ListOptions().FieldSelector)
 
+			if tt.ignoreRuleBindings {
+				// rule bindings are not watched when ignored
+				assert.Equal(t, 1, len(result))
+				return
+			}
+
+			assert.Equal(t, 2, len(result))
 			rbResource := result[1]
 			assert.Equal(t, typesv1.RuleBindingAlertGvr, rbResource.GroupVersionResource())
 			assert.Equal(t, metav1.ListOptions{}, rbResource.ListOptions())


### PR DESCRIPTION
## What

Corrects how `IgnoreRuleBindings` is handled across container monitoring and the rule-binding cache.

### Background / root cause
In `IgnoreRuleBindings` mode every pod is evaluated against the full rule set, so `ruleManagedPods` is never populated (it is only fed from binding notifications). When a container's ApplicationProfile reaches end-of-life, the EOL-driven `unregisterContainer` tore down monitoring — detection silently stopped after learning completed. Validated on a live cluster (chart sets `IGNORERULEBINDINGS=true`; with no binding, attack-suite containers were unregistered at profile-EOL and a command-injection produced zero detections).

### The fix
The original one-line fix short-circuited the **entire** `unregisterContainer`, which also disabled removal of explicitly *ignored* containers (excludeNamespaces/labels, e.g. kube-system) and cleanup of learning-complete containers when runtime detection is off. This PR scopes the behavior correctly:

- **`unregisterContainer`** — the `IgnoreRuleBindings` early-return is placed *inside* the `EnableRuntimeDetection` block (the actual buggy decision), treating every pod as rule-managed so the container keeps being monitored. The real removal is extracted into `removeContainer`.
- **`containerCallback`** — ignored containers now call `removeContainer` directly, so they are always dropped regardless of rule bindings / runtime detection.

### Stop wasted rule-binding work when bindings are ignored
- **`resourcesToWatch`** no longer watches `RuntimeAlertRuleBinding` objects (RBCache is the sole watcher), which also removes the misleading `RBCache - refreshed rule bindings rules` log.
- **`RefreshRuleBindingsRules`** skips the per-binding rule rebuild but **still notifies consumers**, so `RuleManager` keeps recompiling the profile projection spec on `Rule` CRD changes.
- **RBCache handlers** skip pod→binding bookkeeping (`addPod`/`deletePod`) since it is never read in this mode.

## Tests
- `TestUnregisterContainer`: new case keeping a container in `ignoreRuleBindings` mode with no matching binding (fails on `main`, passes here).
- `TestResourcesToWatch`: new case asserting rule bindings are not watched when ignored.
- `go build ./...` clean; `pkg/rulebindingmanager/...`, `pkg/rulemanager`, `pkg/containerwatcher/v2` green.

## Docs
- `docs/CONFIGURATION.md` — expanded the `ignoreRuleBindings` entry to describe the now-explicit behavior.

## Follow-up (not in this PR)
Component-test blind spot: the test chart ships an unconditional `all-rules-all-pods` binding, so `ruleManagedPods` is always populated and the bug is masked. A component-test variant with `ignoreRuleBindings=true` and **no** binding would close the gap.