### PR TITLE
fix: stop seccomp-profile watch goroutine leak and zero-backoff re-watch loop

### DIFF
--- a/pkg/storage/v1/seccompprofile_crd.go
+++ b/pkg/storage/v1/seccompprofile_crd.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,30 +91,47 @@ func (c *CRDSeccompProfileClient) GetSeccompProfile(namespace, name string) (*v1
 
 // convertingWatch wraps a watch.Interface to convert unstructured objects to typed SeccompProfile objects
 type convertingWatch struct {
-	source  watch.Interface
-	result  chan watch.Event
-	stopped bool
+	source   watch.Interface
+	result   chan watch.Event
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func newConvertingWatch(source watch.Interface) *convertingWatch {
 	cw := &convertingWatch{
 		source: source,
 		result: make(chan watch.Event),
+		done:   make(chan struct{}),
 	}
 	go cw.run()
 	return cw
+}
+
+// send forwards ev to the consumer, aborting if Stop() has been called so run()
+// can never park forever on an unread result channel. Returns false if shutdown won.
+func (cw *convertingWatch) send(ev watch.Event) bool {
+	select {
+	case cw.result <- ev:
+		return true
+	case <-cw.done:
+		return false
+	}
 }
 
 func (cw *convertingWatch) run() {
 	defer close(cw.result)
 	for event := range cw.source.ResultChan() {
 		if event.Type == watch.Error {
-			cw.result <- event
+			if !cw.send(event) {
+				return
+			}
 			continue
 		}
 
 		if event.Object == nil {
-			cw.result <- event
+			if !cw.send(event) {
+				return
+			}
 			continue
 		}
 
@@ -121,30 +139,32 @@ func (cw *convertingWatch) run() {
 		unstructuredObj, ok := event.Object.(runtime.Unstructured)
 		if !ok {
 			// If it's already typed, pass through
-			cw.result <- event
+			if !cw.send(event) {
+				return
+			}
 			continue
 		}
 
 		profile := &v1beta1.SeccompProfile{}
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.UnstructuredContent(), profile); err != nil {
 			// On conversion error, send an error event
-			cw.result <- watch.Event{
-				Type:   watch.Error,
-				Object: event.Object,
+			if !cw.send(watch.Event{Type: watch.Error, Object: event.Object}) {
+				return
 			}
 			continue
 		}
 
-		cw.result <- watch.Event{
-			Type:   event.Type,
-			Object: profile,
+		if !cw.send(watch.Event{Type: event.Type, Object: profile}) {
+			return
 		}
 	}
 }
 
 func (cw *convertingWatch) Stop() {
-	cw.source.Stop()
-	cw.stopped = true
+	cw.stopOnce.Do(func() {
+		close(cw.done)
+		cw.source.Stop()
+	})
 }
 
 func (cw *convertingWatch) ResultChan() <-chan watch.Event {

--- a/pkg/storage/v1/seccompprofile_crd_test.go
+++ b/pkg/storage/v1/seccompprofile_crd_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// fakeSource is a minimal watch.Interface whose ResultChan is driven by the test.
+type fakeSource struct {
+	ch      chan watch.Event
+	stopped bool
+}
+
+func newFakeSource() *fakeSource { return &fakeSource{ch: make(chan watch.Event)} }
+
+func (f *fakeSource) Stop()                          { f.stopped = true; close(f.ch) }
+func (f *fakeSource) ResultChan() <-chan watch.Event { return f.ch }
+
+// When the consumer never reads ResultChan(), a pending forward must not pin the
+// run() goroutine forever: Stop() must unblock it and close the result channel.
+func TestConvertingWatch_StopUnblocksPendingSend(t *testing.T) {
+	src := newFakeSource()
+	cw := newConvertingWatch(src)
+
+	// Push an error event; run() will block trying to forward it onto the
+	// unbuffered result channel because we never read from ResultChan().
+	src.ch <- watch.Event{Type: watch.Error, Object: &metav1.Status{Code: 410}}
+
+	// Give run() a moment to park on the send.
+	time.Sleep(20 * time.Millisecond)
+
+	cw.Stop()
+
+	// After Stop(), run() must exit and close the result channel.
+	select {
+	case _, ok := <-cw.ResultChan():
+		assert.False(t, ok, "result channel should be closed after Stop()")
+	case <-time.After(time.Second):
+		t.Fatal("run() goroutine leaked: result channel not closed after Stop()")
+	}
+}
+
+func TestConvertingWatch_StopIsIdempotent(t *testing.T) {
+	src := newFakeSource()
+	cw := newConvertingWatch(src)
+	cw.Stop()
+	assert.NotPanics(t, func() { cw.Stop() }, "second Stop() must not panic")
+}

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
@@ -113,7 +113,13 @@ func (w *SeccompProfileWatcherImpl) watchWithRetry(ctx context.Context) {
 			logger.L().Ctx(ctx).Debug("SeccompProfileWatcher - watch error, retrying",
 				helpers.Error(err),
 				helpers.String("retryIn", delay.String()))
-			time.Sleep(delay)
+			select {
+			case <-time.After(delay):
+			case <-w.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
 			continue
 		}
 
@@ -140,7 +146,13 @@ func (w *SeccompProfileWatcherImpl) watchWithRetry(ctx context.Context) {
 			delay := b.NextBackOff()
 			logger.L().Ctx(ctx).Debug("SeccompProfileWatcher - watch error event, re-listing and backing off",
 				helpers.String("retryIn", delay.String()))
-			time.Sleep(delay)
+			select {
+			case <-time.After(delay):
+			case <-w.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
 		}
 	}
 }

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
@@ -129,12 +129,26 @@ func (w *SeccompProfileWatcherImpl) watchWithRetry(ctx context.Context) {
 		case exitStopped:
 			return
 		case exitChannelClosed:
-			// Clean close (e.g. server rotated the watch). Resume from the last
-			// good RV; no re-List and no backoff penalty since we made progress.
 			if resourceVersion != "" {
+				// Made progress before the close (e.g. server rotated the watch after
+				// delivering events). Resume from the last good RV and reset backoff.
 				opts.ResourceVersion = resourceVersion
+				b.Reset()
+				continue
 			}
-			b.Reset()
+			// Clean close before any event: the CRD watch path can close without a
+			// watch.Error on disconnects/timeouts. Resetting backoff here would let
+			// repeated instant closes hot-spin, so back off before retrying instead.
+			delay := b.NextBackOff()
+			logger.L().Ctx(ctx).Debug("SeccompProfileWatcher - watch closed before any event, backing off",
+				helpers.String("retryIn", delay.String()))
+			select {
+			case <-time.After(delay):
+			case <-w.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
 		case exitErrorEvent:
 			// The RV is poisoned (e.g. 410 Expired after etcd compaction). Drop it
 			// and re-List to recover a fresh RV, then back off before re-watching so

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go
@@ -83,6 +83,15 @@ func (w *SeccompProfileWatcherImpl) listExisting(ctx context.Context) error {
 	return nil
 }
 
+// watchExit explains why processEvents returned, so watchWithRetry can react.
+type watchExit int
+
+const (
+	exitStopped       watchExit = iota // stopCh/ctx cancelled — caller should return
+	exitErrorEvent                     // watch.Error / expired RV — poison RV, re-List, back off
+	exitChannelClosed                  // clean channel close — re-watch from same RV
+)
+
 func (w *SeccompProfileWatcherImpl) watchWithRetry(ctx context.Context) {
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 0 // Never stop retrying
@@ -108,16 +117,35 @@ func (w *SeccompProfileWatcherImpl) watchWithRetry(ctx context.Context) {
 			continue
 		}
 
-		// Reset backoff on successful connection
-		b.Reset()
+		resourceVersion, exit := w.processEvents(ctx, watcher)
 
-		if resourceVersion := w.processEvents(ctx, watcher); resourceVersion != "" {
-			opts.ResourceVersion = resourceVersion
+		switch exit {
+		case exitStopped:
+			return
+		case exitChannelClosed:
+			// Clean close (e.g. server rotated the watch). Resume from the last
+			// good RV; no re-List and no backoff penalty since we made progress.
+			if resourceVersion != "" {
+				opts.ResourceVersion = resourceVersion
+			}
+			b.Reset()
+		case exitErrorEvent:
+			// The RV is poisoned (e.g. 410 Expired after etcd compaction). Drop it
+			// and re-List to recover a fresh RV, then back off before re-watching so
+			// a persistent error can never drive a zero-delay hot loop.
+			opts.ResourceVersion = ""
+			if err := w.listExisting(ctx); err != nil {
+				logger.L().Ctx(ctx).Warning("SeccompProfileWatcher - re-list after watch error failed", helpers.Error(err))
+			}
+			delay := b.NextBackOff()
+			logger.L().Ctx(ctx).Debug("SeccompProfileWatcher - watch error event, re-listing and backing off",
+				helpers.String("retryIn", delay.String()))
+			time.Sleep(delay)
 		}
 	}
 }
 
-func (w *SeccompProfileWatcherImpl) processEvents(ctx context.Context, watcher watch.Interface) string {
+func (w *SeccompProfileWatcherImpl) processEvents(ctx context.Context, watcher watch.Interface) (string, watchExit) {
 	defer watcher.Stop()
 
 	var lastResourceVersion string
@@ -125,18 +153,18 @@ func (w *SeccompProfileWatcherImpl) processEvents(ctx context.Context, watcher w
 	for {
 		select {
 		case <-w.stopCh:
-			return lastResourceVersion
+			return lastResourceVersion, exitStopped
 		case <-ctx.Done():
-			return lastResourceVersion
+			return lastResourceVersion, exitStopped
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
 				// Channel closed, need to restart watch
-				return lastResourceVersion
+				return lastResourceVersion, exitChannelClosed
 			}
 
 			if event.Type == watch.Error {
 				logger.L().Ctx(ctx).Debug("SeccompProfileWatcher - watch error event")
-				return lastResourceVersion
+				return lastResourceVersion, exitErrorEvent
 			}
 
 			profile, ok := event.Object.(*v1beta1api.SeccompProfile)

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
@@ -189,9 +189,10 @@ func TestSeccompProfileWatcher_ProcessEvents(t *testing.T) {
 	// Close the watch
 	close(mockWatch.events)
 
-	rv := watcher.processEvents(ctx, mockWatch)
+	rv, exit := watcher.processEvents(ctx, mockWatch)
 
 	assert.Equal(t, "123", rv)
+	assert.Equal(t, exitChannelClosed, exit)
 	assert.Equal(t, 1, mockManager.GetProfileCount())
 }
 
@@ -224,4 +225,67 @@ func (w *testWatch) Stop() {
 
 func (w *testWatch) ResultChan() <-chan watch.Event {
 	return w.events
+}
+
+// erroringClient is a SeccompProfileClient whose watches immediately emit a 410
+// error event. It counts how often the watcher re-Lists and re-Watches so we can
+// prove the retry loop re-Lists on error and does not hot-spin.
+type erroringClient struct {
+	mu         sync.Mutex
+	listCalls  int
+	watchCalls int
+}
+
+var _ storage.SeccompProfileClient = (*erroringClient)(nil)
+
+func (c *erroringClient) WatchSeccompProfiles(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	c.mu.Lock()
+	c.watchCalls++
+	c.mu.Unlock()
+	ch := make(chan watch.Event, 1)
+	ch <- watch.Event{Type: watch.Error, Object: &metav1.Status{Reason: metav1.StatusReasonExpired, Code: 410}}
+	// Do NOT close ch: processEvents returns on the error event, then Stops the watch.
+	return &testWatch{events: ch}, nil
+}
+
+func (c *erroringClient) ListSeccompProfiles(_ string, _ metav1.ListOptions) (*v1beta1api.SeccompProfileList, error) {
+	c.mu.Lock()
+	c.listCalls++
+	c.mu.Unlock()
+	return &v1beta1api.SeccompProfileList{ListMeta: metav1.ListMeta{ResourceVersion: "fresh"}}, nil
+}
+
+func (c *erroringClient) GetSeccompProfile(_ string, _ string) (*v1beta1api.SeccompProfile, error) {
+	return nil, nil
+}
+
+func (c *erroringClient) counts() (list, watch int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.listCalls, c.watchCalls
+}
+
+func TestSeccompProfileWatcher_ReListsAndBacksOffOnError(t *testing.T) {
+	client := &erroringClient{}
+	watcher := NewSeccompProfileWatcher(client, newTrackingSeccompManagerMock())
+
+	go watcher.watchWithRetry(context.Background())
+
+	// Re-List must engage on the error event (pre-fix: never re-Lists).
+	assert.Eventually(t, func() bool {
+		list, _ := client.counts()
+		return list >= 1
+	}, 3*time.Second, 10*time.Millisecond, "watcher must re-List after a watch.Error")
+
+	// Let it run a fixed window, then stop and assert it did NOT hot-spin.
+	time.Sleep(time.Second)
+	watcher.Stop()
+
+	list, watchCount := client.counts()
+	assert.GreaterOrEqual(t, list, 1)
+	// Pre-fix this loop spins hundreds-to-thousands of times/sec with zero delay.
+	// Post-fix each error triggers re-List + exponential backoff (>=~250ms), so a
+	// ~1s window yields only a handful of attempts. 20 is a generous ceiling that
+	// still separates cleanly from the pre-fix hot loop.
+	assert.Less(t, watchCount, 20, "retry loop must back off, not hot-spin")
 }

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
@@ -289,3 +289,33 @@ func TestSeccompProfileWatcher_ReListsAndBacksOffOnError(t *testing.T) {
 	// still separates cleanly from the pre-fix hot loop.
 	assert.Less(t, watchCount, 20, "retry loop must back off, not hot-spin")
 }
+
+// TestSeccompProfileWatcher_StopInterruptsBackoff proves that Stop() interrupts
+// an in-progress backoff sleep in watchWithRetry, rather than making the caller
+// wait out the full backoff interval (up to MaxInterval=60s) before shutting down.
+func TestSeccompProfileWatcher_StopInterruptsBackoff(t *testing.T) {
+	client := &erroringClient{}
+	watcher := NewSeccompProfileWatcher(client, newTrackingSeccompManagerMock())
+
+	done := make(chan struct{})
+	go func() {
+		watcher.watchWithRetry(context.Background())
+		close(done)
+	}()
+
+	// Wait until the loop has hit the client at least once, so it is in (or about
+	// to enter) the backoff sleep after the watch error event.
+	assert.Eventually(t, func() bool {
+		list, _ := client.counts()
+		return list >= 1
+	}, 3*time.Second, 10*time.Millisecond, "watcher must re-List after a watch.Error before we stop it")
+
+	watcher.Stop()
+
+	select {
+	case <-done:
+		// good: watchWithRetry returned promptly
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("watchWithRetry did not return within 200ms of Stop(); backoff sleep is not cancellable")
+	}
+}

--- a/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
+++ b/pkg/watcher/seccompprofilewatcher/seccompprofilewatcher_test.go
@@ -319,3 +319,55 @@ func TestSeccompProfileWatcher_StopInterruptsBackoff(t *testing.T) {
 		t.Fatal("watchWithRetry did not return within 200ms of Stop(); backoff sleep is not cancellable")
 	}
 }
+
+// closingClient is a SeccompProfileClient whose watches close immediately with no
+// event delivered (a clean close before any progress). It counts watch attempts so
+// we can prove the retry loop backs off instead of hot-spinning on repeated closes.
+type closingClient struct {
+	mu         sync.Mutex
+	watchCalls int
+}
+
+var _ storage.SeccompProfileClient = (*closingClient)(nil)
+
+func (c *closingClient) WatchSeccompProfiles(_ string, _ metav1.ListOptions) (watch.Interface, error) {
+	c.mu.Lock()
+	c.watchCalls++
+	c.mu.Unlock()
+	ch := make(chan watch.Event)
+	close(ch) // clean close, no event => processEvents returns exitChannelClosed with empty RV
+	return &testWatch{events: ch}, nil
+}
+
+func (c *closingClient) ListSeccompProfiles(_ string, _ metav1.ListOptions) (*v1beta1api.SeccompProfileList, error) {
+	return &v1beta1api.SeccompProfileList{}, nil
+}
+
+func (c *closingClient) GetSeccompProfile(_ string, _ string) (*v1beta1api.SeccompProfile, error) {
+	return nil, nil
+}
+
+func (c *closingClient) watches() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.watchCalls
+}
+
+// TestSeccompProfileWatcher_BacksOffOnCleanCloseWithoutEvents proves that when a
+// watch closes cleanly before delivering any event (resourceVersion never advances),
+// the retry loop backs off instead of resetting backoff and re-watching immediately.
+func TestSeccompProfileWatcher_BacksOffOnCleanCloseWithoutEvents(t *testing.T) {
+	client := &closingClient{}
+	watcher := NewSeccompProfileWatcher(client, newTrackingSeccompManagerMock())
+
+	go watcher.watchWithRetry(context.Background())
+
+	// Let it run a fixed window, then stop and assert it did NOT hot-spin.
+	time.Sleep(time.Second)
+	watcher.Stop()
+
+	// Pre-fix: exitChannelClosed with an empty RV calls b.Reset() and reopens with
+	// zero delay -> hundreds/thousands of watch attempts. Post-fix: each no-progress
+	// close backs off (>=~250ms), so a ~1s window yields only a handful.
+	assert.Less(t, client.watches(), 20, "retry loop must back off on repeated clean closes, not hot-spin")
+}


### PR DESCRIPTION
## Summary

Fixes a goroutine leak in the seccomp-profile CRD watch path that grows node-agent memory ~300 MiB/hour until the pod is OOM/liveness-killed and restarted (observed ~59,600 goroutines in a single pod, 99% parked forwarding a watch.Error event). Two coupled defects are fixed here.

## Defect 1: convertingWatch leaks a goroutine on Stop()

In pkg/storage/v1/seccompprofile_crd.go, run() forwarded every event with a blocking send onto an unbuffered channel, and Stop() only stopped the source; it never unblocked a pending send. The moment the client-go reflector stopped reading (which it does on watch.Error), run() parked forever. Fix: a done channel so every send aborts on Stop() via select, with Stop() guarded by sync.Once.

## Defect 2: zero-backoff re-watch hot loop

In pkg/watcher/seccompprofilewatcher/seccompprofilewatcher.go, backoff was reset on every successful watch open, a watch.Error event just re-watched with no delay, and the watcher never re-Listed. A resourceVersion compacted out of etcd returned an instant 410 Expired on every re-watch, spinning ~7x/sec and leaking a convertingWatch goroutine each spin. Fix: processEvents now reports why it returned (exitStopped / exitErrorEvent / exitChannelClosed); on a watch error the loop drops the stale RV, re-Lists to recover a fresh one, and applies exponential backoff. Backoff resets only on a clean close, never on a mere open. A third commit makes the backoff sleeps cancellable by stopCh/ctx so shutdown cannot be delayed.

## Trigger / localization

Requires both (a) the CRD-backed seccomp client active and (b) a seccompprofile whose RV was compacted out of etcd. Clusters that actively update seccompprofiles keep RVs inside the compaction window; storage-backend clusters never touch this code.

## Validation

On the affected cluster, after clearing the stale profile and restarting: old pods 59,622 goroutines / ~1 GiB / 100m pinned; fresh pods after 20-24 min 196-215 goroutines / ~250 MiB / 22-42m (flat). Unit tests added for both defects plus a test proving Stop() interrupts an in-progress backoff sleep. go test -race passes on both packages.

<!-- armosec-pr: v=1 via=manual -->

AI-skills: superpowers:systematic-debugging,superpowers:brainstorming,superpowers:writing-plans,superpowers:subagent-driven-development,superpowers:finishing-a-development-branch | cmds: /model,/compact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch shutdown so streaming seccomp profiles stops cleanly without hanging.
  * Made watch retries more resilient: it now handles dropped connections and error events more reliably, restarts from the last known state when possible, and avoids rapid retry loops.
  * Stopping a watch now interrupts any in-progress wait immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->