### PR TITLE
fix: raise gRPC client/server message limits on sbom-scanner sidecar channel

### DIFF
--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	healthCheckTimeout = 5 * time.Second
+	MaxgRPCMessageSize = 128 * 1024 * 1024
 )
 
 type sbomScannerClient struct {
@@ -37,6 +38,10 @@ func NewSBOMScannerClient(socketPath string) (SBOMScannerClient, error) {
 				return info.FullMethodName != pb.SBOMScanner_Health_FullMethodName
 			}),
 		)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gRPC client: %w", err)

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -44,12 +44,19 @@ func startIntegrationServer(t *testing.T) (SBOMScannerClient, *grpc.Server, stri
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
+	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
 	go srv.Serve(lis)
 
 	conn, err := grpc.NewClient("unix://"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	require.NoError(t, err)
 

--- a/pkg/sbomscanner/v1/run.go
+++ b/pkg/sbomscanner/v1/run.go
@@ -71,11 +71,15 @@ func RunServer(ctx context.Context, accountID, accessKey string) {
 		logger.L().Fatal("failed to listen on socket", helpers.Error(err), helpers.String("path", socketPath))
 	}
 
-	srv := grpc.NewServer(grpc.StatsHandler(otelgrpc.NewServerHandler(
-		otelgrpc.WithFilter(func(info *grpcstats.RPCTagInfo) bool {
-			return info.FullMethodName != pb.SBOMScanner_Health_FullMethodName
-		}),
-	)))
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
+		grpc.StatsHandler(otelgrpc.NewServerHandler(
+			otelgrpc.WithFilter(func(info *grpcstats.RPCTagInfo) bool {
+				return info.FullMethodName != pb.SBOMScanner_Health_FullMethodName
+			}),
+		)),
+	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
 
 	sigCh := make(chan os.Signal, 1)

--- a/pkg/sbomscanner/v1/server_test.go
+++ b/pkg/sbomscanner/v1/server_test.go
@@ -26,12 +26,19 @@ func startTestServer(t *testing.T) (pb.SBOMScannerClient, func()) {
 	lis, err := net.Listen("unix", sock)
 	require.NoError(t, err)
 
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(
+		grpc.MaxRecvMsgSize(MaxgRPCMessageSize),
+		grpc.MaxSendMsgSize(MaxgRPCMessageSize),
+	)
 	pb.RegisterSBOMScannerServer(srv, NewScannerServer())
 	go srv.Serve(lis)
 
 	conn, err := grpc.NewClient("unix://"+sock,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize),
+			grpc.MaxCallSendMsgSize(MaxgRPCMessageSize),
+		),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
### Description
This PR resolves the issue where scanning larger images (such as `wordpress:6.0.1-php7.4`) fails because the generated SBOM size exceeds the default gRPC message size limit of 4 MiB on the client-side/server-side communication channel with `sbom-scanner` sidecar.

We raise the default message size limit on both ends to **128 MiB** (`128 * 1024 * 1024` bytes) to safely accommodate larger SBOM payloads.

This is the equivalent of kubescape/kubevuln#382 and references kubescape/kubevuln#381.

### Changes
* **v1 Package (`pkg/sbomscanner/v1/client.go`):**
  * Defined `MaxgRPCMessageSize = 128 * 1024 * 1024`.
  * Added `grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxgRPCMessageSize), grpc.MaxCallSendMsgSize(MaxgRPCMessageSize))` to `grpc.NewClient`.
* **Server Runner (`pkg/sbomscanner/v1/run.go`):**
  * Configured `grpc.NewServer` with `grpc.MaxRecvMsgSize(MaxgRPCMessageSize)` and `grpc.MaxSendMsgSize(MaxgRPCMessageSize)`.
* **Tests (`pkg/sbomscanner/v1/integration_test.go` and `pkg/sbomscanner/v1/server_test.go`):**
  * Updated test gRPC servers and clients to also use `MaxgRPCMessageSize` call and server options.
