### PR TITLE
allowing CIDRs, wildcards and Plural in IP and DNS

### DIFF
--- a/docs/features/network-wildcards.md
+++ b/docs/features/network-wildcards.md
@@ -1,0 +1,82 @@
+# Network Wildcards (CIDRs, wildcards, and plural IP/DNS)
+
+The CEL `networkneighborhood` library matches observed connections against the
+`NetworkNeighborhood` profile. As of storage `v0.0.2` the IP and DNS surfaces
+accept wildcard, CIDR, and list-valued entries instead of byte-exact strings
+only. This lets a profile describe a *range* of allowed peers (a CIDR, a DNS
+subdomain family, "any IP") rather than enumerating every literal.
+
+The matching logic lives in
+`pkg/rulemanager/cel/libraries/networkneighborhood/network.go` and delegates the
+wildcard/CIDR semantics to `kubescape/storage`'s `networkmatch` package
+(`MatchIP` / `MatchDNS`). Node-agent pins `kubescape/storage v0.0.290`, which
+carries storage [#324](https://github.com/kubescape/storage/pull/324).
+
+## IP matching (`ipAddresses`, `ipAddress`)
+
+`matchIPField` checks, cheapest first:
+
+1. Exact string equality against the profile's `Values` set.
+2. Canonicalised IP equality — a single `net.ParseIP`, so observed
+   `::ffff:10.0.0.1` matches a profile entry of `10.0.0.1`, and expanded IPv6
+   matches compact IPv6.
+3. `networkmatch.MatchIP` over the full entry set, which matches literals,
+   CIDRs and the `*` sentinel uniformly.
+
+Accepted `ipAddresses[]` entry forms:
+
+| Form | Example | Meaning |
+|---|---|---|
+| Literal IPv4/IPv6 | `162.0.217.171`, `2001:db8::1` | exact host |
+| CIDR | `10.0.0.0/8`, `2001:db8::/32` | any host in range |
+| `*` sentinel | `*` | sugar for `0.0.0.0/0` ∪ `::/0` (any IP) — discouraged outside dev |
+
+A match succeeds if **any** entry matches. The singular `ipAddress` (string)
+field is deprecated and kept for back-compat; it is matched by byte-equality
+only. Producers MUST NOT populate both `ipAddress` and `ipAddresses` on the
+same entry.
+
+## DNS matching (`dnsNames`, `dns`)
+
+`matchDNSField` first normalises the FQDN trailing dot (spec §5.8): `example.com`
+and `example.com.` are equivalent. It then runs `networkmatch.MatchDNS` over the
+full entry set for the wildcard forms:
+
+| Token | Example | Meaning |
+|---|---|---|
+| Literal | `api.stripe.com.` | exact name |
+| Leading `*` | `*.example.com.` | RFC 4592 — exactly **one** label before the suffix |
+| Mid `⋯` (U+22EF) | `svc.⋯.cluster.local.` | exactly **one** label in that position |
+| Trailing `*` | `mycorp.com.*` | **one or more** labels after the prefix (never zero) |
+
+`⋯` is the single Unicode codepoint MIDLINE HORIZONTAL ELLIPSIS, **not** three
+ASCII periods. The recursive token `**` is invalid v0.0.2 syntax: the apiserver
+rejects it at admission, and the runtime matcher additionally drops it on read.
+A match succeeds if **any** entry matches. The singular `dns` (string) field is
+deprecated; v0.0.2 producers MUST emit `dnsNames` (list).
+
+## Port/protocol matching
+
+`wasAddressPortProtocolInEgress` / `...Ingress` validate the port range
+(0–65535) and protocol type, but the port/protocol projection
+(`AddressPortsByAddr`) is out of scope for the current projection-v1 layer, so
+these matchers **degrade to address-only** matching. Wildcard/CIDR IP semantics
+are still enforced via `matchIPField`.
+
+## Default rule change
+
+This feature enables the **"Unexpected Egress Network Traffic"** rule
+(`R0011`) by default in
+`tests/chart/templates/node-agent/default-rules.yaml`. R0011 fires on egress
+that is not whitelisted by the application/network profile; the wildcard surface
+above is what producers use to whitelist legitimate ranges without enumerating
+every IP.
+
+## Tests
+
+- `pkg/rulemanager/cel/libraries/networkneighborhood/wildcard_test.go` and
+  `fixtures_test.go` — unit coverage of the match semantics.
+- `tests/resources/network-wildcards/` — 20 declarative `NetworkNeighborhood`
+  fixtures, one per edge case, with a `README.md` token/field reference.
+- `Test_28_UserDefinedNetworkNeighborhood` in `tests/component_test.go` — an
+  end-to-end component test of a user-defined NetworkNeighborhood.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/kubescape/backend v0.0.39
 	github.com/kubescape/go-logger v0.0.32
 	github.com/kubescape/k8s-interface v0.0.214
-	github.com/kubescape/storage v0.0.287
+	github.com/kubescape/storage v0.0.290
 	github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/oleiade/lane/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -885,8 +885,8 @@ github.com/kubescape/go-logger v0.0.32 h1:4mI+XJOV8VFCMewrEE9VIFEIOhzXokYT3nFpNf
 github.com/kubescape/go-logger v0.0.32/go.mod h1:Alj7JBQ8/WCxbXe8Ura6ZheSRK45E0p21M3xeqedX90=
 github.com/kubescape/k8s-interface v0.0.214 h1:j7KP0/5VvYOoQdBGV2+gRM3qnR8PWLAGF8RM/k/DmJ0=
 github.com/kubescape/k8s-interface v0.0.214/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
-github.com/kubescape/storage v0.0.287 h1:3POQZ4xiGTstVVGpHO94rMPQhK7v079vBBr4C/EuePM=
-github.com/kubescape/storage v0.0.287/go.mod h1:ARiTDaeDWLqEcOIbH+zz4dwdMEVxubfu5X5ehdDOqPc=
+github.com/kubescape/storage v0.0.290 h1:oIXxz31vrbQiUjBE9I6t/sBmhrwlNTAN4Vs70FxFMA4=
+github.com/kubescape/storage v0.0.290/go.mod h1:ARiTDaeDWLqEcOIbH+zz4dwdMEVxubfu5X5ehdDOqPc=
 github.com/kubescape/syft v1.32.0-ks.2 h1:xdUksUmKEyyVKsTfJDYW8Z5HawVJtelsUolPOsWtDx0=
 github.com/kubescape/syft v1.32.0-ks.2/go.mod h1:E6Kd4iBM2ljUOUQvSt7hVK6vBwaHkMXwcvBZmGMSY5o=
 github.com/kubescape/workerpool v0.0.0-20250526074519-0e4a4e7f44cf h1:hI0jVwrB6fT4GJWvuUjzObfci1CUknrZdRHfnRVtKM0=

--- a/pkg/objectcache/containerprofilecache/projection.go
+++ b/pkg/objectcache/containerprofilecache/projection.go
@@ -313,6 +313,19 @@ func mergeNetworkNeighbor(normal, user v1beta1.NetworkNeighbor) v1beta1.NetworkN
 	if user.IPAddress != "" {
 		merged.IPAddress = user.IPAddress
 	}
+	if len(user.IPAddresses) > 0 {
+		ipSet := make(map[string]struct{})
+		for _, ip := range merged.IPAddresses {
+			ipSet[ip] = struct{}{}
+		}
+		for _, ip := range user.IPAddresses {
+			ipSet[ip] = struct{}{}
+		}
+		merged.IPAddresses = make([]string, 0, len(ipSet))
+		for ip := range ipSet {
+			merged.IPAddresses = append(merged.IPAddresses, ip)
+		}
+	}
 	if user.Type != "" {
 		merged.Type = user.Type
 	}

--- a/pkg/objectcache/containerprofilecache/projection_apply.go
+++ b/pkg/objectcache/containerprofilecache/projection_apply.go
@@ -226,6 +226,7 @@ func extractEgressAddresses(cp *v1beta1.ContainerProfile) []string {
 		if n.IPAddress != "" {
 			addrs = append(addrs, n.IPAddress)
 		}
+		addrs = append(addrs, n.IPAddresses...)
 	}
 	return addrs
 }
@@ -247,6 +248,7 @@ func extractIngressAddresses(cp *v1beta1.ContainerProfile) []string {
 		if n.IPAddress != "" {
 			addrs = append(addrs, n.IPAddress)
 		}
+		addrs = append(addrs, n.IPAddresses...)
 	}
 	return addrs
 }

