### PR TITLE
fix: validate rootfs diff-ids before use to prevent SBOM panic on digest-less images

### DIFF
--- a/pkg/sbommanager/v1/syftutil/source.go
+++ b/pkg/sbommanager/v1/syftutil/source.go
@@ -42,6 +42,9 @@ func NewSource(imageName, imageDigest, imageID string, imageStatus *runtime.Imag
 	if err != nil {
 		return nil, fmt.Errorf("unable to unmarshal image info: %w", err)
 	}
+	if err := validateDiffIDs(imageInfo.ImageSpec.RootFS.DiffIDs); err != nil {
+		return nil, fmt.Errorf("invalid image diff-ids: %w", err)
+	}
 	reverseLayers := imageInfo.ImageSpec.RootFS.DiffIDs
 	slices.Reverse(reverseLayers)
 	configFile := v1.ConfigFile{
@@ -127,6 +130,15 @@ func toConfig(config imagespec.ImageConfig) v1.Config {
 		StopSignal:      config.StopSignal,
 		Shell:           nil,
 	}
+}
+
+func validateDiffIDs(ds []imagedigest.Digest) error {
+	for i, d := range ds {
+		if err := d.Validate(); err != nil {
+			return fmt.Errorf("invalid diff-id at index %d (%q): %w", i, d, err)
+		}
+	}
+	return nil
 }
 
 func toDiffIDs(ds []imagedigest.Digest) []v1.Hash {

--- a/pkg/sbommanager/v1/syftutil/source_test.go
+++ b/pkg/sbommanager/v1/syftutil/source_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
 
 func Test_toLayers(t *testing.T) {
@@ -92,4 +93,80 @@ func Test_toLayers(t *testing.T) {
 			assert.Equalf(t, tt.want1, got1, "toLayers(%v, %v)", tt.args.ds, tt.args.ms)
 		})
 	}
+}
+
+func Test_validateDiffIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		ds      []imagedigest.Digest
+		wantErr bool
+	}{
+		{
+			name: "valid digests",
+			ds: []imagedigest.Digest{
+				imagedigest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				imagedigest.Digest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty string digest (issue #853 crash input)",
+			ds:      []imagedigest.Digest{""},
+			wantErr: true,
+		},
+		{
+			name:    "malformed digest with no separator",
+			ds:      []imagedigest.Digest{imagedigest.Digest("deadbeef")},
+			wantErr: true,
+		},
+		{
+			name: "mixed valid and invalid digests",
+			ds: []imagedigest.Digest{
+				imagedigest.Digest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+				imagedigest.Digest(""),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty slice",
+			ds:      []imagedigest.Digest{},
+			wantErr: false,
+		},
+		{
+			name:    "nil slice",
+			ds:      nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDiffIDs(tt.ds)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_NewSource_InvalidDiffID(t *testing.T) {
+	imageStatus := &runtime.ImageStatusResponse{
+		Image: &runtime.Image{
+			Id:       "myimage-id",
+			RepoTags: []string{"myimage:latest"},
+		},
+		Info: map[string]string{
+			"info": `{"imageSpec":{"rootfs":{"type":"layers","diff_ids":[""]}}}`,
+		},
+	}
+
+	var src *NodeSource
+	var err error
+	assert.NotPanics(t, func() {
+		src, err = NewSource("myimage:latest", "", "myimage-id", imageStatus, nil, 0)
+	})
+	assert.Nil(t, src)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid image diff-ids")
 }


### PR DESCRIPTION
## Overview
Node-agent crashed with `panic: no ':' separator in digest ""` when the SBOM manager processed a container image without a resolvable digest (e.g. an image referenced only by tag, such as `:latest`, which CRI-O/OpenShift can report with an empty layer diff-id). The empty digest string reached `go-digest`'s `Digest.Algorithm()`/`Digest.Hex()`, which panic on malformed input instead of returning an error, taking down the whole node-agent process.

This adds a `validateDiffIDs` helper (using the digest library's own non-panicking `Validate()` method) and calls it in `NewSource` before any diff-id is touched. Images with an invalid/empty diff-id now surface as a reported SBOM-generation failure through the existing `reportFailure` error path instead of crashing the process — the agent keeps running.

## Additional Information
This change is deliberately scoped to `pkg/sbommanager/v1/syftutil/source.go` + its test file only — no changes to `sbom_manager.go`. During root-cause investigation a **separate, pre-existing** defect was found (SBOM-generation-failure objects aren't marked terminal and get silently reprocessed/re-logged on every container restart); that is out of scope here and is addressed in a follow-up PR.

## How to Test
```
go test ./pkg/sbommanager/v1/syftutil/...
go build ./...
```
`Test_NewSource_InvalidDiffID` reproduces the exact crash input (`diff_ids: [""]`) and asserts no panic + a wrapped error.

## Related issues/PRs
* Resolved #853

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of image filesystem layer identifiers.
  * Invalid image metadata now returns a clear error instead of risking a crash.
  * Added detailed error reporting to identify the problematic layer identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->