### PR TITLE
fix(cooldownqueue): eliminate "send on closed channel" panic on shutdown

### DIFF
--- a/pkg/cooldownqueue/cooldownqueue.go
+++ b/pkg/cooldownqueue/cooldownqueue.go
@@ -1,6 +1,7 @@
 package cooldownqueue
 
 import (
+	"sync/atomic"
 	"time"
 
 	"istio.io/pkg/cache"
@@ -14,45 +15,93 @@ const (
 // CooldownQueue is a queue that lets clients put events into it with a cooldown
 //
 // When a client puts an event into a queue, it waits for a cooldown period before
-// the event is forwarded to the consumer. If and event for the same key is put into the queue
+// the event is forwarded to the consumer. If an event for the same key is put into the queue
 // again before the cooldown period is over, the event is overridden and the cooldown period is reset.
+//
+// Concurrency design: the TTL-cache evicter goroutine (istio.io/pkg/cache) cannot be
+// stopped synchronously, so we must never close the channel it sends to. Instead a
+// relay goroutine owns the consumer-facing channel (resultChan) and closes it only
+// after the done signal is received. The intermediate (innerChan) is never closed,
+// eliminating any "send on closed channel" panic during shutdown.
 type CooldownQueue[T any] struct {
-	closed     bool
+	// closed is set atomically to true when Stop() is called, preventing further
+	// Enqueue operations and signalling the relay goroutine via done.
+	closed     atomic.Bool
 	seenEvents cache.ExpiringCache
-	innerChan  chan T   // Private channel
-	resultChan <-chan T // Read-only public channel
+	innerChan  chan T   // written only by the eviction callback; never closed
+	resultChan <-chan T // closed by the relay goroutine when done is signalled
+	done       chan struct{}
 }
 
 // NewCooldownQueue returns a new Cooldown Queue
 func NewCooldownQueue[T any](cooldown time.Duration, evictionInterval time.Duration) *CooldownQueue[T] {
-	events := make(chan T)
+	// intermediate receives evicted items from the TTL-cache callback.
+	// It is NEVER closed so the callback can never panic with "send on closed channel".
+	intermediate := make(chan T)
+	// result is the consumer-facing channel; it is closed by the relay goroutine
+	// once Stop() signals done, unblocking any for-range consumer.
+	result := make(chan T)
+	done := make(chan struct{})
+
 	callback := func(key, value any) {
-		events <- value.(T)
+		// intermediate is never closed, so this select can never panic.
+		select {
+		case <-done:
+		case intermediate <- value.(T):
+		}
 	}
+
 	c := cache.NewTTLWithCallback(cooldown, evictionInterval, callback)
-	return &CooldownQueue[T]{
+
+	q := &CooldownQueue[T]{
 		seenEvents: c,
-		innerChan:  events,
-		resultChan: events,
+		innerChan:  intermediate,
+		resultChan: result,
+		done:       done,
 	}
+
+	// Relay goroutine: forwards events from intermediate to result and closes
+	// result when the queue is stopped.
+	go func() {
+		defer close(result)
+		for {
+			select {
+			case <-done:
+				return
+			case v := <-intermediate:
+				select {
+				case <-done:
+					return
+				case result <- v:
+				}
+			}
+		}
+	}()
+
+	return q
 }
 
 func (q *CooldownQueue[T]) Closed() bool {
-	return q.closed
+	return q.closed.Load()
 }
 
 // Enqueue enqueues an event in the Cooldown Queue
 func (q *CooldownQueue[T]) Enqueue(e T, key string) {
-	if q.closed {
+	if q.closed.Load() {
 		return
 	}
 
 	q.seenEvents.Set(key, e)
 }
 
+// Stop signals the queue to shut down. The result channel is closed by the
+// relay goroutine once all in-flight sends have drained, unblocking any
+// for-range consumer.
 func (q *CooldownQueue[T]) Stop() {
-	q.closed = true
-	close(q.innerChan)
+	if q.closed.Swap(true) {
+		return // already stopped
+	}
+	close(q.done)
 }
 
 // ResultChan returns a read-only channel for consuming events.

--- a/pkg/cooldownqueue/cooldownqueue.go
+++ b/pkg/cooldownqueue/cooldownqueue.go
@@ -94,9 +94,9 @@ func (q *CooldownQueue[T]) Enqueue(e T, key string) {
 	q.seenEvents.Set(key, e)
 }
 
-// Stop signals the queue to shut down. The result channel is closed by the
-// relay goroutine once all in-flight sends have drained, unblocking any
-// for-range consumer.
+// Stop signals the queue to shut down. The relay goroutine closes the result
+// channel after observing done; pending evictions not yet forwarded by then
+// may be dropped, unblocking any for-range consumer.
 func (q *CooldownQueue[T]) Stop() {
 	if q.closed.Swap(true) {
 		return // already stopped

--- a/pkg/cooldownqueue/cooldownqueue_test.go
+++ b/pkg/cooldownqueue/cooldownqueue_test.go
@@ -2,6 +2,7 @@ package cooldownqueue
 
 import (
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -55,6 +56,43 @@ func TestCooldownQueue_Enqueue(t *testing.T) {
 			})
 			assert.Equal(t, tt.outEvents, outEvents)
 		})
+	}
+}
+
+// TestCooldownQueue_StopDuringEviction verifies that calling Stop() while the TTL
+// evicter goroutine is firing eviction callbacks does not cause a "send on closed
+// channel" panic (issue: armosec/private-node-agent#368).
+func TestCooldownQueue_StopDuringEviction(t *testing.T) {
+	// Use a very short cooldown so that items expire (and the eviction callback
+	// fires) almost immediately.
+	const shortCooldown = 10 * time.Millisecond
+	const shortInterval = 5 * time.Millisecond
+
+	for i := 0; i < 50; i++ {
+		q := NewCooldownQueue[watch.Event](shortCooldown, shortInterval)
+
+		// Enqueue an event so there is something to evict.
+		q.Enqueue(podAdded, watcher.MakeEventKey(podAdded))
+
+		// Drain the result channel in a separate goroutine so the callback is
+		// not blocked on an unread receiver when we call Stop().
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			//nolint:revive // intentionally drain all events without processing them to unblock the relay goroutine
+			for range q.ResultChan() {
+			}
+		}()
+
+		// Sleep briefly so the TTL evicter goroutine is likely firing
+		// concurrently with the Stop() call below.
+		time.Sleep(shortCooldown / 2)
+
+		// Must not panic.
+		assert.NotPanics(t, func() { q.Stop() })
+
+		wg.Wait()
 	}
 }
 

--- a/pkg/cooldownqueue/cooldownqueue_test.go
+++ b/pkg/cooldownqueue/cooldownqueue_test.go
@@ -92,6 +92,11 @@ func TestCooldownQueue_StopDuringEviction(t *testing.T) {
 		// Must not panic.
 		assert.NotPanics(t, func() { q.Stop() })
 
+		// Keep this iteration alive long enough for the stopped queue's expired
+		// item to reach the eviction callback, so the final iteration still
+		// exercises the post-Stop eviction path.
+		time.Sleep(shortCooldown + shortInterval)
+
 		wg.Wait()
 	}
 }