--- a/pkg/objectcache/v1/mock.go
+++ b/pkg/objectcache/v1/mock.go
@@ -188,12 +188,18 @@ func (r *RuleObjectCacheMock) GetProjectedContainerProfile(containerID string) *
 	// Egress addresses and domains — All=true: all observed entries are retained.
 	if !specInstalled || spec.EgressAddresses.InUse || spec.EgressDomains.InUse {
 		for _, n := range cp.Spec.Egress {
-			if (!specInstalled || spec.EgressAddresses.InUse) && n.IPAddress != "" {
-				if pcp.EgressAddresses.Values == nil {
-					pcp.EgressAddresses.All = true
-					pcp.EgressAddresses.Values = make(map[string]struct{})
+			if !specInstalled || spec.EgressAddresses.InUse {
+				addrs := n.IPAddresses
+				if n.IPAddress != "" {
+					addrs = append([]string{n.IPAddress}, addrs...)
 				}
-				pcp.EgressAddresses.Values[n.IPAddress] = struct{}{}
+				for _, a := range addrs {
+					if pcp.EgressAddresses.Values == nil {
+						pcp.EgressAddresses.All = true
+						pcp.EgressAddresses.Values = make(map[string]struct{})
+					}
+					pcp.EgressAddresses.Values[a] = struct{}{}
+				}
 			}
 			if !specInstalled || spec.EgressDomains.InUse {
 				domains := n.DNSNames
@@ -214,12 +220,18 @@ func (r *RuleObjectCacheMock) GetProjectedContainerProfile(containerID string) *
 	// Ingress addresses and domains — All=true: all observed entries are retained.
 	if !specInstalled || spec.IngressAddresses.InUse || spec.IngressDomains.InUse {
 		for _, n := range cp.Spec.Ingress {
-			if (!specInstalled || spec.IngressAddresses.InUse) && n.IPAddress != "" {
-				if pcp.IngressAddresses.Values == nil {
-					pcp.IngressAddresses.All = true
-					pcp.IngressAddresses.Values = make(map[string]struct{})
+			if !specInstalled || spec.IngressAddresses.InUse {
+				addrs := n.IPAddresses
+				if n.IPAddress != "" {
+					addrs = append([]string{n.IPAddress}, addrs...)
 				}
-				pcp.IngressAddresses.Values[n.IPAddress] = struct{}{}
+				for _, a := range addrs {
+					if pcp.IngressAddresses.Values == nil {
+						pcp.IngressAddresses.All = true
+						pcp.IngressAddresses.Values = make(map[string]struct{})
+					}
+					pcp.IngressAddresses.Values[a] = struct{}{}
+				}
 			}
 			if !specInstalled || spec.IngressDomains.InUse {
 				if n.DNS != "" {

--- a/pkg/rulemanager/cel/libraries/networkneighborhood/fixtures_test.go
+++ b/pkg/rulemanager/cel/libraries/networkneighborhood/fixtures_test.go
@@ -1,0 +1,239 @@
+package networkneighborhood
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/kubescape/node-agent/pkg/rulemanager/cel/libraries/cache"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// TestFixturesParse validates that every YAML fixture under
+// tests/resources/network-wildcards/ parses against the v1beta1
+// NetworkNeighborhood schema. This is the user-facing-examples gate:
+// the fixtures double as authoritative syntax documentation, so a
+// fixture that fails to parse is a documentation bug.
+//
+// Fixture 14 (recursive-star-rejected) parses but its dnsNames entry
+// '**' is rejected at admission time — see the storage REST strategy
+// validation test (TestValidate_NetworkProfileEntries).
+func TestFixturesParse(t *testing.T) {
+	fixturesDir := findFixturesDir(t)
+	entries, err := os.ReadDir(fixturesDir)
+	require.NoError(t, err)
+
+	if len(entries) == 0 {
+		t.Fatalf("no fixtures found under %s", fixturesDir)
+	}
+
+	parsed := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		name := e.Name()
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(fixturesDir, name))
+			require.NoError(t, err)
+
+			// Strip the literal "{{NAMESPACE}}" placeholder; the fixtures
+			// are templates, runtime substitutes a real namespace.
+			data = []byte(strings.ReplaceAll(string(data), "{{NAMESPACE}}", "test-ns"))
+
+			var nn v1beta1.NetworkNeighborhood
+			// Strict mode: any unknown field in a fixture is a typo
+			// against the v1beta1 schema. Documentation must not drift
+			// from the runtime types.
+			err = yaml.UnmarshalStrict(data, &nn)
+			require.NoError(t, err, "fixture %s must parse against v1beta1 schema (strict)", name)
+			require.Equal(t, "NetworkNeighborhood", nn.Kind, "fixture %s wrong kind", name)
+			require.NotEmpty(t, nn.Spec.Containers, "fixture %s should declare at least one container", name)
+		})
+		parsed++
+	}
+	if parsed < 20 {
+		t.Errorf("expected ≥ 20 fixtures, parsed %d", parsed)
+	}
+}
+
+// TestFixturesMatchExpectedBehaviour walks a curated subset of fixtures
+// through the actual CEL library matchers, asserting the documented
+// observed→match behaviour from each fixture's header comment.
+//
+// This is the contract pin between the user-facing examples and the
+// runtime: if a fixture says "10.1.2.3 → match" and the matcher
+// disagrees, ONE of them is wrong. Today both are pinned by this test.
+//
+// Coverage: representative cases for each major edge case. Not every
+// (fixture × observation) is exercised — that would be brittle as
+// the fixtures evolve.
+func TestFixturesMatchExpectedBehaviour(t *testing.T) {
+	cases := []struct {
+		name      string
+		neighbors []v1beta1.NetworkNeighbor
+		ingress   []v1beta1.NetworkNeighbor
+		// ipChecks verifies wasAddressInEgress only (back-compat for cases
+		// with no ingress declared; runs only the egress matcher).
+		ipChecks []ipCheck
+		// ipBothChecks verifies BOTH wasAddressInEgress and wasAddressInIngress
+		// — used for direction-isolation cases so the assertion goes both ways.
+		ipBothChecks []ipBothCheck
+		dnsChecks    []dnsCheck
+	}{
+		{
+			name: "fixture-01-literal-ipv4",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{IPAddresses: []string{"10.1.2.3"}},
+			},
+			ipChecks: []ipCheck{
+				{"10.1.2.3", true},
+				{"10.1.2.4", false},
+			},
+		},
+		{
+			name: "fixture-03-cidr-ipv4",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{IPAddresses: []string{"10.0.0.0/8"}},
+			},
+			ipChecks: []ipCheck{
+				{"10.0.0.0", true},
+				{"10.255.255.255", true},
+				{"11.0.0.1", false},
+			},
+		},
+		{
+			name: "fixture-05-any-ip-sentinel",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{IPAddresses: []string{"*"}},
+			},
+			ipChecks: []ipCheck{
+				{"1.2.3.4", true},
+				{"::1", true},
+			},
+		},
+		{
+			name: "fixture-08-deprecated-ipaddress",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{IPAddress: "10.1.2.3"}, // singular, deprecated form
+			},
+			ipChecks: []ipCheck{
+				{"10.1.2.3", true},
+				{"10.1.2.4", false},
+			},
+		},
+		{
+			name: "fixture-10-dns-leading-wildcard",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{DNSNames: []string{"*.example.com."}},
+			},
+			dnsChecks: []dnsCheck{
+				{"api.example.com.", true},
+				{"v1.api.example.com.", false}, // RFC 4592: exactly one label
+				{"example.com.", false},        // zero labels
+			},
+		},
+		{
+			name: "fixture-18-cluster-dns-mid-ellipsis",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{DNSNames: []string{"kubernetes.⋯.svc.cluster.local."}},
+			},
+			dnsChecks: []dnsCheck{
+				{"kubernetes.default.svc.cluster.local.", true},
+				{"kubernetes.kube-system.svc.cluster.local.", true},
+				{"redis.default.svc.cluster.local.", false},
+			},
+		},
+		{
+			name: "fixture-15-egress-and-ingress-direction-isolation",
+			neighbors: []v1beta1.NetworkNeighbor{
+				{IPAddresses: []string{"8.8.8.8"}},
+			},
+			ingress: []v1beta1.NetworkNeighbor{
+				{IPAddresses: []string{"10.244.0.0/16"}},
+			},
+			// Direction isolation: each address MUST hit only the direction
+			// it was declared on. CR (node-agent#41) flagged that the prior
+			// version only checked egress; this asserts ingress too.
+			ipBothChecks: []ipBothCheck{
+				{observed: "8.8.8.8", wantEgress: true, wantIngress: false},      // egress-only
+				{observed: "10.244.5.5", wantEgress: false, wantIngress: true},   // ingress-only
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lib := buildLibWithContainer(t, tc.neighbors, tc.ingress)
+			for _, c := range tc.ipChecks {
+				res := lib.wasAddressInEgress(types.String("cid"), types.String(c.observed))
+				res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+				if res != types.Bool(c.want) {
+					t.Errorf("egress ip %q: got %v, want %v", c.observed, res, c.want)
+				}
+			}
+			for _, c := range tc.ipBothChecks {
+				eg := lib.wasAddressInEgress(types.String("cid"), types.String(c.observed))
+				eg = cache.ConvertProfileNotAvailableErrToBool(eg, false)
+				if eg != types.Bool(c.wantEgress) {
+					t.Errorf("egress ip %q: got %v, want %v", c.observed, eg, c.wantEgress)
+				}
+				in := lib.wasAddressInIngress(types.String("cid"), types.String(c.observed))
+				in = cache.ConvertProfileNotAvailableErrToBool(in, false)
+				if in != types.Bool(c.wantIngress) {
+					t.Errorf("ingress ip %q: got %v, want %v", c.observed, in, c.wantIngress)
+				}
+			}
+			for _, c := range tc.dnsChecks {
+				res := lib.isDomainInEgress(types.String("cid"), types.String(c.observed))
+				res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+				if res != types.Bool(c.want) {
+					t.Errorf("dns %q: got %v, want %v", c.observed, res, c.want)
+				}
+			}
+		})
+	}
+}
+
+type ipCheck struct {
+	observed string
+	want     bool
+}
+
+type ipBothCheck struct {
+	observed    string
+	wantEgress  bool
+	wantIngress bool
+}
+
+type dnsCheck struct {
+	observed string
+	want     bool
+}
+
+// findFixturesDir walks up from the test's working directory to locate
+// tests/resources/network-wildcards/. The package's own working dir
+// when `go test` runs is its source dir, so we walk up to find the
+// repo root.
+func findFixturesDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		candidate := filepath.Join(dir, "tests", "resources", "network-wildcards")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not find tests/resources/network-wildcards/ from %s", dir)
+	return ""
+}

--- a/pkg/rulemanager/cel/libraries/networkneighborhood/network.go
+++ b/pkg/rulemanager/cel/libraries/networkneighborhood/network.go
@@ -1,17 +1,92 @@
 package networkneighborhood
 
 import (
+	"net"
+	"strings"
+
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/rulemanager/cel/libraries/cache"
 	"github.com/kubescape/node-agent/pkg/rulemanager/profilehelper"
+	"github.com/kubescape/storage/pkg/registry/file/networkmatch"
 )
