### PR TITLE
fix: map network event pktType to direction in CEL rules engine

### DIFF
--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -273,6 +273,9 @@ func (e *DatasourceEvent) GetCwd() string {
 }
 
 func (e *DatasourceEvent) GetDirection() consts.NetworkDirection {
+	if e.Direction == "" && e.EventType == NetworkEventType {
+		return DirectionFromPktType(e.GetPktType())
+	}
 	return e.Direction
 }
 

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/consts"
@@ -269,4 +270,12 @@ func protoNumToString(protoNum uint16) string {
 	default:
 		return ""
 	}
+}
+
+// DirectionFromPktType maps an Inspektor Gadget packet type string to a NetworkDirection
+func DirectionFromPktType(pktType string) consts.NetworkDirection {
+	if strings.EqualFold(pktType, OutgoingPktType) {
+		return consts.Outbound
+	}
+	return consts.Inbound
 }

--- a/pkg/utils/events_test.go
+++ b/pkg/utils/events_test.go
@@ -1,13 +1,131 @@
 package utils
 
-// Test struct that mimics the structure of events with Comm field
-type testEventWithComm struct {
-	Comm string
+import (
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/consts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructEventGetDirection(t *testing.T) {
+	tests := []struct {
+		name      string
+		event     *StructEvent
+		expectDir consts.NetworkDirection
+	}{
+		{
+			name:      "HTTP event with explicit direction Inbound",
+			event:     &StructEvent{EventType: HTTPEventType, Direction: consts.Inbound},
+			expectDir: consts.Inbound,
+		},
+		{
+			name:      "HTTP event with explicit direction Outbound",
+			event:     &StructEvent{EventType: HTTPEventType, Direction: consts.Outbound},
+			expectDir: consts.Outbound,
+		},
+		{
+			name:      "Network event with no Direction set and OUTGOING packet type maps to Outbound",
+			event:     &StructEvent{EventType: NetworkEventType, PktType: "OUTGOING"},
+			expectDir: consts.Outbound,
+		},
+		{
+			name:      "Network event with no Direction set and HOST packet type maps to Inbound",
+			event:     &StructEvent{EventType: NetworkEventType, PktType: "HOST"},
+			expectDir: consts.Inbound,
+		},
+		{
+			name:      "Network event with explicit Inbound direction ignores packet type",
+			event:     &StructEvent{EventType: NetworkEventType, Direction: consts.Inbound, PktType: "OUTGOING"},
+			expectDir: consts.Inbound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectDir, tt.event.GetDirection())
+		})
+	}
 }
 
-// Test struct that mimics the structure of events with Runtime field
-type testEventWithRuntime struct {
-	Runtime struct {
-		ContainerID string
+type mockFieldAccessor struct {
+	datasource.FieldAccessor
+	val uint8
+}
+
+func (m *mockFieldAccessor) Uint8(data datasource.Data) (uint8, error) {
+	return m.val, nil
+}
+
+type mockDataSource struct {
+	datasource.DataSource
+	fields map[string]datasource.FieldAccessor
+}
+
+func (m *mockDataSource) GetField(name string) datasource.FieldAccessor {
+	return m.fields[name]
+}
+
+func TestDatasourceEventGetDirection(t *testing.T) {
+	// Create mock datasource that has a field "egress" returning a mockFieldAccessor
+	dsOutgoing := &mockDataSource{
+		fields: map[string]datasource.FieldAccessor{
+			"egress": &mockFieldAccessor{val: 1},
+		},
+	}
+	dsHost := &mockDataSource{
+		fields: map[string]datasource.FieldAccessor{
+			"egress": &mockFieldAccessor{val: 0},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		event     *DatasourceEvent
+		expectDir consts.NetworkDirection
+	}{
+		{
+			name: "Network event with egress=1 maps to Outbound",
+			event: &DatasourceEvent{
+				EventType:  NetworkEventType,
+				Datasource: dsOutgoing,
+			},
+			expectDir: consts.Outbound,
+		},
+		{
+			name: "Network event with egress=0 maps to Inbound",
+			event: &DatasourceEvent{
+				EventType:  NetworkEventType,
+				Datasource: dsHost,
+			},
+			expectDir: consts.Inbound,
+		},
+		{
+			name: "Non-network event doesn't map egress to outbound",
+			event: &DatasourceEvent{
+				EventType:  HTTPEventType,
+				Datasource: dsOutgoing,
+			},
+			expectDir: "",
+		},
+		{
+			name: "HTTP event with explicit direction Inbound",
+			event: &DatasourceEvent{
+				EventType: HTTPEventType,
+				Direction: consts.Inbound,
+			},
+			expectDir: consts.Inbound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear package-level fieldCaches maps so we don't bleed cache between tests
+			fieldCaches.Range(func(key, val interface{}) bool {
+				fieldCaches.Delete(key)
+				return true
+			})
+			assert.Equal(t, tt.expectDir, tt.event.GetDirection())
+		})
 	}
 }

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -154,6 +154,9 @@ func (e *StructEvent) GetCwd() string {
 }
 
 func (e *StructEvent) GetDirection() consts.NetworkDirection {
+	if e.Direction == "" && e.EventType == NetworkEventType {
+		return DirectionFromPktType(e.GetPktType())
+	}
 	return e.Direction
 }
 


### PR DESCRIPTION
This PR fixes a bug where `event.direction` on a network event is always empty, causing rules evaluating `event.direction == 'outbound'` (such as R1077) to never trigger. It falls back to mapping Inspektor Gadget's `pktType` (`OUTGOING` vs others) to direction if `e.Direction` is empty.

Closes #840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network events now automatically show the correct inbound or outbound direction when no direction is explicitly set.
  * Direction handling is more consistent across event types, including cases where packet type information is used to determine the result.

* **Tests**
  * Expanded coverage for event direction behavior, including explicit directions and packet-type-based inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->