### PR TITLE
fix(containerprofilemanager): cap identified call stacks per container

### DIFF
--- a/pkg/containerprofilemanager/v1/event_reporting.go
+++ b/pkg/containerprofilemanager/v1/event_reporting.go
@@ -19,6 +19,13 @@ import (
 
 var procRegex = regexp.MustCompile(`^/proc/\d+`)
 
+// maxIdentifiedCallStacksPerContainer bounds the number of distinct identified
+// call stacks retained per container between reporting flushes. Each distinct
+// call site produces a distinct (deduped-by-hash) call stack; without a cap a
+// workload that launches many distinct executables grows this map unbounded and
+// drives the node-agent OOM.
+const maxIdentifiedCallStacksPerContainer = 512
+
 // ReportCapability reports a capability event for a container
 func (cpm *ContainerProfileManager) ReportCapability(containerID, capability string) {
 	err := cpm.withContainer(containerID, func(data *containerData) (int, error) {
@@ -230,6 +237,15 @@ func (cpm *ContainerProfileManager) ReportIdentifiedCallStack(containerID string
 
 		// Check if we already have this call stack
 		if data.callStacks.Has(callStackIdentifier) {
+			return 0, nil
+		}
+
+		// Bound memory: a container that launches many distinct executables (or a
+		// process-enumeration/fork-churn attack) produces a distinct call stack per
+		// call site, which would otherwise grow this map unbounded within a
+		// reporting window and drive the node-agent OOM. The profile only needs a
+		// representative set, so stop retaining new call stacks past the cap.
+		if data.callStacks.Len() >= maxIdentifiedCallStacksPerContainer {
 			return 0, nil
 		}
 

--- a/pkg/objectcache/callstackcache/callstackcache.go
+++ b/pkg/objectcache/callstackcache/callstackcache.go
@@ -7,6 +7,12 @@ import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
 
+// maxCallStacksInTree bounds the number of distinct call sites (CallIDs) indexed
+// in a container's search tree. A container that launches many distinct
+// executables produces many distinct call sites; without a cap the tree, trie and
+// per-CallID paths grow unbounded and inflate node-agent memory.
+const maxCallStacksInTree = 512
+
 // BidirectionalNode extends the call stack node with parent reference
 type BidirectionalNode struct {
 	Frame    v1beta1.StackFrame
@@ -36,6 +42,12 @@ func NewCallStackSearchTree() *CallStackSearchTree {
 func (t *CallStackSearchTree) AddCallStack(stack v1beta1.IdentifiedCallStack) {
 	// If call stack already exists, skip
 	if _, ok := t.Roots[stack.CallID]; ok {
+		return
+	}
+
+	// Bound memory: stop indexing new call sites past the cap (see
+	// maxCallStacksInTree). The tree already retains a representative set.
+	if len(t.Roots) >= maxCallStacksInTree {
 		return
 	}
 


### PR DESCRIPTION
Each distinct call site produces a distinct (deduped-by-hash) `IdentifiedCallStack` stored in the per-container `callStacks` map. A workload that launches many distinct executables (or a process-enumeration/fork-churn attack) grows this map **unbounded** within a reporting window, driving the node-agent OOM. Observed via heap profiling on a live cluster: Go heap grew to ~900MB under churn (`createCallStackFromTrace`/`ReportIdentifiedCallStack` the top allocation), node-agent OOMKilled. Cap at 512 distinct stacks per container; dedup-by-hash preserved below the cap.

🤖 Generated with Claude Code