+
+// matchIPField is the wildcard-aware adapter from the projection layer's
+// ProjectedField (Values exact-set + Patterns slice) to the v0.0.2 wildcard
+// semantics implemented in storage's networkmatch package.
+//
+// Order of checks (cheapest first):
+//  1. Values map — exact byte equality
+//  2. Patterns slice — CIDRs, '*' sentinels, RFC 4592 leading wildcards,
+//     mid-⋯, trailing-* (via networkmatch.MatchIP)
+//
+// ProjectedField.All is intentionally NOT consulted as a match short-circuit:
+// it's the producer-side flag set when projectField is in pass-through
+// retention mode (no rule declared profileDataRequired for this surface),
+// in which case projectField has already populated Values with every raw
+// entry. Treating it as a "match any" sentinel here would let unknown IPs
+// match when they're absent from the profile (CR #43, finding R-NET-7).
+//
+// Cold-path use only: the existing CEL functionCache in nn.go memoises
+// (containerID, observed) for the TTL window, so per-call MatchIP/MatchDNS
+// cost only fires on cache misses.
+func matchIPField(field *objectcache.ProjectedField, observed string) bool {
+	if observed == "" || field == nil {
+		return false
+	}
+	// Exact-string lookup first (cheapest).
+	if _, ok := field.Values[observed]; ok {
+		return true
+	}
+	// IP canonicalisation: observed "::ffff:10.0.0.1" should hit a profile
+	// entry of "10.0.0.1", and expanded IPv6 should hit compact IPv6.
+	// Single net.ParseIP per call; only fires on Values miss.
+	if parsed := net.ParseIP(observed); parsed != nil {
+		if _, ok := field.Values[parsed.String()]; ok {
+			return true
+		}
+	}
+	// CIDRs, "*" sentinels and wildcards: the network projection routes ALL
+	// entries to Values (it calls projectField with isPathSurface=false, so
+	// nothing is ever classified into Patterns). networkmatch.MatchIP matches
+	// literals, CIDRs and "*" uniformly, so run it over the full entry set.
+	entries := make([]string, 0, len(field.Values)+len(field.Patterns))
+	for v := range field.Values {
+		entries = append(entries, v)
+	}
+	entries = append(entries, field.Patterns...)
+	return networkmatch.MatchIP(entries, observed)
+}
+
+func matchDNSField(field *objectcache.ProjectedField, observed string) bool {
+	if observed == "" || field == nil {
+		return false
+	}
+	// FQDN trailing-dot normalisation per spec §5.8: both profile entries
+	// and observed names MAY or MAY NOT carry a trailing dot. Try both
+	// canonical forms against Values; cheaper than a per-call MatchDNS.
+	canon := strings.TrimSuffix(observed, ".")
+	if _, ok := field.Values[canon]; ok {
+		return true
+	}
+	if _, ok := field.Values[canon+"."]; ok {
+		return true
+	}
+	// Leading-*, mid-⋯ and trailing-* DNS patterns also land in Values (network
+	// surfaces never populate Patterns), so run MatchDNS over the full set.
+	entries := make([]string, 0, len(field.Values)+len(field.Patterns))
+	for v := range field.Values {
+		entries = append(entries, v)
+	}
+	entries = append(entries, field.Patterns...)
+	return networkmatch.MatchDNS(entries, observed)
+}
 
 func (l *nnLibrary) wasAddressInEgress(containerID, address ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -20,24 +95,17 @@ func (l *nnLibrary) wasAddressInEgress(containerID, address ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(address)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.EgressAddresses.Values[addressStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchIPField(&cp.EgressAddresses, addressStr))
 }
 
 func (l *nnLibrary) wasAddressInIngress(containerID, address ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -46,24 +114,17 @@ func (l *nnLibrary) wasAddressInIngress(containerID, address ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(address)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.IngressAddresses.Values[addressStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchIPField(&cp.IngressAddresses, addressStr))
 }
 
 func (l *nnLibrary) isDomainInEgress(containerID, domain ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -72,24 +133,17 @@ func (l *nnLibrary) isDomainInEgress(containerID, domain ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(domain)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.EgressDomains.Values[domainStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchDNSField(&cp.EgressDomains, domainStr))
 }
 
 func (l *nnLibrary) isDomainInIngress(containerID, domain ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -98,24 +152,17 @@ func (l *nnLibrary) isDomainInIngress(containerID, domain ref.Val) ref.Val {
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(domain)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.IngressDomains.Values[domainStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchDNSField(&cp.IngressDomains, domainStr))
 }
 
 func (l *nnLibrary) wasAddressPortProtocolInEgress(containerID, address, port, protocol ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -124,31 +171,30 @@ func (l *nnLibrary) wasAddressPortProtocolInEgress(containerID, address, port, p
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(address)
 	}
-	// port/protocol projection (AddressPortsByAddr) is out of scope for v1; degrade to address-only matching.
-	if _, ok := port.Value().(int64); !ok {
+	// port/protocol projection (AddressPortsByAddr) is out of scope for the
+	// projection-v1 layer upstream landed; matchers degrade to address-only.
+	// Wildcards remain enforced via matchIPField.
+	portInt, ok := port.Value().(int64)
+	if !ok {
 		return types.MaybeNoSuchOverloadErr(port)
+	}
+	if portInt < 0 || portInt > 65535 {
+		return types.Bool(false)
 	}
 	if _, ok := protocol.Value().(string); !ok {
 		return types.MaybeNoSuchOverloadErr(protocol)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.EgressAddresses.Values[addressStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchIPField(&cp.EgressAddresses, addressStr))
 }
 
 func (l *nnLibrary) wasAddressPortProtocolInIngress(containerID, address, port, protocol ref.Val) ref.Val {
 	if l.objectCache == nil {
 		return types.NewErr("objectCache is nil")
 	}
-
 	containerIDStr, ok := containerID.Value().(string)
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(containerID)
@@ -157,22 +203,19 @@ func (l *nnLibrary) wasAddressPortProtocolInIngress(containerID, address, port, 
 	if !ok {
 		return types.MaybeNoSuchOverloadErr(address)
 	}
-	// port/protocol projection (AddressPortsByAddr) is out of scope for v1; degrade to address-only matching.
-	if _, ok := port.Value().(int64); !ok {
+	portInt, ok := port.Value().(int64)
+	if !ok {
 		return types.MaybeNoSuchOverloadErr(port)
+	}
+	if portInt < 0 || portInt > 65535 {
+		return types.Bool(false)
 	}
 	if _, ok := protocol.Value().(string); !ok {
 		return types.MaybeNoSuchOverloadErr(protocol)
 	}
-
 	cp, _, err := profilehelper.GetProjectedContainerProfile(l.objectCache, containerIDStr)
 	if err != nil {
 		return cache.NewProfileNotAvailableErr("%v", err)
 	}
-
-	if _, ok := cp.IngressAddresses.Values[addressStr]; ok {
-		return types.Bool(true)
-	}
-
-	return types.Bool(false)
+	return types.Bool(matchIPField(&cp.IngressAddresses, addressStr))
 }

--- a/pkg/rulemanager/cel/libraries/networkneighborhood/wildcard_test.go
+++ b/pkg/rulemanager/cel/libraries/networkneighborhood/wildcard_test.go
@@ -1,0 +1,386 @@
+package networkneighborhood
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/goradd/maps"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	objectcachev1 "github.com/kubescape/node-agent/pkg/objectcache/v1"
+	"github.com/kubescape/node-agent/pkg/rulemanager/cel/libraries/cache"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// Helper: build a ready-to-use library with a single-container profile.
+func buildLibWithContainer(t *testing.T, neighbors []v1beta1.NetworkNeighbor, ingressNeighbors []v1beta1.NetworkNeighbor) *nnLibrary {
+	t.Helper()
+	objCache := objectcachev1.RuleObjectCacheMock{
+		ContainerIDToSharedData: maps.NewSafeMap[string, *objectcache.WatchedContainerData](),
+	}
+	objCache.SetSharedContainerData("cid", &objectcache.WatchedContainerData{
+		ContainerType: objectcache.Container,
+		ContainerInfos: map[objectcache.ContainerType][]objectcache.ContainerInfo{
+			objectcache.Container: {{Name: "c"}},
+		},
+	})
+	nn := &v1beta1.NetworkNeighborhood{}
+	nn.Spec.Containers = append(nn.Spec.Containers, v1beta1.NetworkNeighborhoodContainer{
+		Name:    "c",
+		Egress:  neighbors,
+		Ingress: ingressNeighbors,
+	})
+	objCache.SetNetworkNeighborhood(nn)
+	return &nnLibrary{
+		objectCache:   &objCache,
+		functionCache: cache.NewFunctionCache(cache.DefaultFunctionCacheConfig()),
+	}
+}
+
+func TestWasAddressInEgress_WildcardCIDRMatch(t *testing.T) {
+	// Profile uses the new IPAddresses[] field with a CIDR. Old byte-equality
+	// implementation would fail to match observed IPs that fall inside.
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{IPAddresses: []string{"10.0.0.0/8"}},
+	}, nil)
+
+	cases := []struct {
+		observed string
+		want     bool
+	}{
+		{"10.1.2.3", true},     // inside CIDR
+		{"10.255.255.254", true},
+		{"11.0.0.1", false},    // outside
+	}
+	for _, tc := range cases {
+		t.Run(tc.observed, func(t *testing.T) {
+			res := lib.wasAddressInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "address %q", tc.observed)
+		})
+	}
+}
+
+func TestWasAddressInEgress_AnyIPSentinel(t *testing.T) {
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{IPAddresses: []string{"*"}},
+	}, nil)
+
+	for _, addr := range []string{"1.2.3.4", "8.8.8.8", "10.0.0.1", "2001:db8::1"} {
+		res := lib.wasAddressInEgress(types.String("cid"), types.String(addr))
+		res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+		assert.Equal(t, types.Bool(true), res, "addr %q", addr)
+	}
+}
+
+func TestWasAddressInEgress_LegacySingularStillWorks(t *testing.T) {
+	// Backward compatibility: profiles using the deprecated singular
+	// IPAddress field MUST keep matching as before.
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{IPAddress: "10.1.2.3"},
+	}, nil)
+
+	res := lib.wasAddressInEgress(types.String("cid"), types.String("10.1.2.3"))
+	res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+	assert.Equal(t, types.Bool(true), res)
+
+	res = lib.wasAddressInEgress(types.String("cid"), types.String("10.1.2.4"))
+	res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+	assert.Equal(t, types.Bool(false), res)
+}
+
+func TestWasAddressInEgress_BothSingularAndPlural(t *testing.T) {
+	// Mixed profile: one entry uses deprecated IPAddress, another uses new IPAddresses.
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{IPAddress: "8.8.8.8"},
+		{IPAddresses: []string{"10.0.0.0/8"}},
+	}, nil)
+
+	for addr, want := range map[string]bool{
+		"8.8.8.8":   true,  // deprecated singular hit
+		"10.1.2.3":  true,  // new CIDR hit
+		"1.2.3.4":   false, // neither
+	} {
+		res := lib.wasAddressInEgress(types.String("cid"), types.String(addr))
+		res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+		assert.Equal(t, types.Bool(want), res, "addr %q", addr)
+	}
+}
+
+func TestIsDomainInEgress_LeadingWildcard(t *testing.T) {
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{DNSNames: []string{"*.stripe.com."}},
+	}, nil)
+
+	cases := []struct {
+		observed string
+		want     bool
+	}{
+		{"api.stripe.com.", true},
+		{"webhooks.stripe.com.", true},
+		{"v1.api.stripe.com.", false}, // two labels deep
+		{"stripe.com.", false},        // zero labels — RFC 4592
+		{"api.stripe.org.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.observed, func(t *testing.T) {
+			res := lib.isDomainInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "obs %q", tc.observed)
+		})
+	}
+}
+
+func TestIsDomainInEgress_MidEllipsis(t *testing.T) {
+	// User's specific case: parametric namespace label in K8s service FQDN.
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{DNSNames: []string{"kubernetes.⋯.svc.cluster.local."}},
+	}, nil)
+
+	cases := []struct {
+		observed string
+		want     bool
+	}{
+		{"kubernetes.default.svc.cluster.local.", true},
+		{"kubernetes.kube-system.svc.cluster.local.", true},
+		{"redis.default.svc.cluster.local.", false},     // wrong service prefix
+		{"kubernetes.foo.bar.svc.cluster.local.", false}, // two labels mid
+	}
+	for _, tc := range cases {
+		t.Run(tc.observed, func(t *testing.T) {
+			res := lib.isDomainInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "obs %q", tc.observed)
+		})
+	}
+}
+
+func TestIsDomainInEgress_TrailingDotResilience(t *testing.T) {
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{DNSNames: []string{"api.stripe.com"}}, // no trailing dot in profile
+	}, nil)
+
+	// Observed name comes WITH trailing dot (FQDN canonical form).
+	res := lib.isDomainInEgress(types.String("cid"), types.String("api.stripe.com."))
+	res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+	assert.Equal(t, types.Bool(true), res)
+}
+
+// CR (node-agent#41 round 3) flagged that routing the deprecated IPAddress
+// through MatchIP (round 2 fix) creates an unspoken behaviour change: the
+// deprecated field now ALSO accepts wildcard/CIDR patterns. This is
+// intentional — the contract is "deprecated singular gets the same
+// semantics as the list form" — and these tests pin it explicitly so it
+// can't silently regress.
+func TestWasAddressInEgress_DeprecatedIPAddress_AcceptsWildcardAndCIDR(t *testing.T) {
+	cases := []struct {
+		profileIP string
+		observed  string
+		want      bool
+	}{
+		// '*' sentinel on the deprecated field — matches any valid IP
+		{"*", "1.2.3.4", true},
+		{"*", "8.8.8.8", true},
+		{"*", "::1", true},
+		// CIDR on the deprecated field — same membership semantics
+		{"10.0.0.0/8", "10.1.2.3", true},
+		{"10.0.0.0/8", "10.255.255.255", true},
+		{"10.0.0.0/8", "11.0.0.1", false},
+		{"0.0.0.0/0", "203.0.113.7", true},  // any-IPv4 via CIDR
+		{"::/0", "2001:db8::1", true},        // any-IPv6 via CIDR
+		// Literal still works
+		{"192.168.1.1", "192.168.1.1", true},
+		{"192.168.1.1", "192.168.1.2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.profileIP+"_vs_"+tc.observed, func(t *testing.T) {
+			lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+				{IPAddress: tc.profileIP}, // deprecated singular field
+			}, nil)
+			res := lib.wasAddressInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "profile=%q observed=%q", tc.profileIP, tc.observed)
+		})
+	}
+}
+
+// CR (node-agent#41 round 2) flagged that the deprecated singular IPAddress
+// field originally compared via raw string equality, which would diverge from
+// IPAddresses[] behaviour for IPv6 canonicalisation. neighborMatchesIP now
+// routes both fields through MatchIP — pin the parity here.
+func TestWasAddressInEgress_DeprecatedIPAddress_IPv6Canonicalisation(t *testing.T) {
+	cases := []struct {
+		profileIP string
+		observed  string
+		want      bool
+	}{
+		{"2001:db8::1", "2001:db8::1", true},                                  // identical
+		{"2001:db8::1", "2001:0db8:0000:0000:0000:0000:0000:0001", true},      // expanded form same address
+		{"10.0.0.1", "::ffff:10.0.0.1", true},                                  // IPv4-mapped IPv6
+		{"10.0.0.1", "10.0.0.2", false},                                        // genuine miss
+	}
+	for _, tc := range cases {
+		t.Run(tc.profileIP+"_vs_"+tc.observed, func(t *testing.T) {
+			lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+				{IPAddress: tc.profileIP}, // deprecated singular field
+			}, nil)
+			res := lib.wasAddressInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "profile=%q observed=%q", tc.profileIP, tc.observed)
+		})
+	}
+}
+
+// CR (node-agent#41) flagged that the deprecated singular DNS field
+// originally compared via raw string equality, which would diverge from
+// DNSNames behaviour for trailing-dot variants. neighborMatchesDNS now
+// routes both fields through MatchDNS — pin the parity here.
+func TestIsDomainInEgress_DeprecatedDNS_TrailingDotParity(t *testing.T) {
+	cases := []struct {
+		profileDNS string
+		observed   string
+		want       bool
+	}{
+		{"api.stripe.com.", "api.stripe.com.", true},  // both with dot
+		{"api.stripe.com", "api.stripe.com.", true},   // profile no dot, observed with dot
+		{"api.stripe.com.", "api.stripe.com", true},   // profile with dot, observed no dot
+		{"api.stripe.com", "api.stripe.com", true},    // neither dot
+		{"api.stripe.com.", "api.stripe.org.", false}, // wrong TLD
+	}
+	for _, tc := range cases {
+		t.Run(tc.profileDNS+"_vs_"+tc.observed, func(t *testing.T) {
+			lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+				{DNS: tc.profileDNS}, // deprecated singular field
+			}, nil)
+			res := lib.isDomainInEgress(types.String("cid"), types.String(tc.observed))
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res, "profile=%q observed=%q", tc.profileDNS, tc.observed)
+		})
+	}
+}
+
+// CR (node-agent#41) flagged int64→int32 wrap risk in port comparison.
+// 4294967739 narrows to 443 — without the range guard this would
+// incorrectly match a profile entry on port 443.
+func TestWasAddressPortProtocolInEgress_PortWrapRejected(t *testing.T) {
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{
+			IPAddress: "10.1.2.3",
+			Ports: []v1beta1.NetworkPort{
+				{Name: "TCP-443", Protocol: "TCP", Port: ptr.To(int32(443))},
+			},
+		},
+	}, nil)
+
+	// See TestWasAddressPortProtocolInEgress_WithCIDR for the
+	// port/protocol regression note. The port-range guard ([0, 65535])
+	// still applies — what's gone is port-specific matching: any in-range
+	// port matches if the address matches.
+	cases := []struct {
+		name string
+		port int64
+		want bool
+	}{
+		{"in-range hit", 443, true},
+		{"in-range miss", 444, true},                // was: false (port mismatch). Now matches: address-only after projection-v1.
+		{"wrap-to-443 rejected", 4294967739, false}, // (1<<32)+443 — range guard fires
+		{"negative rejected", -1, false},            // range guard fires
+		{"too-large rejected", 65536, false},        // range guard fires
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := lib.wasAddressPortProtocolInEgress(
+				types.String("cid"), types.String("10.1.2.3"),
+				types.Int(tc.port), types.String("TCP"),
+			)
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res)
+		})
+	}
+}
+
+func TestWasAddressInIngress_WildcardCIDR(t *testing.T) {
+	// Direction isolation: the same address can be allowed on ingress
+	// but not egress, and vice versa.
+	lib := buildLibWithContainer(t,
+		[]v1beta1.NetworkNeighbor{ /* empty egress */ },
+		[]v1beta1.NetworkNeighbor{
+			{IPAddresses: []string{"10.244.0.0/16"}},
+		},
+	)
+
+	t.Run("ingress-CIDR-hit", func(t *testing.T) {
+		res := lib.wasAddressInIngress(types.String("cid"), types.String("10.244.5.5"))
+		res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+		assert.Equal(t, types.Bool(true), res)
+	})
+	t.Run("egress-must-stay-empty", func(t *testing.T) {
+		// Same address on egress must NOT match — direction isolation.
+		res := lib.wasAddressInEgress(types.String("cid"), types.String("10.244.5.5"))
+		res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+		assert.Equal(t, types.Bool(false), res)
+	})
+}
+
+func TestIsDomainInIngress_LeadingWildcard(t *testing.T) {
+	lib := buildLibWithContainer(t,
+		nil,
+		[]v1beta1.NetworkNeighbor{
+			{DNSNames: []string{"*.internal."}},
+		},
+	)
+	res := lib.isDomainInIngress(types.String("cid"), types.String("api.internal."))
+	res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+	assert.Equal(t, types.Bool(true), res)
+
+	// Egress is empty so the same name must NOT match on egress.
+	res = lib.isDomainInEgress(types.String("cid"), types.String("api.internal."))
+	res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+	assert.Equal(t, types.Bool(false), res)
+}
+
+func TestWasAddressPortProtocolInEgress_WithCIDR(t *testing.T) {
+	// Composed match: CIDR + port + protocol. Mirror of fixture 19.
+	lib := buildLibWithContainer(t, []v1beta1.NetworkNeighbor{
+		{
+			IPAddresses: []string{"10.0.0.0/8"},
+			Ports: []v1beta1.NetworkPort{
+				{Name: "TCP-443", Protocol: "TCP", Port: ptr.To(int32(443))},
+			},
+		},
+	}, nil)
+
+	// NOTE: upstream's projection-v1 (PR #799) explicitly drops port/protocol
+	// granularity from the address surface — the comment in network.go reads
+	// "port/protocol projection (AddressPortsByAddr) is out of scope for v1;
+	// degrade to address-only matching". So the matcher now only checks IP.
+	//
+	// Spec §4.7 still says ports[] is per-neighbor; the runtime gap is a
+	// known limitation flagged in the rebase commit. Test expectations
+	// updated to match runtime reality. Bringing port/protocol back is a
+	// follow-up: would need projection_apply to surface a per-address
+	// (port, protocol) set into ProjectedContainerProfile and the CEL
+	// helper to consult it.
+	cases := []struct {
+		observed string
+		port     int64
+		proto    string
+		want     bool
+	}{
+		{"10.1.2.3", 443, "TCP", true},  // CIDR match (port/proto not enforced)
+		{"10.1.2.3", 80, "TCP", true},   // was: wrong port — now matches address-only
+		{"10.1.2.3", 443, "UDP", true},  // was: wrong protocol — now matches address-only
+		{"11.0.0.1", 443, "TCP", false}, // outside CIDR — still rejected
+	}
+	for _, tc := range cases {
+		t.Run(tc.observed, func(t *testing.T) {
+			res := lib.wasAddressPortProtocolInEgress(
+				types.String("cid"), types.String(tc.observed),
+				types.Int(tc.port), types.String(tc.proto),
+			)
+			res = cache.ConvertProfileNotAvailableErrToBool(res, false)
+			assert.Equal(t, types.Bool(tc.want), res)
+		})
+	}
+}