### PR DESCRIPTION
## Problem

The `istio.io/pkg/cache` TTL evicter goroutine races with `CooldownQueue.Stop()` during SIGTERM, panicking with `send on closed channel`.

A `select { case <-done: }` guard is insufficient: Go evaluates **all** select-case operands before choosing — so if `innerChan` is already closed when the evicter callback fires, the send-case evaluation panics before `<-done` can be taken.

## Approach

Split the single channel into two, owned by different actors:

| Channel | Writer | Closed by |
|---|---|---|
| `intermediate` (`innerChan`) | evicter callback | **never** — eliminates the panic |
| `result` (`resultChan`, consumer-facing) | relay goroutine | relay goroutine on `done` signal |

A new relay goroutine forwards `intermediate → result` and `defer close(result)` unblocks any `for range` consumer on shutdown.

```go
// intermediate is NEVER closed, so the evicter callback cannot panic.
callback := func(key, value any) {
    select {
    case <-done:
    case intermediate <- value.(T):
    }
}

// Relay closes result when done fires, unblocking consumers cleanly.
go func() {
    defer close(result)
    for {
        select {
        case <-done:
            return
        case v := <-intermediate:
            select {
            case <-done:
                return
            case result <- v:
            }
        }
    }
}()
```

`Stop()` now just `close(done)` — no direct channel close.

## Additional fix

- `closed bool` → `atomic.Bool` to eliminate a pre-existing data race between `Stop()` and concurrent `Enqueue()`/`Closed()` callers.

## Testing

Adds `TestCooldownQueue_StopDuringEviction`, which races `Stop()` against the evicter callback 50 times. The full package passes under `go test -race`.

---

This is the upstream version of armosec/private-node-agent#370 (which applied the same fix as a local override because `kubescape/node-agent` is consumed there as a non-vendored dependency). Fixes the shutdown panic tracked in armosec/private-node-agent#368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queue shutdown behavior to avoid panics or blocking during item eviction.
  * Separated internal event forwarding from the consumer-facing output so results close safely after shutdown.

* **Tests**
  * Added coverage for stopping the queue while evictions are in progress to verify stable behavior under concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->