--- a/tests/chart/templates/node-agent/default-rules.yaml
+++ b/tests/chart/templates/node-agent/default-rules.yaml
@@ -305,7 +305,7 @@ spec:
           - "anomaly"
           - "applicationprofile"
       - name: "Unexpected Egress Network Traffic"
-        enabled: false
+        enabled: true
         id: "R0011"
         description: "Detecting unexpected egress network traffic that is not whitelisted by application profile."
         expressions:

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -2745,3 +2745,485 @@ func Test_32_UnexpectedProcessArguments(t *testing.T) {
 			"curl trailing literal mismatches profile [curl, -s, ⋯, <lit>, file:///etc/hostname]: R0040 must fire")
 	})
 }
+
+func Test_28_UserDefinedNetworkNeighborhood(t *testing.T) {
+	start := time.Now()
+	defer tearDownTest(t, start)
+
+	// setup creates a namespace with user-defined AP + NN + pod.
+	// The NN allows only fusioncore.ai (162.0.217.171) on TCP/80.
+	setup := func(t *testing.T) *testutils.TestWorkload {
+		t.Helper()
+		ns := testutils.NewRandomNamespace()
+		k8sClient := k8sinterface.NewKubernetesApi()
+		storageClient := spdxv1beta1client.NewForConfigOrDie(k8sClient.K8SConfig)
+
+		// Upstream ContainerProfileCache (kubescape/node-agent#788) reads ONE
+		// pod label `kubescape.io/user-defined-profile=<name>` and uses
+		// <name> as the lookup key for BOTH the user AP and the user NN.
+		// AP and NN MUST therefore share that single name.
+		const overlayName = "curl-28-overlay"
+
+		ap := &v1beta1.ApplicationProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      overlayName,
+				Namespace: ns.Name,
+			},
+			Spec: v1beta1.ApplicationProfileSpec{
+				Containers: []v1beta1.ApplicationProfileContainer{
+					{
+						Name: "curl",
+						Execs: []v1beta1.ExecCalls{
+							{Path: "/bin/sleep"},
+							{Path: "/usr/bin/curl"},
+							{Path: "/usr/bin/nslookup"},
+							{Path: "/usr/bin/wget"},
+						},
+						Syscalls: []string{"socket", "connect", "sendto", "recvfrom", "read", "write", "close", "openat", "mmap", "mprotect", "munmap", "fcntl", "ioctl", "poll", "epoll_create1", "epoll_ctl", "epoll_wait", "bind", "listen", "accept4", "getsockopt", "setsockopt", "getsockname", "getpid", "fstat", "rt_sigaction", "rt_sigprocmask", "writev"},
+					},
+				},
+			},
+		}
+		_, err := storageClient.ApplicationProfiles(ns.Name).Create(
+			context.Background(), ap, metav1.CreateOptions{})
+		require.NoError(t, err, "create AP")
+
+		nn := &v1beta1.NetworkNeighborhood{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      overlayName,
+				Namespace: ns.Name,
+				Annotations: map[string]string{
+					helpersv1.ManagedByMetadataKey:  helpersv1.ManagedByUserValue,
+					helpersv1.StatusMetadataKey:     helpersv1.Completed,
+					helpersv1.CompletionMetadataKey: helpersv1.Full,
+				},
+				Labels: map[string]string{
+					helpersv1.ApiGroupMetadataKey:   "apps",
+					helpersv1.ApiVersionMetadataKey: "v1",
+					helpersv1.RelatedKindMetadataKey:       "Deployment",
+					helpersv1.RelatedNameMetadataKey:       "curl-28",
+					helpersv1.RelatedNamespaceMetadataKey:  ns.Name,
+				},
+			},
+			Spec: v1beta1.NetworkNeighborhoodSpec{
+				LabelSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "curl-28"},
+				},
+				Containers: []v1beta1.NetworkNeighborhoodContainer{
+					{
+						Name: "curl",
+						Egress: []v1beta1.NetworkNeighbor{
+							{
+								Identifier: "fusioncore-egress",
+								Type:       "external",
+								DNS:        "fusioncore.ai.",
+								DNSNames:   []string{"fusioncore.ai."},
+								IPAddress:  "162.0.217.171",
+								Ports: []v1beta1.NetworkPort{
+									{Name: "TCP-80", Protocol: "TCP", Port: ptr.To(int32(80))},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err = storageClient.NetworkNeighborhoods(ns.Name).Create(
+			context.Background(), nn, metav1.CreateOptions{})
+		require.NoError(t, err, "create NN")
+
+		require.Eventually(t, func() bool {
+			_, apErr := storageClient.ApplicationProfiles(ns.Name).Get(context.Background(), overlayName, v1.GetOptions{})
+			_, nnErr := storageClient.NetworkNeighborhoods(ns.Name).Get(context.Background(), overlayName, v1.GetOptions{})
+			return apErr == nil && nnErr == nil
+		}, 30*time.Second, 1*time.Second, "AP+NN must be in storage before pod deploy")
+
+		wl, err := testutils.NewTestWorkload(ns.Name,
+			path.Join(utils.CurrentDir(), "resources/nginx-user-defined-deployment.yaml"))
+		require.NoError(t, err)
+		require.NoError(t, wl.WaitForReady(80))
+		// Cache-load latency on the upstream ContainerProfileCache is bursty
+		// — 15s is enough on a quiet runner but not on a loaded one. The
+		// failure mode is alert metadata `errorMessage:"waiting for profile
+		// update"`, which means the rule manager evaluated against an
+		// unloaded NN and fired R0005/R0011 spuriously. 30s covers the
+		// observed worst-case in CI without pushing total test time too
+		// far. Real fix would be to poll a cache-loaded signal, but no
+		// such signal is exposed today.
+		time.Sleep(30 * time.Second)
+		return wl
+	}
+
+	countByRule := func(alerts []testutils.Alert, ruleID string) int {
+		n := 0
+		for _, a := range alerts {
+			if a.Labels["rule_id"] == ruleID {
+				n++
+			}
+		}
+		return n
+	}
+
+	waitAlerts := func(t *testing.T, ns string) []testutils.Alert {
+		t.Helper()
+		var alerts []testutils.Alert
+		var err error
+		require.Eventually(t, func() bool {
+			alerts, err = testutils.GetAlerts(ns)
+			return err == nil
+		}, 60*time.Second, 5*time.Second, "must be able to fetch alerts")
+		// Extra settle time for remaining alerts.
+		time.Sleep(10 * time.Second)
+		alerts, _ = testutils.GetAlerts(ns)
+		return alerts
+	}
+
+	logAlerts := func(t *testing.T, alerts []testutils.Alert) {
+		t.Helper()
+		for i, a := range alerts {
+			t.Logf("  [%d] %s(%s) comm=%s container=%s",
+				i, a.Labels["rule_name"], a.Labels["rule_id"],
+				a.Labels["comm"], a.Labels["container_name"])
+		}
+	}
+
+	// ---------------------------------------------------------------
+	// 28a. Allowed traffic — fusioncore.ai is in the NN.
+	//      No R0005 (DNS) and no R0011 (egress) expected.
+	// ---------------------------------------------------------------
+	t.Run("allowed_fusioncore_no_alert", func(t *testing.T) {
+		wl := setup(t)
+
+		// DNS lookup via nslookup (domain in NN).
+		stdout, stderr, err := wl.ExecIntoPod([]string{"nslookup", "fusioncore.ai"}, "curl")
+		t.Logf("nslookup fusioncore.ai → err=%v stdout=%q stderr=%q", err, stdout, stderr)
+
+		// HTTP via curl (domain + IP in NN).
+		stdout, stderr, err = wl.ExecIntoPod([]string{"curl", "-sm5", "http://fusioncore.ai"}, "curl")
+		t.Logf("curl fusioncore.ai → err=%v stdout=%q stderr=%q", err, stdout, stderr)
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		assert.Equal(t, 0, countByRule(alerts, "R0005"),
+			"fusioncore.ai is in NN — should NOT fire R0005")
+		assert.Equal(t, 0, countByRule(alerts, "R0011"),
+			"fusioncore.ai IP is in NN — should NOT fire R0011")
+	})
+
+	// ---------------------------------------------------------------
+	// 28b. Unknown domains — domains NOT in the NN → R0005.
+	//      Uses both nslookup (pure DNS) and curl (DNS + TCP).
+	// ---------------------------------------------------------------
+	t.Run("unknown_domain_R0005", func(t *testing.T) {
+		wl := setup(t)
+
+		// nslookup generates a DNS query without any TCP connection.
+		wl.ExecIntoPod([]string{"nslookup", "google.com"}, "curl")
+		// curl resolves + connects.
+		wl.ExecIntoPod([]string{"curl", "-sm5", "http://ebpf.io"}, "curl")
+		wl.ExecIntoPod([]string{"curl", "-sm5", "http://cloudflare.com"}, "curl")
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		require.Greater(t, countByRule(alerts, "R0005"), 0,
+			"unknown domains must fire R0005")
+	})
+
+	// ---------------------------------------------------------------
+	// 28c. Unknown IPs — raw IP egress NOT in the NN → R0011.
+	// ---------------------------------------------------------------
+	t.Run("unknown_ip_R0011", func(t *testing.T) {
+		wl := setup(t)
+
+		wl.ExecIntoPod([]string{"curl", "-sm5", "http://8.8.8.8"}, "curl")
+		wl.ExecIntoPod([]string{"curl", "-sm5", "http://1.1.1.1"}, "curl")
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		require.Greater(t, countByRule(alerts, "R0011"), 0,
+			"IPs not in NN must fire R0011")
+	})
+
+	// ---------------------------------------------------------------
+	// 28d. MITM — DNS spoofing simulation.
+	//      fusioncore.ai is an allowed domain but the IP is spoofed.
+	//
+	//      Step 1: nslookup fusioncore.ai (legitimate DNS, no alert).
+	//      Step 2: curl --resolve fusioncore.ai:80:8.8.4.4
+	//              Simulates a DNS MITM returning a different IP.
+	//              The domain is allowed but the connection goes to
+	//              8.8.4.4 (not 162.0.217.171) → R0011.
+	// ---------------------------------------------------------------
+	t.Run("mitm_spoofed_ip_R0011", func(t *testing.T) {
+		wl := setup(t)
+
+		// Step 1: Legitimate DNS lookup — no alert expected.
+		wl.ExecIntoPod([]string{"nslookup", "fusioncore.ai"}, "curl")
+
+		// Step 2: MITM — domain resolves to spoofed IP 8.8.4.4.
+		// curl --resolve skips DNS and connects directly to the
+		// spoofed IP, simulating what happens after DNS poisoning.
+		stdout, stderr, err := wl.ExecIntoPod(
+			[]string{"curl", "-sm5", "--resolve", "fusioncore.ai:80:8.8.4.4", "http://fusioncore.ai"}, "curl")
+		t.Logf("curl MITM → err=%v stdout=%q stderr=%q", err, stdout, stderr)
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		require.Greater(t, countByRule(alerts, "R0011"), 0,
+			"MITM: fusioncore.ai allowed but spoofed IP 8.8.4.4 must fire R0011")
+	})
+
+	// ---------------------------------------------------------------
+	// 28e. MITM — real CoreDNS poisoning via template plugin.
+	//      Poisons CoreDNS so fusioncore.ai resolves to 8.8.4.4
+	//      instead of the legitimate 162.0.217.171.
+	//
+	//      nslookup triggers the poisoned DNS response.
+	//      R0005 does NOT fire: fusioncore.ai is in the NN egress
+	//      list and BusyBox nslookup does NOT do PTR reverse-lookups.
+	//      R0011 does NOT fire: no TCP egress (DNS is UDP to cluster
+	//      DNS which is a private IP filtered by is_private_ip).
+	//
+	//      This documents a detection gap: pure DNS MITM (without
+	//      subsequent TCP to the spoofed IP) is invisible to both
+	//      R0005 and R0011 when the domain is already whitelisted.
+	//
+	//      NOTE: this subtest MUST run last — it modifies the
+	//      cluster-wide CoreDNS configmap.
+	// ---------------------------------------------------------------
+	t.Run("mitm_coredns_poisoning", func(t *testing.T) {
+		wl := setup(t)
+		ctx := context.Background()
+		k8sClient := k8sinterface.NewKubernetesApi()
+
+		// ── Back up original CoreDNS Corefile ──
+		cm, err := k8sClient.KubernetesClient.CoreV1().
+			ConfigMaps("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+		require.NoError(t, err, "get coredns configmap")
+		originalCorefile := cm.Data["Corefile"]
+
+		restartAndWaitCoreDNS := func() {
+			deploy, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			require.NoError(t, err, "get coredns deployment")
+			if deploy.Spec.Template.ObjectMeta.Annotations == nil {
+				deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			}
+			deploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+			_, err = k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Update(ctx, deploy, metav1.UpdateOptions{})
+			require.NoError(t, err, "restart coredns")
+
+			require.Eventually(t, func() bool {
+				d, err := k8sClient.KubernetesClient.AppsV1().
+					Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+				if err != nil || d.Spec.Replicas == nil {
+					return false
+				}
+				return d.Status.ReadyReplicas == *d.Spec.Replicas &&
+					d.Status.UpdatedReplicas == *d.Spec.Replicas
+			}, 60*time.Second, 2*time.Second, "coredns must become ready")
+		}
+
+		// ── Restore CoreDNS on cleanup (best-effort) ──
+		t.Cleanup(func() {
+			t.Log("cleanup: restoring CoreDNS Corefile")
+			cm, err := k8sClient.KubernetesClient.CoreV1().
+				ConfigMaps("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("cleanup: get coredns cm: %v", err)
+				return
+			}
+			cm.Data["Corefile"] = originalCorefile
+			if _, err := k8sClient.KubernetesClient.CoreV1().
+				ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+				t.Logf("cleanup: update coredns cm: %v", err)
+				return
+			}
+			deploy, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("cleanup: get coredns deploy: %v", err)
+				return
+			}
+			if deploy.Spec.Template.ObjectMeta.Annotations == nil {
+				deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			}
+			deploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+			if _, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Update(ctx, deploy, metav1.UpdateOptions{}); err != nil {
+				t.Logf("cleanup: restart coredns: %v", err)
+			}
+		})
+
+		// ── Poison CoreDNS: fusioncore.ai → 8.8.4.4 ──
+		poisoned := strings.Replace(originalCorefile,
+			"forward .",
+			"template IN A fusioncore.ai {\n        answer \"fusioncore.ai. 60 IN A 8.8.4.4\"\n        fallthrough\n    }\n    forward .",
+			1)
+		require.NotEqual(t, originalCorefile, poisoned, "template injection must modify Corefile")
+
+		cm.Data["Corefile"] = poisoned
+		_, err = k8sClient.KubernetesClient.CoreV1().
+			ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(t, err, "apply poisoned Corefile")
+		restartAndWaitCoreDNS()
+
+		// Verify poisoned DNS returns the spoofed IP.
+		require.Eventually(t, func() bool {
+			stdout, _, _ := wl.ExecIntoPod([]string{"nslookup", "fusioncore.ai"}, "curl")
+			return strings.Contains(stdout, "8.8.4.4")
+		}, 30*time.Second, 3*time.Second, "poisoned CoreDNS must return 8.8.4.4 for fusioncore.ai")
+
+		// ── Trigger alerts ──
+		// nslookup does DNS only (no TCP egress).
+		// BusyBox nslookup does NOT do PTR reverse-lookups on result IPs.
+		stdout, stderr, err := wl.ExecIntoPod([]string{"nslookup", "fusioncore.ai"}, "curl")
+		t.Logf("nslookup (poisoned) → err=%v stdout=%q stderr=%q", err, stdout, stderr)
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		// R0005 does NOT fire: fusioncore.ai is already in the NN
+		// egress list, and BusyBox nslookup does NOT perform PTR
+		// reverse-lookups on result IPs, so no unknown domain is queried.
+		assert.Equal(t, 0, countByRule(alerts, "R0005"),
+			"DNS MITM: domain is in NN and no PTR lookup — R0005 should not fire")
+
+		// R0011 does NOT fire: nslookup generates only DNS (UDP)
+		// traffic to the cluster DNS service, which is a private IP
+		// excluded by is_private_ip().
+		assert.Equal(t, 0, countByRule(alerts, "R0011"),
+			"DNS MITM: nslookup has no TCP egress — R0011 should not fire")
+	})
+
+	// ---------------------------------------------------------------
+	// 28f. MITM — CoreDNS poisoning with TCP egress.
+	//      Same CoreDNS poisoning as 28e, but now fusioncore.ai
+	//      resolves to 128.130.194.56 (a routable IP that accepts
+	//      TCP on port 80).  curl generates a real TCP connection
+	//      to the spoofed IP.
+	//
+	//      Expected:
+	//        R0005 = 0 — domain is in NN, no PTR reverse-lookup.
+	//        R0011 fires — TCP egress to 128.130.194.56 which is
+	//                       NOT in the NN (NN only has 162.0.217.171).
+	//
+	//      NOTE: runs after 28e; modifies cluster-wide CoreDNS.
+	// ---------------------------------------------------------------
+	t.Run("mitm_coredns_poisoning_tcp", func(t *testing.T) {
+		wl := setup(t)
+		ctx := context.Background()
+		k8sClient := k8sinterface.NewKubernetesApi()
+
+		// ── Back up original CoreDNS Corefile ──
+		cm, err := k8sClient.KubernetesClient.CoreV1().
+			ConfigMaps("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+		require.NoError(t, err, "get coredns configmap")
+		originalCorefile := cm.Data["Corefile"]
+
+		restartAndWaitCoreDNS := func() {
+			deploy, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			require.NoError(t, err, "get coredns deployment")
+			if deploy.Spec.Template.ObjectMeta.Annotations == nil {
+				deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			}
+			deploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+			_, err = k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Update(ctx, deploy, metav1.UpdateOptions{})
+			require.NoError(t, err, "restart coredns")
+
+			require.Eventually(t, func() bool {
+				d, err := k8sClient.KubernetesClient.AppsV1().
+					Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+				if err != nil || d.Spec.Replicas == nil {
+					return false
+				}
+				return d.Status.ReadyReplicas == *d.Spec.Replicas &&
+					d.Status.UpdatedReplicas == *d.Spec.Replicas
+			}, 60*time.Second, 2*time.Second, "coredns must become ready")
+		}
+
+		// ── Restore CoreDNS on cleanup (best-effort) ──
+		t.Cleanup(func() {
+			t.Log("cleanup: restoring CoreDNS Corefile")
+			cm, err := k8sClient.KubernetesClient.CoreV1().
+				ConfigMaps("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("cleanup: get coredns cm: %v", err)
+				return
+			}
+			cm.Data["Corefile"] = originalCorefile
+			if _, err := k8sClient.KubernetesClient.CoreV1().
+				ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+				t.Logf("cleanup: update coredns cm: %v", err)
+				return
+			}
+			deploy, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Get(ctx, "coredns", metav1.GetOptions{})
+			if err != nil {
+				t.Logf("cleanup: get coredns deploy: %v", err)
+				return
+			}
+			if deploy.Spec.Template.ObjectMeta.Annotations == nil {
+				deploy.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+			}
+			deploy.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+			if _, err := k8sClient.KubernetesClient.AppsV1().
+				Deployments("kube-system").Update(ctx, deploy, metav1.UpdateOptions{}); err != nil {
+				t.Logf("cleanup: restart coredns: %v", err)
+			}
+		})
+
+		// ── Poison CoreDNS: fusioncore.ai → 128.130.194.56 ──
+		poisoned := strings.Replace(originalCorefile,
+			"forward .",
+			"template IN A fusioncore.ai {\n        answer \"fusioncore.ai. 60 IN A 128.130.194.56\"\n        fallthrough\n    }\n    forward .",
+			1)
+		require.NotEqual(t, originalCorefile, poisoned, "template injection must modify Corefile")
+
+		cm.Data["Corefile"] = poisoned
+		_, err = k8sClient.KubernetesClient.CoreV1().
+			ConfigMaps("kube-system").Update(ctx, cm, metav1.UpdateOptions{})
+		require.NoError(t, err, "apply poisoned Corefile")
+		restartAndWaitCoreDNS()
+
+		// Verify poisoned DNS returns the spoofed IP.
+		require.Eventually(t, func() bool {
+			stdout, _, _ := wl.ExecIntoPod([]string{"nslookup", "fusioncore.ai"}, "curl")
+			return strings.Contains(stdout, "128.130.194.56")
+		}, 30*time.Second, 3*time.Second, "poisoned CoreDNS must return 128.130.194.56 for fusioncore.ai")
+
+		// ── Trigger alerts ──
+		// curl resolves fusioncore.ai → 128.130.194.56 (poisoned)
+		// then opens a TCP connection to 128.130.194.56:80.
+		stdout, stderr, err := wl.ExecIntoPod(
+			[]string{"curl", "-sm5", "http://fusioncore.ai"}, "curl")
+		t.Logf("curl (poisoned DNS) → err=%v stdout=%q stderr=%q", err, stdout, stderr)
+
+		alerts := waitAlerts(t, wl.Namespace)
+		t.Logf("=== %d alerts ===", len(alerts))
+		logAlerts(t, alerts)
+
+		// R0005 does NOT fire: fusioncore.ai is already in the NN
+		// egress list, and curl (like BusyBox nslookup) does NOT
+		// perform PTR reverse-lookups on resolved IPs.
+		assert.Equal(t, 0, countByRule(alerts, "R0005"),
+			"DNS MITM: domain is in NN and no PTR lookup — R0005 should not fire")
+
+		// R0011 fires: TCP egress to 128.130.194.56 which is NOT
+		// in the NN (NN only allows 162.0.217.171).
+		require.Greater(t, countByRule(alerts, "R0011"), 0,
+			"DNS MITM: TCP to spoofed IP 128.130.194.56 must fire R0011")
+	})
+}

--- a/tests/resources/known-network-neighborhood.yaml
+++ b/tests/resources/known-network-neighborhood.yaml
@@ -1,0 +1,49 @@
+##
+## User-defined NetworkNeighborhood for Test_28.
+##
+## Referenced directly from a pod via the label:
+##   kubescape.io/user-defined-network: fusioncore-network
+##
+## Carries "kubescape.io/managed-by: User" annotation and workload
+## labels to match the schema the node-agent cache expects.
+##
+## Modeled after a real auto-learned NN from curlimages/curl:8.5.0.
+##
+## Usage:
+##   sed "s/{{NAMESPACE}}/$NS/g" known-network-neighborhood.yaml \
+##     | kubectl apply -f -
+##
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: fusioncore-network
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    kubescape.io/managed-by: User
+    kubescape.io/status: completed
+    kubescape.io/completion: complete
+  labels:
+    kubescape.io/workload-api-group: apps
+    kubescape.io/workload-api-version: v1
+    kubescape.io/workload-kind: Deployment
+    kubescape.io/workload-name: curl-fusioncore-deployment
+    kubescape.io/workload-namespace: "{{NAMESPACE}}"
+spec:
+  matchLabels:
+    app: curl-fusioncore-28-1
+  containers:
+  - name: curl
+    ingress: []
+    egress:
+    - dns: fusioncore.ai.
+      dnsNames:
+      - fusioncore.ai.
+      identifier: a5e64ff1db824089b1706ac872303e55075f92cf6a652b5272f06c3a2b9e8d10
+      ipAddress: 162.0.217.171
+      namespaceSelector: null
+      podSelector: null
+      ports:
+      - name: TCP-80
+        port: 80
+        protocol: TCP
+      type: external

--- a/tests/resources/network-wildcards/01-literal-ipv4.yaml
+++ b/tests/resources/network-wildcards/01-literal-ipv4.yaml
@@ -1,0 +1,26 @@
+# Fixture 01 — IPv4 literal in ipAddresses[]
+#
+# Edge case:    single IPv4 literal in the new plural field
+# Expects:      observed IP "162.0.217.171" matches; "162.0.217.172" does NOT
+# Match path:   networkmatch.MatchIP(["162.0.217.171"], observed) → true iff equal
+# Spec ref:     §5.7 "IPv4 / IPv6 literal" row
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-01-literal-ipv4
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-01
+  containers:
+  - name: client
+    egress:
+    - identifier: literal-ipv4
+      type: external
+      ipAddresses:
+        - "162.0.217.171"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/02-literal-ipv6.yaml
+++ b/tests/resources/network-wildcards/02-literal-ipv6.yaml
@@ -1,0 +1,27 @@
+# Fixture 02 — IPv6 literal, canonicalisation
+#
+# Edge case:    IPv6 literal, both compressed and expanded forms MUST compare equal
+# Expects:      "2001:db8::1", "2001:0db8:0000:0000:0000:0000:0000:0001",
+#               and "2001:DB8::1" all match each other
+# Match path:   net.ParseIP(...) normalises before .Equal() — verifier responsibility
+# Spec ref:     §5.7 — "textual canonicalisation is the verifier's responsibility"
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-02-literal-ipv6
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-02
+  containers:
+  - name: client
+    egress:
+    - identifier: literal-ipv6
+      type: external
+      ipAddresses:
+        - "2001:db8::1"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/03-cidr-ipv4.yaml
+++ b/tests/resources/network-wildcards/03-cidr-ipv4.yaml
@@ -1,0 +1,28 @@
+# Fixture 03 — IPv4 CIDR
+#
+# Edge case:    a single CIDR block covers a range of IPs
+# Expects:      observed "10.0.0.1" matches; "10.255.255.254" matches;
+#               "11.0.0.1" does NOT match
+# Match path:   net.ParseCIDR("10.0.0.0/8") → *IPNet; IPNet.Contains(observed)
+# Perf:         compile once at profile-load, reuse the *IPNet on every event
+# Spec ref:     §5.7 "CIDR" row
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-03-cidr-ipv4
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-03
+  containers:
+  - name: client
+    egress:
+    - identifier: rfc1918-class-a
+      type: internal
+      ipAddresses:
+        - "10.0.0.0/8"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/04-cidr-ipv6.yaml
+++ b/tests/resources/network-wildcards/04-cidr-ipv6.yaml
@@ -1,0 +1,26 @@
+# Fixture 04 — IPv6 CIDR
+#
+# Edge case:    IPv6 CIDR matching
+# Expects:      observed "2001:db8::1" matches; "2001:db9::1" does NOT
+# Match path:   same code path as IPv4 CIDR — net.ParseCIDR recognises both
+# Spec ref:     §5.7 "CIDR" row, second example
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-04-cidr-ipv6
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-04
+  containers:
+  - name: client
+    egress:
+    - identifier: rfc3849-doc-prefix
+      type: external
+      ipAddresses:
+        - "2001:db8::/32"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/05-any-ip-sentinel.yaml
+++ b/tests/resources/network-wildcards/05-any-ip-sentinel.yaml
@@ -1,0 +1,31 @@
+# Fixture 05 — `*` sentinel for ANY IP
+#
+# Edge case:    a single "*" entry — matches any IPv4 or IPv6 address
+# Expects:      every observed IP matches; this is permissive-mode profiling
+# Match path:   compileIP("*") returns isAny=true; runtime short-circuits
+# Spec ref:     §5.7 "* (any-IP sentinel)" row + the warning at the bottom
+# Operations:   strongly DISCOURAGED outside development profiles —
+#               equivalent to disabling egress filtering for this workload.
+#               Producers should normally enumerate concrete IPs/CIDRs.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-05-any-sentinel
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+    # Make the operational risk explicit:
+    sbob.io/discouraged-wildcards: "ipAddresses-any-sentinel"
+spec:
+  matchLabels:
+    app: nw-05
+  containers:
+  - name: client
+    egress:
+    - identifier: any-ip-development-profile
+      type: external
+      ipAddresses:
+        - "*"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/06-any-as-cidr.yaml
+++ b/tests/resources/network-wildcards/06-any-as-cidr.yaml
@@ -1,0 +1,34 @@
+# Fixture 06 — RFC-aligned alternatives to the `*` sentinel
+#
+# Edge case:    `0.0.0.0/0` (RFC 4632 — all IPv4) and `::/0` (RFC 4291 — all IPv6)
+#               MUST behave identically to `*`
+# Expects:      observed "1.2.3.4" matches via 0.0.0.0/0;
+#               observed "2001:db8::1" matches via ::/0
+# Match path:   regular CIDR matching — no special casing needed
+# Spec ref:     §5.7 — "*" sentinel "is sugar for the union of 0.0.0.0/0 + ::/0"
+# Why both forms exist:
+#               Producers who prefer standards-compliant CIDR over our `*`
+#               sugar can express "any IP" via these two CIDRs and the
+#               document will be accepted by tooling that doesn't recognise
+#               the `*` sentinel.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-06-any-as-cidr
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-06
+  containers:
+  - name: client
+    egress:
+    - identifier: any-via-cidrs
+      type: external
+      ipAddresses:
+        - "0.0.0.0/0"
+        - "::/0"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/07-mixed-ip-list.yaml
+++ b/tests/resources/network-wildcards/07-mixed-ip-list.yaml
@@ -1,0 +1,36 @@
+# Fixture 07 — mixed list (literal + CIDR + sentinel)
+#
+# Edge case:    a single ipAddresses[] list mixes all three forms
+# Expects:
+#               "10.1.2.3"      → matches via 10.0.0.0/8
+#               "162.0.217.171" → matches via the literal
+#               "8.8.8.8"       → matches via the `*` sentinel
+#               (this fixture intentionally has an unconstrained `*` because
+#               of the sentinel — the literal and CIDR are illustrative)
+# Match path:   ANY entry matches → match passes (logical OR)
+# Spec ref:     §5.7 algorithm "for each entry e in profile.ipAddresses"
+# Test value:   exercises the loop ordering and short-circuit-on-first-match
+#               behaviour
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-07-mixed-ip-list
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-07
+  containers:
+  - name: client
+    egress:
+    - identifier: mixed-shapes
+      type: external
+      ipAddresses:
+        - "162.0.217.171"     # IPv4 literal
+        - "10.0.0.0/8"        # IPv4 CIDR
+        - "2001:db8::/32"     # IPv6 CIDR
+        - "*"                 # any (sentinel — overrides everything; here for test)
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/08-deprecated-ipaddress.yaml
+++ b/tests/resources/network-wildcards/08-deprecated-ipaddress.yaml
@@ -1,0 +1,32 @@
+# Fixture 08 — backward compatibility with deprecated singular `ipAddress`
+#
+# Edge case:    only the deprecated singular field populated; ipAddresses absent
+# Expects:      observed "10.0.0.42" matches via the singular field;
+#               behaviour unchanged from v0.0.1
+# Match path:   verifier walks BOTH singular and plural fields, treating them
+#               as a logical OR
+# Spec ref:     §4.7 ipAddress row — "Deprecated since v0.0.2 — kept for back-compat"
+# Producer rule: MUST NOT populate both `ipAddress` (singular) and `ipAddresses`
+#                (plural) on the same entry — admission strategy rejects
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-08-deprecated-ipaddress
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+    # New profiles should use ipAddresses; this fixture exists only to pin
+    # back-compat behaviour for v0.0.1-era documents that haven't migrated yet.
+    sbob.io/migration-target: "ipAddresses"
+spec:
+  matchLabels:
+    app: nw-08
+  containers:
+  - name: legacy-client
+    egress:
+    - identifier: legacy-singular-ip
+      type: external
+      ipAddress: "10.0.0.42"     # DEPRECATED — kept here on purpose to exercise back-compat
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/09-dns-literal.yaml
+++ b/tests/resources/network-wildcards/09-dns-literal.yaml
@@ -1,0 +1,29 @@
+# Fixture 09 — DNS literal
+#
+# Edge case:    plain FQDN, byte-equality after trailing-dot normalisation
+# Expects:      observed "api.stripe.com." matches; "api.stripe.com" matches
+#               (both forms equivalent); "v1.api.stripe.com." does NOT
+# Match path:   normalise trailing dot on both profile entry and observed name,
+#               then byte-equality
+# Spec ref:     §5.8 "Literal" row, plus the trailing-dot normalisation paragraph
+# RFC ref:      RFC 1035 § 3.1 (FQDN syntax)
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-09-dns-literal
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-09
+  containers:
+  - name: client
+    egress:
+    - identifier: stripe-api-literal
+      type: external
+      dnsNames:
+        - "api.stripe.com."
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/10-dns-leading-wildcard.yaml
+++ b/tests/resources/network-wildcards/10-dns-leading-wildcard.yaml
@@ -1,0 +1,35 @@
+# Fixture 10 — DNS leading wildcard `*.<suffix>`
+#
+# Edge case:    RFC 4592 wildcard label — exactly ONE label before the suffix
+# Expects:
+#   observed "api.example.com."          → match (one label "api")
+#   observed "webhooks.example.com."     → match (one label "webhooks")
+#   observed "v1.api.example.com."       → NO match (two labels — leading * is exactly one)
+#   observed "example.com."              → NO match (apex — leading * requires at least one)
+#   observed ".example.com."              → NO match (empty label — invalid DNS)
+# Match path:   label-split + per-position match using the same recursive
+#               matcher as path wildcards (`compareLabels`)
+# Spec ref:     §5.8 "*.<suffix>" row + the rationale block
+# RFC ref:      RFC 4592 (DNS wildcard match) — "exactly one label" is the
+#               only ratified wildcard form; bind/coredns/cilium/k8s ingress
+#               all honour this convention
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-10-dns-leading-wildcard
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-10
+  containers:
+  - name: client
+    egress:
+    - identifier: example-com-subdomains
+      type: external
+      dnsNames:
+        - "*.example.com."
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/11-dns-mid-ellipsis.yaml
+++ b/tests/resources/network-wildcards/11-dns-mid-ellipsis.yaml
@@ -1,0 +1,41 @@
+# Fixture 11 — DNS mid-label `⋯` (DynamicIdentifier)
+#
+# Edge case:    exactly ONE label between two static segments
+#               (the user's `svc.*.kubernetes.io.` use case, spelt with ⋯
+#                because mid-label `*` is non-standard)
+# Expects:
+#   observed "svc.kube-system.cluster.local."   → match
+#   observed "svc.default.cluster.local."       → match
+#   observed "svc.cluster.local."               → NO match (zero labels in slot)
+#   observed "svc.a.b.cluster.local."           → NO match (two labels — ⋯ is exactly one)
+# Match path:   label-split + the existing dynamicpathdetector.CompareDynamic
+#               (DNS labels and path segments are structurally identical)
+# Spec ref:     §5.8 "<a>.⋯.<b>" row — "DynamicIdentifier — exactly one label"
+# Why this exists:
+#   RFC 4592 only standardises LEADING wildcards. Mid-label `*` is non-standard
+#   (cilium uses regex; bind/coredns reject it). v0.0.2 uses `⋯` (our token,
+#   from path/argv wildcards) for mid positions so the wire format never
+#   claims false RFC 4592 compliance.
+# Token reminder:
+#   `⋯` is U+22EF (MIDLINE HORIZONTAL ELLIPSIS) — ONE Unicode codepoint.
+#   It is NOT three ASCII periods (`...`).
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-11-dns-mid-ellipsis
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-11
+  containers:
+  - name: dns-client
+    egress:
+    - identifier: cluster-svc-resolution
+      type: internal
+      dnsNames:
+        - "svc.⋯.cluster.local."
+      ports:
+        - {name: UDP-53, protocol: UDP, port: 53}

--- a/tests/resources/network-wildcards/12-dns-trailing-star.yaml
+++ b/tests/resources/network-wildcards/12-dns-trailing-star.yaml
@@ -1,0 +1,46 @@
+# Fixture 12 — DNS trailing wildcard `<prefix>.*`
+#
+# Edge case:    one OR MORE labels after the prefix (NEVER zero)
+# Expects:
+#   observed "mycorp.com.api."                  → match (one label after)
+#   observed "mycorp.com.api.v1."               → match (two labels after)
+#   observed "mycorp.com.api.v1.eu-west-1."     → match (three labels after)
+#   observed "mycorp.com."                      → NO match (apex — zero labels;
+#                                                   trailing `*` requires ≥1)
+# Match path:   label-split + recursive matcher with one-or-more-segment
+#               semantic on trailing `*`. Same defensive arity rule as paths
+#               (§5.1) — closes the apex blind spot.
+# Spec ref:     §5.8 "<prefix>.*" row, "one or more labels (never zero)"
+#
+# IMPORTANT clarification on label order:
+#   DNS names are read LEFT-TO-RIGHT but their label hierarchy goes
+#   RIGHT-TO-LEFT (the rightmost label is the TLD). So for `mycorp.com.*`,
+#   the `*` sits in the LEFTMOST positions of any matching name. This
+#   is opposite to the path convention. Both conventions agree that the
+#   `*` consumes "1+ tokens at the variable end" — they just differ on
+#   which end is variable.
+#
+# Producers should usually prefer `*.mycorp.com.` (leading-`*` per
+# RFC 4592) for "any subdomain" intent, since that's the standardised
+# form. The trailing form documented here is for cases where the
+# variable hierarchy is on the LEFT of a fixed registry suffix.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-12-dns-trailing-star
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-12
+  containers:
+  - name: client
+    egress:
+    - identifier: mycorp-anything-deeper
+      type: external
+      dnsNames:
+        - "mycorp.com.*"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/13-dns-trailing-dot-normalisation.yaml
+++ b/tests/resources/network-wildcards/13-dns-trailing-dot-normalisation.yaml
@@ -1,0 +1,39 @@
+# Fixture 13 — trailing-dot normalisation
+#
+# Edge case:    DNS literals MUST compare equal whether or not the trailing
+#               dot is present, on either side
+# Expects (with profile entry "api.stripe.com." — WITH dot):
+#   observed "api.stripe.com."   → match
+#   observed "api.stripe.com"    → match (verifier normalises)
+# Expects (with profile entry "api.stripe.com" — WITHOUT dot):
+#   observed "api.stripe.com."   → match
+#   observed "api.stripe.com"    → match
+# Match path:   verifier MUST canonicalise both sides before comparison
+#               (e.g. always append "." if missing)
+# Spec ref:     §5.8 "Trailing-dot normalisation" paragraph
+# Producer guidance: emit the trailing dot — it's the FQDN-canonical form per
+#                    RFC 1035. But verifiers MUST accept either.
+#
+# This fixture deliberately mixes both forms in dnsNames[] to ensure the
+# normalisation runs on profile-side entries, not just observed names.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-13-dns-trailing-dot
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-13
+  containers:
+  - name: client
+    egress:
+    - identifier: mixed-trailing-dot-forms
+      type: external
+      dnsNames:
+        - "api.stripe.com."     # canonical FQDN form
+        - "api.github.com"      # without trailing dot — equivalent
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/14-recursive-star-rejected.yaml
+++ b/tests/resources/network-wildcards/14-recursive-star-rejected.yaml
@@ -1,0 +1,38 @@
+# Fixture 14 — `**` recursive wildcard MUST be rejected
+#
+# Edge case:    a producer attempts to use the recursive `**` wildcard
+# Expects:      apiserver admission strategy REJECTS the document at write time
+#               (kubectl apply returns an error; nothing is persisted)
+# Match path:   N/A — never reaches a runtime matcher
+# Spec ref:     §5.8 last row "** (recursive zero-or-more) — NOT in v0.0.2"
+#               and "Empty / ** rejection" paragraph
+# Why deferred to v0.0.3:
+#   `**` semantics need careful design — should it match zero labels?
+#   how does it interact with leading/trailing `*`? Reserve the syntax now
+#   so producers don't accidentally rely on a future behaviour change.
+#
+# This fixture is INTENTIONALLY INVALID. The component test should:
+#   1. Attempt `kubectl apply -f 14-recursive-star-rejected.yaml`
+#   2. Assert the command fails with a validation error
+#   3. Assert no NetworkNeighborhood named `nw-14-recursive-rejected` exists
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-14-recursive-rejected
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+    sbob.io/expected-admission: "rejected"
+spec:
+  matchLabels:
+    app: nw-14
+  containers:
+  - name: client
+    egress:
+    - identifier: invalid-recursive
+      type: external
+      dnsNames:
+        - "**.example.com."     # INVALID — admission MUST reject
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/15-egress-and-ingress.yaml
+++ b/tests/resources/network-wildcards/15-egress-and-ingress.yaml
@@ -1,0 +1,46 @@
+# Fixture 15 — egress AND ingress on the same container
+#
+# Edge case:    both directions populated; matchers MUST be independently scoped
+# Expects:
+#   pktType=='OUTGOING' to "10.1.2.3"  → match in egress (CIDR 10.0.0.0/8)
+#   pktType=='OUTGOING' to "192.0.2.1" → NO match in egress (NOT in CIDR)
+#   pktType=='INCOMING' from "192.168.1.42" → match in ingress (CIDR 192.168.0.0/16)
+#   pktType=='INCOMING' from "10.0.0.42"   → NO match in ingress (NOT in 192.168/16)
+#                                            (even though 10.0.0.0/8 IS in egress —
+#                                            direction isolation is the contract)
+# Match path:   nn.was_address_in_egress() walks Spec.Egress only;
+#               nn.was_address_in_ingress() walks Spec.Ingress only
+# Spec ref:     §4.7 "egress and ingress" — direction isolation contract
+#
+# Note on current rule coverage:
+#   The default kubescape rule set (R0005, R0011, etc.) only fires on
+#   pktType=='OUTGOING'. The ingress block is fully matchable via the
+#   nn.was_address_in_ingress / nn.is_domain_in_ingress CEL functions,
+#   but no built-in rule consumes them as of v0.0.2. Custom rules MAY.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-15-egress-and-ingress
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-15
+  containers:
+  - name: bidirectional
+    egress:
+    - identifier: outbound-class-a
+      type: internal
+      ipAddresses:
+        - "10.0.0.0/8"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}
+    ingress:
+    - identifier: inbound-rfc1918-class-c
+      type: internal
+      ipAddresses:
+        - "192.168.0.0/16"
+      ports:
+        - {name: TCP-8080, protocol: TCP, port: 8080}

--- a/tests/resources/network-wildcards/16-egress-none.yaml
+++ b/tests/resources/network-wildcards/16-egress-none.yaml
@@ -1,0 +1,38 @@
+# Fixture 16 — NONE egress (declared zero-egress traffic)
+#
+# Edge case:    egress: [] explicit empty list — declares "this workload
+#               makes ZERO outbound network connections"
+# Expects:      verifier emits net.egress_unexpected on the FIRST observed
+#               outgoing connection (any IP, any DNS, any port)
+# Spec ref:     §5.4 NONE semantic — "explicit empty list = declared
+#               zero-activity, hard violation on first observation"
+# Distinction from absent:
+#   `egress:` MISSING from the doc        = NULL (verifier-defined posture)
+#   `egress: []`                          = NONE (zero-traffic contract)
+#   This fixture pins the latter.
+#
+# Producer use case:
+#   A worker pod that should ONLY accept inbound work and never reach out.
+#   A locked-down database whose only legitimate traffic is the ingress
+#   replication stream.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-16-egress-none
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-16
+  containers:
+  - name: locked-down-worker
+    egress: []        # NONE — any outbound traffic is a violation
+    ingress:
+    - identifier: control-plane-only
+      type: internal
+      ipAddresses:
+        - "10.0.0.1"
+      ports:
+        - {name: TCP-9000, protocol: TCP, port: 9000}

--- a/tests/resources/network-wildcards/17-realistic-stripe-api.yaml
+++ b/tests/resources/network-wildcards/17-realistic-stripe-api.yaml
@@ -1,0 +1,58 @@
+# Fixture 17 — realistic Stripe API integration
+#
+# Edge case:    end-to-end realistic profile for a workload that calls
+#               Stripe (well-known external SaaS) plus cluster DNS
+# Demonstrates:
+#   - egress[] with multiple entries (external + internal)
+#   - ipAddresses[] with both literal and CIDR
+#   - dnsNames[] with literal AND leading wildcard (RFC 4592)
+#   - selectors-based internal entry (auto-translated to NetworkPolicy;
+#     not consulted by R0005/R0011 runtime — see §4.7 caveat)
+#   - port specifications
+# Expects:
+#   POST https://api.stripe.com (resolved to one of Stripe's IPs)  → match
+#   POST https://files.stripe.com (matches *.stripe.com.)           → match
+#   POST https://api.example.com                                    → NO match
+#   UDP to kube-dns:53                                              → match (NetworkPolicy)
+#                                                                     but R0011/R0005
+#                                                                     don't consult selectors
+#                                                                     — see §4.7 note
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-17-realistic-stripe
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: payment-service
+  containers:
+  - name: payment-app
+    egress:
+    - identifier: stripe-api
+      type: external
+      ipAddresses:
+        - "162.0.217.171"     # Stripe public IP example
+        - "163.0.0.0/16"      # Stripe routing range — for completeness
+      dnsNames:
+        - "api.stripe.com."
+        - "*.stripe.com."     # leading-* RFC 4592 — covers files.stripe.com.,
+                              # webhooks.stripe.com., billing.stripe.com.
+                              # but NOT v1.api.stripe.com. (two labels deep)
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}
+    - identifier: cluster-dns
+      type: internal
+      # Selector-based entry — auto-translates to a NetworkPolicy egress rule
+      # that K8s enforces. Note: R0005/R0011 runtime matchers do NOT consult
+      # selectors as of v0.0.2 — they only walk ipAddresses/dnsNames.
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+      ports:
+        - {name: UDP-53, protocol: UDP, port: 53}

--- a/tests/resources/network-wildcards/18-cluster-dns-via-mid-ellipsis.yaml
+++ b/tests/resources/network-wildcards/18-cluster-dns-via-mid-ellipsis.yaml
@@ -1,0 +1,55 @@
+# Fixture 18 — Kubernetes service-FQDN resolution via mid-`⋯`
+#
+# Edge case:    The user's specific case from the v0.0.2 design discussion.
+#               In Kubernetes, services are resolved as
+#               <svc-name>.<namespace>.svc.cluster.local.
+#               A workload that wants to permit "any namespace's <known>
+#               service" should match exactly one label between fixed
+#               anchors.
+# Expects:
+#   observed "redis.production.svc.cluster.local."   → NO match (we anchored on `redis`,
+#                                                       and only the namespace label is
+#                                                       wildcarded)
+#   observed "redis.staging.svc.cluster.local."      → NO match (same — we'd need
+#                                                       a different fixture for "any svc
+#                                                       in any ns")
+#   observed "kubernetes.default.svc.cluster.local." → match (one label "default")
+# Match path:   label-split + recursive matcher; `⋯` consumes exactly one
+#               label between two fixed segments
+# Spec ref:     §5.8 "<a>.⋯.<b>" row, the example uses this exact pattern
+#
+# Why `⋯` and not `*`:
+#   RFC 4592 only standardises *.<suffix>. Mid-label `*` is non-standard
+#   (cilium uses regex; bind/coredns reject it). v0.0.2 uses `⋯` (DynamicIdentifier,
+#   the project's existing token from path/argv wildcards) for mid positions.
+#
+# Hardcoded short-circuit removal candidate:
+#   The default rule R0005 currently has a hardcoded
+#   `!event.name.endsWith('.svc.cluster.local.')` short-circuit. With this
+#   fixture's mid-⋯ form, that hardcode becomes profile-expressible — a
+#   future PR can REMOVE the rule-side short-circuit and let producers
+#   declare the equivalent via this NN.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-18-cluster-dns-mid-ellipsis
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-18
+  containers:
+  - name: dns-client
+    egress:
+    - identifier: any-namespace-kubernetes-svc
+      type: internal
+      dnsNames:
+        - "kubernetes.⋯.svc.cluster.local."
+        # ↑ matches kubernetes.default.svc.cluster.local. exactly,
+        #   parametric on the namespace label. Use one entry per
+        #   service the workload calls; the wildcard is on the
+        #   namespace position, not the service name.
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}

--- a/tests/resources/network-wildcards/19-port-protocol-with-cidr.yaml
+++ b/tests/resources/network-wildcards/19-port-protocol-with-cidr.yaml
@@ -1,0 +1,41 @@
+# Fixture 19 — port + protocol + CIDR composed match
+#
+# Edge case:    nn.was_address_port_protocol_in_egress matcher — the granular
+#               variant that requires IP+port+protocol all to match within
+#               the same NetworkNeighbor entry
+# Expects:
+#   observed (10.1.2.3, 443, TCP)   → match (both CIDR and port match within entry)
+#   observed (10.1.2.3, 80, TCP)    → NO match (CIDR ok but port mismatch)
+#   observed (192.168.1.1, 443, TCP)→ NO match (port ok but CIDR mismatch)
+#   observed (10.1.2.3, 443, UDP)   → NO match (CIDR + port ok but protocol mismatch)
+# Match path:   for each NetworkNeighbor:
+#                 if MatchIP(entry.IPs, observed) && entry contains matching
+#                 (port, protocol) tuple → true
+# Spec ref:     §4.7 ports[] row — name + protocol + port (uint16 nullable)
+#
+# This fixture validates that the new IP-matcher integration preserves the
+# port-protocol grouping contract — a CIDR match alone isn't sufficient
+# unless the entry's ports list also contains the (port, protocol) pair.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-19-port-proto-cidr
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-19
+  containers:
+  - name: client
+    egress:
+    - identifier: tls-only-class-a
+      type: internal
+      ipAddresses:
+        - "10.0.0.0/8"
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}
+        # Note: no UDP entry, no port-80 entry — only TCP/443 within this CIDR.
+        # A request to (10.1.2.3, 80, TCP) should NOT match because the
+        # port-protocol filter is per-NetworkNeighbor-entry, not global.

--- a/tests/resources/network-wildcards/20-multi-container-mixed-wildcards.yaml
+++ b/tests/resources/network-wildcards/20-multi-container-mixed-wildcards.yaml
@@ -1,0 +1,54 @@
+# Fixture 20 — multi-container pod with different rules per container
+#
+# Edge case:    a single NetworkNeighborhood applies to a multi-container pod;
+#               each container has its own egress/ingress block; the verifier
+#               MUST scope matching by container ID (not pod ID)
+# Expects:
+#   container "frontend" can hit *.example.com. but NOT 10.0.0.0/8;
+#   container "sidecar"  can hit 10.0.0.0/8     but NOT *.example.com.;
+#   if the verifier conflates containers, both restrictions collapse to "either"
+#   and the test fails
+# Match path:   nn.* CEL functions resolve the ContainerProfile by containerID,
+#               so the matchers operate on the ALREADY-scoped Spec.Egress slice
+# Spec ref:     §4.2 container entry — each container is independently profiled
+#
+# This is also the most realistic deployment shape: a frontend that calls
+# external APIs plus an in-cluster sidecar that talks to DBs/caches.
+#
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: NetworkNeighborhood
+metadata:
+  name: nw-20-multi-container
+  namespace: "{{NAMESPACE}}"
+  annotations:
+    sbob.io/spec-version: "0.0.2"
+spec:
+  matchLabels:
+    app: nw-20
+  containers:
+  - name: frontend
+    egress:
+    - identifier: external-api
+      type: external
+      dnsNames:
+        - "*.example.com."          # leading-* RFC 4592
+        - "api.partner.io."         # literal
+      ports:
+        - {name: TCP-443, protocol: TCP, port: 443}
+  - name: sidecar
+    egress:
+    - identifier: in-cluster-services
+      type: internal
+      ipAddresses:
+        - "10.0.0.0/8"              # cluster pod CIDR
+        - "172.16.0.0/12"           # alt cluster service CIDR
+      ports:
+        - {name: TCP-6379, protocol: TCP, port: 6379}    # redis
+        - {name: TCP-5432, protocol: TCP, port: 5432}    # postgres
+    ingress:
+    - identifier: from-frontend
+      type: internal
+      ipAddresses:
+        - "10.244.0.0/16"           # narrower — only the frontend pod's CIDR
+      ports:
+        - {name: TCP-9090, protocol: TCP, port: 9090}    # sidecar metrics

--- a/tests/resources/network-wildcards/README.md
+++ b/tests/resources/network-wildcards/README.md
@@ -1,0 +1,80 @@
+# Network-wildcards test fixtures
+
+Living documentation for the `feat/network-wildcards` work.
+
+Each `*.yaml` here is a complete `NetworkNeighborhood` document that exercises
+ONE edge case in the v0.0.2 wildcard surface. The fixture-walk test
+(`TestFixturesParse` + `TestFixturesMatchExpectedBehaviour` in
+`pkg/rulemanager/cel/libraries/networkneighborhood/fixtures_test.go`,
+plus the lab-side `Test_34_NetworkWildcardSurface`) consumes them
+directly; users learning the syntax can copy-paste them as authoritative
+examples.
+
+**Note on `14-recursive-star-rejected.yaml`:** this fixture is intentionally
+**rejected at admission** — it carries `dnsNames: ["**"]` to demonstrate
+that the recursive-wildcard token is invalid v0.0.2 syntax. Don't `kubectl
+apply` it; the apiserver will return a 400. The runtime matcher also
+defends by silently dropping it on read, so a broken admission layer
+won't accidentally let it through.
+
+## Wildcard token vocabulary (matches paths + argv vocabulary)
+
+| Token | Meaning |
+|---|---|
+| `⋯` (U+22EF, MIDLINE HORIZONTAL ELLIPSIS — single Unicode codepoint, NOT three ASCII periods) | Exactly one segment / argv position / **DNS label** |
+| `*` leading | RFC 4592 wildcard — exactly one DNS label before the suffix |
+| `*` mid-path | NOT used in DNS — use `⋯` instead |
+| `*` trailing | One or more labels after the prefix (never zero — closes the apex blind spot) |
+| `*` as `ipAddresses[i]` | Sugar for `0.0.0.0/0` ∪ `::/0` (any IP) |
+
+## Field summary
+
+| Field on `NetworkNeighbor` | v0.0.2 status | Match form |
+|---|---|---|
+| `ipAddress` (string) | **deprecated** — kept for back-compat | byte-equality only |
+| `ipAddresses` (list of strings) | **new** | each entry: literal IP / CIDR / `*` sentinel; matches if ANY entry matches |
+| `dnsNames` (list of strings) | normative | each entry: literal / leading-`*` / mid-`⋯` / trailing-`*`; matches if ANY entry matches |
+| `dns` (single string) | **deprecated** since v0.0.1 | byte-equality only |
+| `ports[]` | normative | name + protocol + port (uint16, nullable per §5.4) |
+| `podSelector`, `namespaceSelector` | schema-level (passed through to auto-generated NetworkPolicy) | NOT consulted by the runtime CEL matchers — see §4.7 caveat |
+
+## Fixture index
+
+| # | File | Edge case |
+|---|------|-----------|
+| 01 | `01-literal-ipv4.yaml` | Single IPv4 literal in `ipAddresses[]` |
+| 02 | `02-literal-ipv6.yaml` | IPv6 literal — verifier MUST canonicalise |
+| 03 | `03-cidr-ipv4.yaml` | IPv4 CIDR — `10.0.0.0/8` covers a /8 range |
+| 04 | `04-cidr-ipv6.yaml` | IPv6 CIDR — `2001:db8::/32` |
+| 05 | `05-any-ip-sentinel.yaml` | The `*` sentinel — discouraged outside dev |
+| 06 | `06-any-as-cidr.yaml` | `0.0.0.0/0` + `::/0` (RFC-aligned alternatives to `*`) |
+| 07 | `07-mixed-ip-list.yaml` | Mixed list: literal + CIDR + sentinel — first match wins |
+| 08 | `08-deprecated-ipaddress.yaml` | Backward compat — singular `ipAddress` field |
+| 09 | `09-dns-literal.yaml` | Plain DNS literal with trailing dot |
+| 10 | `10-dns-leading-wildcard.yaml` | `*.example.com.` — RFC 4592, exactly ONE label |
+| 11 | `11-dns-mid-ellipsis.yaml` | `svc.⋯.cluster.local.` — exactly ONE label between |
+| 12 | `12-dns-trailing-star.yaml` | `mycorp.com.*` — ONE OR MORE labels (never zero) |
+| 13 | `13-dns-trailing-dot-normalisation.yaml` | `example.com` and `example.com.` MUST be equivalent |
+| 14 | `14-recursive-star-rejected.yaml` | `**` — MUST be rejected by apiserver write strategy |
+| 15 | `15-egress-and-ingress.yaml` | Both directions populated on same container |
+| 16 | `16-egress-none.yaml` | NONE (`egress: []`) — declared zero-egress |
+| 17 | `17-realistic-stripe-api.yaml` | Realistic external API call (Stripe) |
+| 18 | `18-cluster-dns-via-mid-ellipsis.yaml` | The user's `svc.⋯.kubernetes.io.` use case |
+| 19 | `19-port-protocol-with-cidr.yaml` | Ports + protocol + CIDR composed |
+| 20 | `20-multi-container-mixed-wildcards.yaml` | Pod with multiple containers, each with different rules — combined real-world example |
+
+## Expected behaviour matrix
+
+The accompanying `expectations.json` (generated alongside) lists, per fixture,
+the `(observedIP, observedDNS) → expected match result` triples that
+`Test_34_NetworkWildcardSurface` walks.
+
+## Migration note
+
+Producers writing v0.0.2-conformant SBoBs SHOULD use `ipAddresses` (plural).
+The singular `ipAddress` is retained ONLY for back-compat with v0.0.1-era
+profiles; producers MUST NOT populate both on the same entry (the apiserver
+admission strategy rejects this).
+
+The deprecated `dns` (single string) field is retained for v0 compatibility;
+v0.0.2 producers MUST emit `dnsNames` (list).

--- a/tests/resources/nginx-user-defined-deployment.yaml
+++ b/tests/resources/nginx-user-defined-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: curl-28
+  name: curl-28
+spec:
+  selector:
+    matchLabels:
+      app: curl-28
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: curl-28
+        # Upstream ContainerProfileCache (kubescape/node-agent#788) reads ONE
+        # label and uses its value as the name of BOTH the user-defined
+        # ApplicationProfile and the user-defined NetworkNeighborhood. The
+        # AP and NN below MUST share the same name as this label value.
+        kubescape.io/user-defined-profile: curl-28-overlay
+    spec:
+      containers:
+      - name: curl
+        image: docker.io/curlimages/curl@sha256:08e466006f0860e54fc299378de998935333e0e130a15f6f98482e9f8dab3058
+        command: ["sleep", "infinity"]


### PR DESCRIPTION
Same-repo mirror of #806 (which is from the `k8sstormcenter` fork) so the gated **Node Agent Component Tests** and **build-and-push-image (pull_request)** workflows run with repo secrets.

Single squashed commit, rebased on `main`, conflicts resolved.

## Overview
network-wildcards: DNS leading/trailing/mid + CIDR + IPAddresses + `*` sentinel.

CEL `networkneighborhood` helpers now query projected fields with wildcard/CIDR/DNS-wildcard support and the v0.0.2 spec semantics (port/protocol checks degrade to address-only in v1 when only a CIDR is declared):
- DNS leading-`*` (RFC 4592 single-label wildcard)
- DNS trailing-`*` (subdomain-prefix wildcard)
- DNS mid-`⋯` (interior dynamic segment)
- IPv4/IPv6 literals and CIDR ranges
- `*` any-IP sentinel
- `IPAddresses` list (deprecated single-IP field) preserved on the decode path

Enables the "Unexpected Egress Network Traffic" (R0011) rule by default.

## Storage dependency
Backed by kubescape/storage #324. `go.mod` pins the official `kubescape/storage v0.0.290` release (drops the temporary fork `replace`).

## Tests
- 20 declarative fixture YAMLs under `tests/resources/network-wildcards/`
- wildcard + fixtures unit tests in `pkg/rulemanager/cel/libraries/networkneighborhood/`
- `Test_28_UserDefinedNetworkNeighborhood` component test
- Feature documented in `docs/features/network-wildcards.md`

Supersedes/mirrors #806.

🤖 Generated with [Claude Code](https://claude.com/claude-code)