### PR TITLE
fix: persist terminal status on generic SBOM-generation failures to stop reprocessing loop

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -295,6 +295,15 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		},
 	}
 	wipSbom, err = s.storageClient.CreateSBOM(wipSbom)
+	// wipSbomHadContent is true only when we're about to reprocess an SBOM that previously
+	// completed successfully (the Learning case below). It exists solely to keep a
+	// content-bearing SBOM from ever being marked TooLarge on the reprocess path: unlike
+	// Incomplete, TooLarge is a one-way door in the storage layer -- GuaranteedUpdate
+	// silently drops every future write once status=too-large is set, so persisting it here
+	// (with the real Spec still attached, since PatchSBOMAnnotations never clears it) would
+	// leave the SBOM permanently frozen with its old content, unfixable by any later version.
+	// Incomplete has no such short-circuit and stays safely retryable, so it's used instead.
+	var wipSbomHadContent bool
 	switch {
 	case k8serrors.IsAlreadyExists(err):
 		// get the existing SBOM metadata and check if it is ready or being processed by another node
@@ -333,6 +342,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				"SBOM was created with an different version of tool, recreating it") {
 				return
 			}
+			wipSbomHadContent = true
 			// continue to create SBOM
 		case wipSbom.Annotations[helpersv1.StatusMetadataKey] == helpersv1.Incomplete:
 			if !s.shouldRetryAtCurrentVersion(wipSbom, sbomName, notif,
@@ -416,7 +426,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				s.metrics.ObserveSBOMScanDuration("oom_killed", scanDuration)
 				s.metrics.ReportSBOMScannerRestart()
 				s.metrics.SetSBOMScannerReady(false)
-				s.handleScannerCrash(sbomName, notif, scanErr, imageTag, imageID)
+				s.handleScannerCrash(sbomName, notif, scanErr, imageTag, imageID, wipSbomHadContent)
 				return
 			}
 			s.metrics.ReportSBOMScan("error")
@@ -471,7 +481,13 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
 			if errors.Is(srcErr, syftutil.ErrImageTooLarge) {
-				s.markSBOMStatus(sbomName, helpersv1.TooLarge, nil)
+				if wipSbomHadContent {
+					// don't let a content-bearing SBOM reach the TooLarge one-way door; treat
+					// it as a generic (retryable, eventually Incomplete) failure instead.
+					s.handleGenericFailure(sbomName)
+				} else {
+					s.markSBOMStatus(sbomName, helpersv1.TooLarge, nil)
+				}
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonImageTooLarge, srcErr)
 			} else {
 				s.handleGenericFailure(sbomName)
@@ -562,7 +578,11 @@ func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcac
 }
 
 // handleScannerCrash responds to repeated sidecar OOM crashes while scanning the same image.
-func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string) {
+// hadContent must be true when the SBOM being reprocessed previously completed successfully
+// (see the wipSbomHadContent doc comment in processContainerWithMetadata) -- in that case the
+// terminal status is Incomplete rather than TooLarge, since TooLarge is a one-way door in the
+// storage layer that would permanently freeze the SBOM's existing content.
+func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string, hadContent bool) {
 	s.scanRetries[sbomName]++
 	retryCount := s.scanRetries[sbomName]
 
@@ -576,9 +596,13 @@ func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollect
 		helpers.Int("maxRetries", maxScanRetries))
 
 	if retryCount >= maxScanRetries {
-		s.markSBOMStatus(sbomName, helpersv1.TooLarge, map[string]any{
-			ScannerMemoryLimitAnnotation: fmt.Sprintf("%d", s.scannerMemLimit),
-		})
+		if hadContent {
+			s.markSBOMStatus(sbomName, helpersv1.Incomplete, nil)
+		} else {
+			s.markSBOMStatus(sbomName, helpersv1.TooLarge, map[string]any{
+				ScannerMemoryLimitAnnotation: fmt.Sprintf("%d", s.scannerMemLimit),
+			})
+		}
 		// Report OOM regardless of persist success — the user should know the scan failed
 		s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
 		delete(s.scanRetries, sbomName)

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -88,6 +88,7 @@ type SbomManager struct {
 	scannerClient      sbomscanner.SBOMScannerClient
 	scannerMemLimit    int64
 	scanRetries        map[string]int // safe without mutex: only accessed from pool workers (pool size 1)
+	failureRetries     map[string]int // consecutive generic SBOM-generation failures per sbomName; safe without mutex: only accessed from pool workers (pool size 1)
 	pendingScans       map[string]pendingScan
 	pendingOrder       []string
 	pendingMu          sync.Mutex
@@ -141,6 +142,7 @@ func CreateSbomManager(ctx context.Context, cfg config.Config, socketPath string
 		scannerClient:      scannerClient,
 		scannerMemLimit:    scannerMemLimit,
 		scanRetries:        make(map[string]int),
+		failureRetries:     make(map[string]int),
 		pendingScans:       make(map[string]pendingScan),
 		failureReporter:    failureReporter,
 		metrics:            metrics,
@@ -283,6 +285,12 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		},
 	}
 	wipSbom, err = s.storageClient.CreateSBOM(wipSbom)
+	// wipSbomHadContent is true only when we're about to reprocess an SBOM that previously
+	// completed successfully (the Learning case below). GetSBOMMeta fetches metadata only, so
+	// wipSbom.Spec is empty here even though the stored object has real content -- if
+	// reprocessing fails, that content must be left untouched rather than wiped via
+	// markSBOMStatus/ReplaceSBOM. See handleGenericFailure.
+	var wipSbomHadContent bool
 	switch {
 	case k8serrors.IsAlreadyExists(err):
 		// get the existing SBOM metadata and check if it is ready or being processed by another node
@@ -316,45 +324,19 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("nodeName", wipSbom.Annotations[NodeNameMetadataKey]))
 			return
 		case wipSbom.Annotations[helpersv1.StatusMetadataKey] == helpersv1.Learning:
-			// only skip if the SBOM was created with the same version of tool
-			if wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] == s.version {
-				logger.L().Debug("SbomManager - SBOM is already created, skipping",
-					helpers.String("namespace", notif.Container.K8s.Namespace),
-					helpers.String("pod", notif.Container.K8s.PodName),
-					helpers.String("container", notif.Container.K8s.ContainerName),
-					helpers.String("sbomName", sbomName))
+			if !s.shouldRetryAtCurrentVersion(wipSbom, sbomName, notif,
+				"SBOM is already created, skipping",
+				"SBOM was created with an different version of tool, recreating it") {
 				return
 			}
-			logger.L().Debug("SbomManager - SBOM was created with an different version of tool, recreating it",
-				helpers.String("namespace", notif.Container.K8s.Namespace),
-				helpers.String("pod", notif.Container.K8s.PodName),
-				helpers.String("container", notif.Container.K8s.ContainerName),
-				helpers.String("sbomName", sbomName),
-				helpers.String("got version", wipSbom.Annotations[helpersv1.ToolVersionMetadataKey]),
-				helpers.String("expected version", s.version))
-			// update the version of the tool
-			wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] = s.version
-		// continue to create SBOM
+			wipSbomHadContent = true
+			// continue to create SBOM
 		case wipSbom.Annotations[helpersv1.StatusMetadataKey] == helpersv1.Incomplete:
-			// only skip if the SBOM was created with the same version of tool, so a fixed
-			// node-agent build still retries images that previously failed
-			if wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] == s.version {
-				logger.L().Debug("SbomManager - SBOM generation previously failed with this tool version, skipping",
-					helpers.String("namespace", notif.Container.K8s.Namespace),
-					helpers.String("pod", notif.Container.K8s.PodName),
-					helpers.String("container", notif.Container.K8s.ContainerName),
-					helpers.String("sbomName", sbomName))
+			if !s.shouldRetryAtCurrentVersion(wipSbom, sbomName, notif,
+				"SBOM generation previously failed with this tool version, skipping",
+				"SBOM generation previously failed with a different tool version, retrying") {
 				return
 			}
-			logger.L().Debug("SbomManager - SBOM generation previously failed with a different tool version, retrying",
-				helpers.String("namespace", notif.Container.K8s.Namespace),
-				helpers.String("pod", notif.Container.K8s.PodName),
-				helpers.String("container", notif.Container.K8s.ContainerName),
-				helpers.String("sbomName", sbomName),
-				helpers.String("got version", wipSbom.Annotations[helpersv1.ToolVersionMetadataKey]),
-				helpers.String("expected version", s.version))
-			// update the version of the tool
-			wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] = s.version
 			// continue to create SBOM
 		case wipSbom.Annotations[NodeNameMetadataKey] != s.cfg.NodeName:
 			logger.L().Debug("SbomManager - SBOM is already being processed by another node, skipping",
@@ -431,7 +413,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				s.metrics.ObserveSBOMScanDuration("oom_killed", scanDuration)
 				s.metrics.ReportSBOMScannerRestart()
 				s.metrics.SetSBOMScannerReady(false)
-				s.handleScannerCrash(sbomName, wipSbom, notif, scanErr, imageTag, imageID)
+				s.handleScannerCrash(sbomName, wipSbom, notif, scanErr, imageTag, imageID, wipSbomHadContent)
 				return
 			}
 			s.metrics.ReportSBOMScan("error")
@@ -442,7 +424,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
-			s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
+			s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, scanErr)
 			return
 		}
@@ -486,10 +468,16 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
 			if errors.Is(srcErr, syftutil.ErrImageTooLarge) {
-				s.markSBOMStatus(wipSbom, sbomName, helpersv1.TooLarge)
+				// totalSize is computed from the currently-mounted layer paths (see
+				// syftutil.toLayers), not a fixed property of the image, so this can also
+				// fire while reprocessing a content-bearing SBOM -- guard it the same way
+				// as handleGenericFailure/handleScannerCrash.
+				if !wipSbomHadContent {
+					s.markSBOMStatus(wipSbom, sbomName, helpersv1.TooLarge)
+				}
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonImageTooLarge, srcErr)
 			} else {
-				s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
+				s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, srcErr)
 			}
 			return
@@ -515,7 +503,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
-			s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
+			s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, syftErr)
 			return
 		}
@@ -524,6 +512,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 	}
 
 	// prepare the SBOM
+	delete(s.failureRetries, sbomName)
 	delete(wipSbom.Annotations, NodeNameMetadataKey)
 	wipSbom.Spec.Metadata.Report.CreatedAt = wipSbom.CreationTimestamp
 	wipSbom.Spec.Metadata.Tool.Name = "syft"
@@ -575,7 +564,12 @@ func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcac
 	}, backoff.WithBackOff(backoff.NewExponentialBackOff()))
 }
 
-func (s *SbomManager) handleScannerCrash(sbomName string, wipSbom *v1beta1.SBOMSyft, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string) {
+// handleScannerCrash responds to repeated sidecar OOM crashes while scanning the same image.
+// hadContent must be true when wipSbom is a GetSBOMMeta-sourced object for an SBOM that
+// previously completed successfully (see handleGenericFailure) -- in that case the Spec-clearing
+// ReplaceSBOM below is skipped so existing SBOM content is never destroyed by a crash loop
+// during a version-bump reprocess; only the failure is reported.
+func (s *SbomManager) handleScannerCrash(sbomName string, wipSbom *v1beta1.SBOMSyft, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string, hadContent bool) {
 	s.scanRetries[sbomName]++
 	retryCount := s.scanRetries[sbomName]
 
@@ -589,14 +583,16 @@ func (s *SbomManager) handleScannerCrash(sbomName string, wipSbom *v1beta1.SBOMS
 		helpers.Int("maxRetries", maxScanRetries))
 
 	if retryCount >= maxScanRetries {
-		delete(wipSbom.Annotations, NodeNameMetadataKey)
-		wipSbom.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
-		wipSbom.Annotations[ScannerMemoryLimitAnnotation] = fmt.Sprintf("%d", s.scannerMemLimit)
-		wipSbom.Spec = v1beta1.SBOMSyftSpec{}
-		if _, replaceErr := s.storageClient.ReplaceSBOM(wipSbom); replaceErr != nil {
-			logger.L().Error("SbomManager - failed to mark SBOM as TooLarge after scanner crashes",
-				helpers.Error(replaceErr),
-				helpers.String("sbomName", sbomName))
+		if !hadContent {
+			delete(wipSbom.Annotations, NodeNameMetadataKey)
+			wipSbom.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
+			wipSbom.Annotations[ScannerMemoryLimitAnnotation] = fmt.Sprintf("%d", s.scannerMemLimit)
+			wipSbom.Spec = v1beta1.SBOMSyftSpec{}
+			if _, replaceErr := s.storageClient.ReplaceSBOM(wipSbom); replaceErr != nil {
+				logger.L().Error("SbomManager - failed to mark SBOM as TooLarge after scanner crashes",
+					helpers.Error(replaceErr),
+					helpers.String("sbomName", sbomName))
+			}
 		}
 		// Report OOM regardless of persist success — the user should know the scan failed
 		s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
@@ -660,6 +656,53 @@ func (s *SbomManager) markSBOMStatus(wipSbom *v1beta1.SBOMSyft, sbomName, status
 			helpers.String("sbomName", sbomName),
 			helpers.String("status", status))
 	}
+}
+
+// shouldRetryAtCurrentVersion checks a status-gated SBOM's recorded tool version against the
+// running version. If they match, it logs skipMsg and returns false (the caller should skip
+// reprocessing). Otherwise it logs retryMsg, updates the tool-version annotation, and returns
+// true (the caller should continue to reprocess).
+func (s *SbomManager) shouldRetryAtCurrentVersion(wipSbom *v1beta1.SBOMSyft, sbomName string, notif containercollection.PubSubEvent, skipMsg, retryMsg string) bool {
+	if wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] == s.version {
+		logger.L().Debug(skipMsg,
+			helpers.String("namespace", notif.Container.K8s.Namespace),
+			helpers.String("pod", notif.Container.K8s.PodName),
+			helpers.String("container", notif.Container.K8s.ContainerName),
+			helpers.String("sbomName", sbomName))
+		return false
+	}
+	logger.L().Debug(retryMsg,
+		helpers.String("namespace", notif.Container.K8s.Namespace),
+		helpers.String("pod", notif.Container.K8s.PodName),
+		helpers.String("container", notif.Container.K8s.ContainerName),
+		helpers.String("sbomName", sbomName),
+		helpers.String("got version", wipSbom.Annotations[helpersv1.ToolVersionMetadataKey]),
+		helpers.String("expected version", s.version))
+	wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] = s.version
+	return true
+}
+
+// handleGenericFailure responds to a non-deterministic SBOM-generation failure (source
+// construction, syft cataloging, or sidecar scan error).
+//
+// If hadContent is true, we're reprocessing an SBOM that previously completed successfully;
+// wipSbom came from GetSBOMMeta, which returns metadata only (no Spec), so persisting it via
+// markSBOMStatus/ReplaceSBOM would silently wipe the existing, real SBOM content. In that case
+// the stored object is left untouched on failure -- the next container start simply retries.
+//
+// Otherwise, the SBOM never had real content (fresh reservation, or a previous attempt already
+// failed), so it's safe to persist -- but only after maxScanRetries consecutive failures, so a
+// single transient error doesn't permanently pin the image to Incomplete.
+func (s *SbomManager) handleGenericFailure(wipSbom *v1beta1.SBOMSyft, sbomName string, hadContent bool) {
+	if hadContent {
+		return
+	}
+	s.failureRetries[sbomName]++
+	if s.failureRetries[sbomName] < maxScanRetries {
+		return
+	}
+	delete(s.failureRetries, sbomName)
+	s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
 }
 
 // reportFailure sends a scan failure report to the backend via the failure reporter.

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -334,6 +334,27 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("expected version", s.version))
 			// update the version of the tool
 			wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] = s.version
+		// continue to create SBOM
+		case wipSbom.Annotations[helpersv1.StatusMetadataKey] == helpersv1.Incomplete:
+			// only skip if the SBOM was created with the same version of tool, so a fixed
+			// node-agent build still retries images that previously failed
+			if wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] == s.version {
+				logger.L().Debug("SbomManager - SBOM generation previously failed with this tool version, skipping",
+					helpers.String("namespace", notif.Container.K8s.Namespace),
+					helpers.String("pod", notif.Container.K8s.PodName),
+					helpers.String("container", notif.Container.K8s.ContainerName),
+					helpers.String("sbomName", sbomName))
+				return
+			}
+			logger.L().Debug("SbomManager - SBOM generation previously failed with a different tool version, retrying",
+				helpers.String("namespace", notif.Container.K8s.Namespace),
+				helpers.String("pod", notif.Container.K8s.PodName),
+				helpers.String("container", notif.Container.K8s.ContainerName),
+				helpers.String("sbomName", sbomName),
+				helpers.String("got version", wipSbom.Annotations[helpersv1.ToolVersionMetadataKey]),
+				helpers.String("expected version", s.version))
+			// update the version of the tool
+			wipSbom.Annotations[helpersv1.ToolVersionMetadataKey] = s.version
 			// continue to create SBOM
 		case wipSbom.Annotations[NodeNameMetadataKey] != s.cfg.NodeName:
 			logger.L().Debug("SbomManager - SBOM is already being processed by another node, skipping",
@@ -421,6 +442,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
+			s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, scanErr)
 			return
 		}
@@ -464,15 +486,10 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
 			if errors.Is(srcErr, syftutil.ErrImageTooLarge) {
-				delete(wipSbom.Annotations, NodeNameMetadataKey)
-				wipSbom.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
-				if _, replaceErr := s.storageClient.ReplaceSBOM(wipSbom); replaceErr != nil {
-					logger.L().Ctx(s.ctx).Error("SbomManager - failed to persist TooLarge SBOM",
-						helpers.Error(replaceErr),
-						helpers.String("sbomName", sbomName))
-				}
+				s.markSBOMStatus(wipSbom, sbomName, helpersv1.TooLarge)
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonImageTooLarge, srcErr)
 			} else {
+				s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, srcErr)
 			}
 			return
@@ -498,6 +515,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
+			s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, syftErr)
 			return
 		}
@@ -627,6 +645,20 @@ func (s *SbomManager) drainPendingScans() {
 		s.pool.Submit(func() {
 			s.processContainerWithMetadata(scan.notif, scan.mounts, scan.imageStatus, scan.imageTag, scan.imageID)
 		}, utils.FuncName(s.processContainerWithMetadata))
+	}
+}
+
+// markSBOMStatus persists the SBOM's terminal status (e.g. TooLarge, Incomplete) so a later
+// container start for the same image is handled by the matching case in
+// processContainerWithMetadata instead of retrying and failing indefinitely.
+func (s *SbomManager) markSBOMStatus(wipSbom *v1beta1.SBOMSyft, sbomName, status string) {
+	delete(wipSbom.Annotations, NodeNameMetadataKey)
+	wipSbom.Annotations[helpersv1.StatusMetadataKey] = status
+	if _, err := s.storageClient.ReplaceSBOM(wipSbom); err != nil {
+		logger.L().Ctx(s.ctx).Error("SbomManager - failed to persist SBOM status",
+			helpers.Error(err),
+			helpers.String("sbomName", sbomName),
+			helpers.String("status", status))
 	}
 }
 

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/distribution/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -62,6 +64,8 @@ const (
 	maxScanRetries                = 3
 	scannerReadinessCheckInterval = 5 * time.Second
 	maxPendingScans               = 1000
+	maxFailureRetryEntries        = 1000
+	failureRetryTTL               = 30 * time.Minute
 )
 
 // pendingScan holds the data needed to retry a container scan after the sidecar becomes ready.
@@ -88,12 +92,18 @@ type SbomManager struct {
 	scannerClient      sbomscanner.SBOMScannerClient
 	scannerMemLimit    int64
 	scanRetries        map[string]int // safe without mutex: only accessed from pool workers (pool size 1)
-	failureRetries     map[string]int // consecutive generic SBOM-generation failures per sbomName; safe without mutex: only accessed from pool workers (pool size 1)
-	pendingScans       map[string]pendingScan
-	pendingOrder       []string
-	pendingMu          sync.Mutex
-	failureReporter    sbommanager.SbomFailureReporter
-	metrics            metricsmanager.MetricsManager
+	// failureRetries tracks consecutive generic SBOM-generation failures per sbomName. Bounded
+	// + TTL'd so short-lived images don't leak entries; a side effect is that the count resets
+	// if two failures for the same image are spaced more than failureRetryTTL apart, so it
+	// bounds retries for a tight failure cadence (e.g. a crash loop) rather than every possible
+	// one -- a slow-cadence permanent failure (long-lived pod, infrequent CronJob) can still
+	// reprocess indefinitely without ever accumulating enough consecutive failures to pin.
+	failureRetries  *expirable.LRU[string, int]
+	pendingScans    map[string]pendingScan
+	pendingOrder    []string
+	pendingMu       sync.Mutex
+	failureReporter sbommanager.SbomFailureReporter
+	metrics         metricsmanager.MetricsManager
 }
 
 var _ sbommanager.SbomManagerClient = (*SbomManager)(nil)
@@ -142,7 +152,7 @@ func CreateSbomManager(ctx context.Context, cfg config.Config, socketPath string
 		scannerClient:      scannerClient,
 		scannerMemLimit:    scannerMemLimit,
 		scanRetries:        make(map[string]int),
-		failureRetries:     make(map[string]int),
+		failureRetries:     expirable.NewLRU[string, int](maxFailureRetryEntries, nil, failureRetryTTL),
 		pendingScans:       make(map[string]pendingScan),
 		failureReporter:    failureReporter,
 		metrics:            metrics,
@@ -285,12 +295,6 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		},
 	}
 	wipSbom, err = s.storageClient.CreateSBOM(wipSbom)
-	// wipSbomHadContent is true only when we're about to reprocess an SBOM that previously
-	// completed successfully (the Learning case below). GetSBOMMeta fetches metadata only, so
-	// wipSbom.Spec is empty here even though the stored object has real content -- if
-	// reprocessing fails, that content must be left untouched rather than wiped via
-	// markSBOMStatus/ReplaceSBOM. See handleGenericFailure.
-	var wipSbomHadContent bool
 	switch {
 	case k8serrors.IsAlreadyExists(err):
 		// get the existing SBOM metadata and check if it is ready or being processed by another node
@@ -329,7 +333,6 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				"SBOM was created with an different version of tool, recreating it") {
 				return
 			}
-			wipSbomHadContent = true
 			// continue to create SBOM
 		case wipSbom.Annotations[helpersv1.StatusMetadataKey] == helpersv1.Incomplete:
 			if !s.shouldRetryAtCurrentVersion(wipSbom, sbomName, notif,
@@ -413,7 +416,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				s.metrics.ObserveSBOMScanDuration("oom_killed", scanDuration)
 				s.metrics.ReportSBOMScannerRestart()
 				s.metrics.SetSBOMScannerReady(false)
-				s.handleScannerCrash(sbomName, wipSbom, notif, scanErr, imageTag, imageID, wipSbomHadContent)
+				s.handleScannerCrash(sbomName, notif, scanErr, imageTag, imageID)
 				return
 			}
 			s.metrics.ReportSBOMScan("error")
@@ -424,7 +427,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
-			s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
+			s.handleGenericFailure(sbomName)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, scanErr)
 			return
 		}
@@ -468,16 +471,10 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
 			if errors.Is(srcErr, syftutil.ErrImageTooLarge) {
-				// totalSize is computed from the currently-mounted layer paths (see
-				// syftutil.toLayers), not a fixed property of the image, so this can also
-				// fire while reprocessing a content-bearing SBOM -- guard it the same way
-				// as handleGenericFailure/handleScannerCrash.
-				if !wipSbomHadContent {
-					s.markSBOMStatus(wipSbom, sbomName, helpersv1.TooLarge)
-				}
+				s.markSBOMStatus(sbomName, helpersv1.TooLarge, nil)
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonImageTooLarge, srcErr)
 			} else {
-				s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
+				s.handleGenericFailure(sbomName)
 				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, srcErr)
 			}
 			return
@@ -503,7 +500,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("sbomName", sbomName))
-			s.handleGenericFailure(wipSbom, sbomName, wipSbomHadContent)
+			s.handleGenericFailure(sbomName)
 			s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonSBOMGenerationFailed, syftErr)
 			return
 		}
@@ -512,7 +509,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 	}
 
 	// prepare the SBOM
-	delete(s.failureRetries, sbomName)
+	s.failureRetries.Remove(sbomName)
 	delete(wipSbom.Annotations, NodeNameMetadataKey)
 	wipSbom.Spec.Metadata.Report.CreatedAt = wipSbom.CreationTimestamp
 	wipSbom.Spec.Metadata.Tool.Name = "syft"
@@ -565,11 +562,7 @@ func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcac
 }
 
 // handleScannerCrash responds to repeated sidecar OOM crashes while scanning the same image.
-// hadContent must be true when wipSbom is a GetSBOMMeta-sourced object for an SBOM that
-// previously completed successfully (see handleGenericFailure) -- in that case the Spec-clearing
-// ReplaceSBOM below is skipped so existing SBOM content is never destroyed by a crash loop
-// during a version-bump reprocess; only the failure is reported.
-func (s *SbomManager) handleScannerCrash(sbomName string, wipSbom *v1beta1.SBOMSyft, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string, hadContent bool) {
+func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string) {
 	s.scanRetries[sbomName]++
 	retryCount := s.scanRetries[sbomName]
 
@@ -583,17 +576,9 @@ func (s *SbomManager) handleScannerCrash(sbomName string, wipSbom *v1beta1.SBOMS
 		helpers.Int("maxRetries", maxScanRetries))
 
 	if retryCount >= maxScanRetries {
-		if !hadContent {
-			delete(wipSbom.Annotations, NodeNameMetadataKey)
-			wipSbom.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
-			wipSbom.Annotations[ScannerMemoryLimitAnnotation] = fmt.Sprintf("%d", s.scannerMemLimit)
-			wipSbom.Spec = v1beta1.SBOMSyftSpec{}
-			if _, replaceErr := s.storageClient.ReplaceSBOM(wipSbom); replaceErr != nil {
-				logger.L().Error("SbomManager - failed to mark SBOM as TooLarge after scanner crashes",
-					helpers.Error(replaceErr),
-					helpers.String("sbomName", sbomName))
-			}
-		}
+		s.markSBOMStatus(sbomName, helpersv1.TooLarge, map[string]any{
+			ScannerMemoryLimitAnnotation: fmt.Sprintf("%d", s.scannerMemLimit),
+		})
 		// Report OOM regardless of persist success — the user should know the scan failed
 		s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
 		delete(s.scanRetries, sbomName)
@@ -646,11 +631,17 @@ func (s *SbomManager) drainPendingScans() {
 
 // markSBOMStatus persists the SBOM's terminal status (e.g. TooLarge, Incomplete) so a later
 // container start for the same image is handled by the matching case in
-// processContainerWithMetadata instead of retrying and failing indefinitely.
-func (s *SbomManager) markSBOMStatus(wipSbom *v1beta1.SBOMSyft, sbomName, status string) {
-	delete(wipSbom.Annotations, NodeNameMetadataKey)
-	wipSbom.Annotations[helpersv1.StatusMetadataKey] = status
-	if _, err := s.storageClient.ReplaceSBOM(wipSbom); err != nil {
+// processContainerWithMetadata instead of retrying and failing indefinitely. It also records
+// the currently-running tool version alongside the status, since that's what determined the
+// outcome -- the Learning/Incomplete cases' version check relies on this being accurate.
+func (s *SbomManager) markSBOMStatus(sbomName, status string, extraAnnotations map[string]any) {
+	annotations := map[string]any{
+		NodeNameMetadataKey:              nil, // no longer owned by this node
+		helpersv1.StatusMetadataKey:      status,
+		helpersv1.ToolVersionMetadataKey: s.version,
+	}
+	maps.Copy(annotations, extraAnnotations)
+	if _, err := s.storageClient.PatchSBOMAnnotations(sbomName, annotations); err != nil {
 		logger.L().Ctx(s.ctx).Error("SbomManager - failed to persist SBOM status",
 			helpers.Error(err),
 			helpers.String("sbomName", sbomName),
@@ -683,26 +674,19 @@ func (s *SbomManager) shouldRetryAtCurrentVersion(wipSbom *v1beta1.SBOMSyft, sbo
 }
 
 // handleGenericFailure responds to a non-deterministic SBOM-generation failure (source
-// construction, syft cataloging, or sidecar scan error).
-//
-// If hadContent is true, we're reprocessing an SBOM that previously completed successfully;
-// wipSbom came from GetSBOMMeta, which returns metadata only (no Spec), so persisting it via
-// markSBOMStatus/ReplaceSBOM would silently wipe the existing, real SBOM content. In that case
-// the stored object is left untouched on failure -- the next container start simply retries.
-//
-// Otherwise, the SBOM never had real content (fresh reservation, or a previous attempt already
-// failed), so it's safe to persist -- but only after maxScanRetries consecutive failures, so a
-// single transient error doesn't permanently pin the image to Incomplete.
-func (s *SbomManager) handleGenericFailure(wipSbom *v1beta1.SBOMSyft, sbomName string, hadContent bool) {
-	if hadContent {
+// construction, syft cataloging, or sidecar scan error). markSBOMStatus only ever patches
+// annotations, never Spec, so it's always safe to call regardless of whether the SBOM
+// previously had real content -- but the image is only pinned Incomplete after
+// maxScanRetries consecutive failures, so a single transient error doesn't lose coverage.
+func (s *SbomManager) handleGenericFailure(sbomName string) {
+	count, _ := s.failureRetries.Get(sbomName)
+	count++
+	if count < maxScanRetries {
+		s.failureRetries.Add(sbomName, count)
 		return
 	}
-	s.failureRetries[sbomName]++
-	if s.failureRetries[sbomName] < maxScanRetries {
-		return
-	}
-	delete(s.failureRetries, sbomName)
-	s.markSBOMStatus(wipSbom, sbomName, helpersv1.Incomplete)
+	s.failureRetries.Remove(sbomName)
+	s.markSBOMStatus(sbomName, helpersv1.Incomplete, nil)
 }
 
 // reportFailure sends a scan failure report to the backend via the failure reporter.

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -1,0 +1,155 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/names"
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/metricsmanager"
+	sbomscanner "github.com/kubescape/node-agent/pkg/sbomscanner/v1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// fakeSbomClient is an in-memory storage.SbomClient used to observe how
+// processContainerWithMetadata persists SBOM state across repeated calls.
+type fakeSbomClient struct {
+	mu           sync.Mutex
+	sboms        map[string]*v1beta1.SBOMSyft
+	replaceCalls int
+}
+
+func newFakeSbomClient() *fakeSbomClient {
+	return &fakeSbomClient{sboms: map[string]*v1beta1.SBOMSyft{}}
+}
+
+func (f *fakeSbomClient) CreateSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.sboms[sbom.Name]; ok {
+		return nil, k8serrors.NewAlreadyExists(schema.GroupResource{Resource: "sbomsyfts"}, sbom.Name)
+	}
+	f.sboms[sbom.Name] = sbom.DeepCopy()
+	return sbom, nil
+}
+
+func (f *fakeSbomClient) GetSBOMMeta(name string) (*v1beta1.SBOMSyft, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if s, ok := f.sboms[name]; ok {
+		return s.DeepCopy(), nil
+	}
+	return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sbomsyfts"}, name)
+}
+
+func (f *fakeSbomClient) ReplaceSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.replaceCalls++
+	f.sboms[sbom.Name] = sbom.DeepCopy()
+	return sbom, nil
+}
+
+// fakeScannerClient is a sbomscanner.SBOMScannerClient that always fails, used to
+// deterministically drive processContainerWithMetadata into its generic
+// SBOM-generation-failure branch without depending on real image/digest parsing.
+type fakeScannerClient struct{ err error }
+
+func (f *fakeScannerClient) CreateSBOM(_ context.Context, _ sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+	return nil, f.err
+}
+func (f *fakeScannerClient) Ready() bool  { return true }
+func (f *fakeScannerClient) Close() error { return nil }
+
+func newTestManager(fake *fakeSbomClient, version string) *SbomManager {
+	return &SbomManager{
+		cfg:           config.Config{NodeName: "node-1"},
+		ctx:           context.Background(),
+		processing:    mapset.NewSet[string](),
+		storageClient: fake,
+		scannerClient: &fakeScannerClient{err: errors.New("scan failed")},
+		metrics:       metricsmanager.NewMetricsNoop(),
+		version:       version,
+	}
+}
+
+func testNotifAndImageStatus() (containercollection.PubSubEvent, *runtime.ImageStatusResponse, string, string) {
+	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
+	imageID := "sha256:94cbbb94f8d6bdf2529d5f9c5279ac4c7411182f4e8e5a3d0b5e8f10a465f73a"
+	notif := containercollection.PubSubEvent{
+		Container: &containercollection.Container{
+			Runtime: containercollection.RuntimeMetadata{
+				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+					ContainerID:        "container-1",
+					ContainerImageName: imageTag,
+				},
+			},
+			K8s: containercollection.K8sMetadata{
+				BasicK8sMetadata: types.BasicK8sMetadata{
+					Namespace:     "default",
+					PodName:       "pod-1",
+					ContainerName: "container-1",
+				},
+			},
+		},
+	}
+	imageStatus := &runtime.ImageStatusResponse{
+		Image: &runtime.Image{
+			Id:       "img-id",
+			RepoTags: []string{imageTag},
+		},
+		Info: map[string]string{"info": `{"imageSpec":{}}`},
+	}
+	return notif, imageStatus, imageTag, imageID
+}
+
+// Test_processContainerWithMetadata_IncompleteReprocessing guards against the
+// SBOM-generation-failure reprocessing loop: a generic failure must persist the SBOM
+// as Incomplete so a later container start for the same image skips reprocessing at
+// the same tool version, instead of retrying and re-failing indefinitely.
+func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
+	fake := newFakeSbomClient()
+	mgr := newTestManager(fake, "v1.0.0")
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	// First attempt: SBOM generation fails, must persist as Incomplete instead of
+	// being left dangling in Initializing.
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+
+	stored, err := fake.GetSBOMMeta(sbomName)
+	assert.NoError(t, err)
+	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, "v1.0.0", stored.Annotations[helpersv1.ToolVersionMetadataKey])
+	assert.Equal(t, 1, fake.replaceCalls)
+
+	// Second attempt at the same tool version: this is the exact bug being fixed --
+	// previously the SBOM stayed in Initializing/no-terminal-status and fell through
+	// to the "processing was interrupted, retrying" default case on every container
+	// start. It must now be skipped without touching storage again.
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	assert.Equal(t, 1, fake.replaceCalls, "second attempt at the same tool version must not reprocess")
+
+	// Third attempt with a different tool version: a fixed/updated node-agent build
+	// must still retry previously-failed images, not pin them to Incomplete forever.
+	mgr.version = "v2.0.0"
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	assert.Equal(t, 2, fake.replaceCalls, "a different tool version must retry")
+
+	stored, err = fake.GetSBOMMeta(sbomName)
+	assert.NoError(t, err)
+	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, "v2.0.0", stored.Annotations[helpersv1.ToolVersionMetadataKey])
+}

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -3,12 +3,14 @@ package v1
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
@@ -30,10 +32,14 @@ import (
 // which fetches with metav1.GetOptions{ResourceVersion: softwarecomposition.ResourceVersionMetadata}
 // and therefore returns the object's metadata WITHOUT its Spec. Tests that rely on Spec
 // being present on a GetSBOMMeta result would hide the exact bug this fake is meant to catch.
+//
+// PatchSBOMAnnotations mirrors the real Storage.PatchSBOMAnnotations contract: it only ever
+// modifies the stored object's Annotations map (nil value deletes the key), never its Spec.
 type fakeSbomClient struct {
 	mu           sync.Mutex
 	sboms        map[string]*v1beta1.SBOMSyft
 	replaceCalls int
+	patchCalls   int
 }
 
 func newFakeSbomClient() *fakeSbomClient {
@@ -70,6 +76,27 @@ func (f *fakeSbomClient) ReplaceSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft,
 	return sbom, nil
 }
 
+func (f *fakeSbomClient) PatchSBOMAnnotations(name string, annotations map[string]any) (*v1beta1.SBOMSyft, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.patchCalls++
+	s, ok := f.sboms[name]
+	if !ok {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sbomsyfts"}, name)
+	}
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	for k, v := range annotations {
+		if v == nil {
+			delete(s.Annotations, k)
+			continue
+		}
+		s.Annotations[k] = fmt.Sprintf("%v", v)
+	}
+	return s.DeepCopy(), nil
+}
+
 func (f *fakeSbomClient) get(name string) *v1beta1.SBOMSyft {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -87,6 +114,10 @@ func (f *fakeScannerClient) CreateSBOM(_ context.Context, _ sbomscanner.ScanRequ
 func (f *fakeScannerClient) Ready() bool  { return true }
 func (f *fakeScannerClient) Close() error { return nil }
 
+func newFailureRetries() *expirable.LRU[string, int] {
+	return expirable.NewLRU[string, int](maxFailureRetryEntries, nil, failureRetryTTL)
+}
+
 func newTestManager(fake *fakeSbomClient, version string) *SbomManager {
 	return newTestManagerWithScannerErr(fake, version, errors.New("scan failed"))
 }
@@ -101,7 +132,7 @@ func newTestManagerWithScannerErr(fake *fakeSbomClient, version string, scannerE
 		metrics:        metricsmanager.NewMetricsNoop(),
 		version:        version,
 		scanRetries:    make(map[string]int),
-		failureRetries: make(map[string]int),
+		failureRetries: newFailureRetries(),
 	}
 }
 
@@ -115,7 +146,7 @@ func newTestManagerInProcess(fake *fakeSbomClient, version string, maxImageSize 
 		storageClient:  fake,
 		version:        version,
 		scanRetries:    make(map[string]int),
-		failureRetries: make(map[string]int),
+		failureRetries: newFailureRetries(),
 	}
 }
 
@@ -173,6 +204,7 @@ func testNotifAndImageStatus() (containercollection.PubSubEvent, *runtime.ImageS
 // only be pinned Incomplete after maxScanRetries consecutive failures (so a single transient
 // error doesn't permanently lose SBOM coverage), after which a later container start at the
 // same tool version must skip reprocessing instead of retrying and re-failing indefinitely.
+// Marking must go through PatchSBOMAnnotations (annotations only), never a full ReplaceSBOM.
 func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 	fake := newFakeSbomClient()
 	mgr := newTestManager(fake, "v1.0.0")
@@ -186,21 +218,22 @@ func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 	for range maxScanRetries - 1 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	}
-	assert.Equal(t, 0, fake.replaceCalls, "failures below the retry threshold must not mark Incomplete")
+	assert.Equal(t, 0, fake.patchCalls, "failures below the retry threshold must not mark Incomplete")
 	assert.Equal(t, helpersv1.Initializing, fake.get(sbomName).Annotations[helpersv1.StatusMetadataKey])
 
-	// The maxScanRetries-th consecutive failure must persist Incomplete.
+	// The maxScanRetries-th consecutive failure must persist Incomplete via a patch.
 	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	stored := fake.get(sbomName)
 	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
 	assert.Equal(t, "v1.0.0", stored.Annotations[helpersv1.ToolVersionMetadataKey])
-	assert.Equal(t, 1, fake.replaceCalls)
+	assert.Equal(t, 1, fake.patchCalls)
+	assert.Equal(t, 0, fake.replaceCalls, "failure marking must never use a full ReplaceSBOM")
 
 	// A later attempt at the same tool version must be skipped without touching storage
 	// again -- this is the exact bug being fixed: previously the SBOM stayed dangling with
 	// no terminal status and was reprocessed on every container start forever.
 	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
-	assert.Equal(t, 1, fake.replaceCalls, "the same tool version must not reprocess")
+	assert.Equal(t, 1, fake.patchCalls, "the same tool version must not reprocess")
 
 	// A different tool version must retry -- a fixed/updated node-agent build gets a fresh
 	// maxScanRetries budget instead of being pinned to Incomplete forever.
@@ -208,9 +241,9 @@ func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 	for range maxScanRetries - 1 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	}
-	assert.Equal(t, 1, fake.replaceCalls, "a version bump must not immediately re-pin Incomplete")
+	assert.Equal(t, 1, fake.patchCalls, "a version bump must not immediately re-pin Incomplete")
 	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
-	assert.Equal(t, 2, fake.replaceCalls)
+	assert.Equal(t, 2, fake.patchCalls)
 
 	stored = fake.get(sbomName)
 	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
@@ -219,9 +252,10 @@ func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 
 // Test_processContainerWithMetadata_PreservesContentOnReprocessFailure guards against
 // silently wiping a previously-successful SBOM. GetSBOMMeta (used to fetch the SBOM on the
-// reprocessing path, e.g. after a tool-version bump) returns metadata only, with no Spec --
-// persisting that stripped object on a failed reprocess would destroy the existing, real SBOM
-// content and permanently lose vulnerability-scan coverage for the image.
+// reprocessing path, e.g. after a tool-version bump) returns metadata only, with no Spec.
+// Marking a repeatedly-failing content-bearing SBOM Incomplete must go through
+// PatchSBOMAnnotations, which never sends Spec, so the existing artifacts survive even though
+// the status/tool-version annotations do get updated once the retry budget is exhausted.
 func Test_processContainerWithMetadata_PreservesContentOnReprocessFailure(t *testing.T) {
 	fake := newFakeSbomClient()
 	mgr := newTestManager(fake, "v2.0.0")
@@ -240,29 +274,27 @@ func Test_processContainerWithMetadata_PreservesContentOnReprocessFailure(t *tes
 	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
 	fake.sboms[sbomName] = good
 
-	// A container start at the new version triggers reprocessing (version mismatch); the
-	// scan then fails (mgr's scanner always errors). The stored SBOM's real content and
-	// status must survive untouched -- reprocessing a content-bearing SBOM must never call
-	// ReplaceSBOM on failure, regardless of the retry budget.
+	// A container start at the new version triggers reprocessing (version mismatch); the scan
+	// then fails (mgr's scanner always errors) on every subsequent attempt. Once the retry
+	// budget is exhausted the SBOM is pinned Incomplete, and further attempts at that recorded
+	// version are skipped -- but the artifacts must survive throughout, since marking never
+	// uses a full ReplaceSBOM.
 	for range maxScanRetries + 2 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	}
 
 	raw := fake.get(sbomName)
-	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by a failed reprocess")
-	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
-	// The stored object is never persisted on this path (see handleGenericFailure), so even
-	// the tool-version bump that triggered the retry is not recorded -- only a successful
-	// reprocess would update it. The image keeps retrying on every container start until
-	// then, which is the accepted trade-off for never risking existing content.
-	assert.Equal(t, "v1.0.0", raw.Annotations[helpersv1.ToolVersionMetadataKey], "storage is untouched, so the original recorded version is unchanged")
-	assert.Equal(t, 0, fake.replaceCalls, "a failed reprocess of a content-bearing SBOM must never touch storage")
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, "v2.0.0", raw.Annotations[helpersv1.ToolVersionMetadataKey])
+	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive failure marks Incomplete; later attempts must skip")
+	assert.Equal(t, 0, fake.replaceCalls, "failure marking must never use a full ReplaceSBOM")
 }
 
 // Test_processContainerWithMetadata_PreservesContentOnScannerCrash is the handleScannerCrash
 // counterpart to Test_processContainerWithMetadata_PreservesContentOnReprocessFailure: repeated
-// sidecar OOM crashes while reprocessing a content-bearing SBOM must not clear its Spec and
-// pin it to TooLarge, the same class of data loss as a generic scan/source/syft error.
+// sidecar OOM crashes while reprocessing a content-bearing SBOM must pin it to TooLarge via an
+// annotation-only patch, never a full ReplaceSBOM that would clear its Spec.
 func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing.T) {
 	fake := newFakeSbomClient()
 	mgr := newTestManagerWithScannerErr(fake, "v2.0.0", sbomscanner.ErrScannerCrashed)
@@ -281,23 +313,25 @@ func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing
 	fake.sboms[sbomName] = good
 
 	// Each container start triggers reprocessing (version mismatch) and the sidecar
-	// "crashes" (ErrScannerCrashed); handleScannerCrash's own maxScanRetries threshold would
-	// normally pin the SBOM to TooLarge with an empty Spec after this many crashes.
+	// "crashes" (ErrScannerCrashed); handleScannerCrash's own maxScanRetries threshold pins
+	// the SBOM to TooLarge once exhausted, after which further attempts are skipped.
 	for range maxScanRetries + 2 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	}
 
 	raw := fake.get(sbomName)
-	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by a scanner crash loop")
-	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
-	assert.Equal(t, 0, fake.replaceCalls, "a scanner crash loop on a content-bearing SBOM must never touch storage")
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
+	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive crash marks TooLarge; later attempts must skip")
+	assert.Equal(t, 0, fake.replaceCalls, "scanner-crash marking must never use a full ReplaceSBOM")
 }
 
 // Test_processContainerWithMetadata_PreservesContentOnTooLarge is the ErrImageTooLarge
 // counterpart to the other content-preservation tests: totalSize in syftutil.toLayers is
 // computed from the currently-mounted layer paths, not a fixed property of the image, so a
-// content-bearing SBOM being reprocessed can also hit ErrImageTooLarge and must not have its
-// existing content wiped.
+// content-bearing SBOM being reprocessed can also hit ErrImageTooLarge. Unlike the generic
+// failure/crash paths, ErrImageTooLarge is marked immediately (no retry budget), but must
+// still go through PatchSBOMAnnotations so the existing content is never wiped.
 func Test_processContainerWithMetadata_PreservesContentOnTooLarge(t *testing.T) {
 	fake := newFakeSbomClient()
 	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
@@ -323,7 +357,8 @@ func Test_processContainerWithMetadata_PreservesContentOnTooLarge(t *testing.T) 
 	mgr.processContainerWithMetadata(notif, mounts, imageStatus, imageTag, imageID)
 
 	raw := fake.get(sbomName)
-	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by an ErrImageTooLarge reprocess")
-	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
-	assert.Equal(t, 0, fake.replaceCalls, "an ErrImageTooLarge reprocess of a content-bearing SBOM must never touch storage")
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
+	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, 1, fake.patchCalls)
+	assert.Equal(t, 0, fake.replaceCalls, "ErrImageTooLarge marking must never use a full ReplaceSBOM")
 }

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -3,6 +3,8 @@ package v1
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -23,6 +25,11 @@ import (
 
 // fakeSbomClient is an in-memory storage.SbomClient used to observe how
 // processContainerWithMetadata persists SBOM state across repeated calls.
+//
+// GetSBOMMeta mirrors the real Storage.GetSBOMMeta contract (pkg/storage/v1/storage.go),
+// which fetches with metav1.GetOptions{ResourceVersion: softwarecomposition.ResourceVersionMetadata}
+// and therefore returns the object's metadata WITHOUT its Spec. Tests that rely on Spec
+// being present on a GetSBOMMeta result would hide the exact bug this fake is meant to catch.
 type fakeSbomClient struct {
 	mu           sync.Mutex
 	sboms        map[string]*v1beta1.SBOMSyft
@@ -46,10 +53,13 @@ func (f *fakeSbomClient) CreateSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, 
 func (f *fakeSbomClient) GetSBOMMeta(name string) (*v1beta1.SBOMSyft, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if s, ok := f.sboms[name]; ok {
-		return s.DeepCopy(), nil
+	s, ok := f.sboms[name]
+	if !ok {
+		return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sbomsyfts"}, name)
 	}
-	return nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "sbomsyfts"}, name)
+	meta := s.DeepCopy()
+	meta.Spec = v1beta1.SBOMSyftSpec{} // metadata-only fetch: mirrors the real API server
+	return meta, nil
 }
 
 func (f *fakeSbomClient) ReplaceSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error) {
@@ -60,9 +70,15 @@ func (f *fakeSbomClient) ReplaceSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft,
 	return sbom, nil
 }
 
-// fakeScannerClient is a sbomscanner.SBOMScannerClient that always fails, used to
-// deterministically drive processContainerWithMetadata into its generic
-// SBOM-generation-failure branch without depending on real image/digest parsing.
+func (f *fakeSbomClient) get(name string) *v1beta1.SBOMSyft {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sboms[name].DeepCopy()
+}
+
+// fakeScannerClient is a sbomscanner.SBOMScannerClient that always fails with a fixed error,
+// used to deterministically drive processContainerWithMetadata into a specific failure branch
+// without depending on real image/digest parsing.
 type fakeScannerClient struct{ err error }
 
 func (f *fakeScannerClient) CreateSBOM(_ context.Context, _ sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
@@ -72,15 +88,54 @@ func (f *fakeScannerClient) Ready() bool  { return true }
 func (f *fakeScannerClient) Close() error { return nil }
 
 func newTestManager(fake *fakeSbomClient, version string) *SbomManager {
+	return newTestManagerWithScannerErr(fake, version, errors.New("scan failed"))
+}
+
+func newTestManagerWithScannerErr(fake *fakeSbomClient, version string, scannerErr error) *SbomManager {
 	return &SbomManager{
-		cfg:           config.Config{NodeName: "node-1"},
-		ctx:           context.Background(),
-		processing:    mapset.NewSet[string](),
-		storageClient: fake,
-		scannerClient: &fakeScannerClient{err: errors.New("scan failed")},
-		metrics:       metricsmanager.NewMetricsNoop(),
-		version:       version,
+		cfg:            config.Config{NodeName: "node-1"},
+		ctx:            context.Background(),
+		processing:     mapset.NewSet[string](),
+		storageClient:  fake,
+		scannerClient:  &fakeScannerClient{err: scannerErr},
+		metrics:        metricsmanager.NewMetricsNoop(),
+		version:        version,
+		scanRetries:    make(map[string]int),
+		failureRetries: make(map[string]int),
 	}
+}
+
+// newTestManagerInProcess builds a manager with no scanner sidecar configured, so
+// processContainerWithMetadata takes the in-process (syftutil.NewSource) fallback path.
+func newTestManagerInProcess(fake *fakeSbomClient, version string, maxImageSize int64) *SbomManager {
+	return &SbomManager{
+		cfg:            config.Config{NodeName: "node-1", MaxImageSize: maxImageSize},
+		ctx:            context.Background(),
+		processing:     mapset.NewSet[string](),
+		storageClient:  fake,
+		version:        version,
+		scanRetries:    make(map[string]int),
+		failureRetries: make(map[string]int),
+	}
+}
+
+// testImageStatusWithLayer builds an ImageStatusResponse with one valid diff-id and a mount
+// pointing to a real temp directory containing a file, so syftutil.toLayers computes a
+// non-zero totalSize and NewSource can be driven into ErrImageTooLarge via a small MaxImageSize.
+func testImageStatusWithLayer(t *testing.T, imageTag string) (*runtime.ImageStatusResponse, []string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "layer.tar"), make([]byte, 1024), 0o644); err != nil {
+		t.Fatalf("failed to write test layer file: %v", err)
+	}
+	imageStatus := &runtime.ImageStatusResponse{
+		Image: &runtime.Image{
+			Id:       "img-id",
+			RepoTags: []string{imageTag},
+		},
+		Info: map[string]string{"info": `{"imageSpec":{"rootfs":{"type":"layers","diff_ids":["sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]}}}`},
+	}
+	return imageStatus, []string{dir}
 }
 
 func testNotifAndImageStatus() (containercollection.PubSubEvent, *runtime.ImageStatusResponse, string, string) {
@@ -114,9 +169,10 @@ func testNotifAndImageStatus() (containercollection.PubSubEvent, *runtime.ImageS
 }
 
 // Test_processContainerWithMetadata_IncompleteReprocessing guards against the
-// SBOM-generation-failure reprocessing loop: a generic failure must persist the SBOM
-// as Incomplete so a later container start for the same image skips reprocessing at
-// the same tool version, instead of retrying and re-failing indefinitely.
+// SBOM-generation-failure reprocessing loop: a fresh reservation that keeps failing must
+// only be pinned Incomplete after maxScanRetries consecutive failures (so a single transient
+// error doesn't permanently lose SBOM coverage), after which a later container start at the
+// same tool version must skip reprocessing instead of retrying and re-failing indefinitely.
 func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 	fake := newFakeSbomClient()
 	mgr := newTestManager(fake, "v1.0.0")
@@ -125,31 +181,149 @@ func Test_processContainerWithMetadata_IncompleteReprocessing(t *testing.T) {
 	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
 	assert.NoError(t, err)
 
-	// First attempt: SBOM generation fails, must persist as Incomplete instead of
-	// being left dangling in Initializing.
-	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	// Failures below the retry threshold must not touch storage -- this is what makes
+	// transient errors (a brief sidecar blip, a registry hiccup) self-healing.
+	for range maxScanRetries - 1 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+	assert.Equal(t, 0, fake.replaceCalls, "failures below the retry threshold must not mark Incomplete")
+	assert.Equal(t, helpersv1.Initializing, fake.get(sbomName).Annotations[helpersv1.StatusMetadataKey])
 
-	stored, err := fake.GetSBOMMeta(sbomName)
-	assert.NoError(t, err)
+	// The maxScanRetries-th consecutive failure must persist Incomplete.
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	stored := fake.get(sbomName)
 	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
 	assert.Equal(t, "v1.0.0", stored.Annotations[helpersv1.ToolVersionMetadataKey])
 	assert.Equal(t, 1, fake.replaceCalls)
 
-	// Second attempt at the same tool version: this is the exact bug being fixed --
-	// previously the SBOM stayed in Initializing/no-terminal-status and fell through
-	// to the "processing was interrupted, retrying" default case on every container
-	// start. It must now be skipped without touching storage again.
+	// A later attempt at the same tool version must be skipped without touching storage
+	// again -- this is the exact bug being fixed: previously the SBOM stayed dangling with
+	// no terminal status and was reprocessed on every container start forever.
 	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
-	assert.Equal(t, 1, fake.replaceCalls, "second attempt at the same tool version must not reprocess")
+	assert.Equal(t, 1, fake.replaceCalls, "the same tool version must not reprocess")
 
-	// Third attempt with a different tool version: a fixed/updated node-agent build
-	// must still retry previously-failed images, not pin them to Incomplete forever.
+	// A different tool version must retry -- a fixed/updated node-agent build gets a fresh
+	// maxScanRetries budget instead of being pinned to Incomplete forever.
 	mgr.version = "v2.0.0"
+	for range maxScanRetries - 1 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+	assert.Equal(t, 1, fake.replaceCalls, "a version bump must not immediately re-pin Incomplete")
 	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
-	assert.Equal(t, 2, fake.replaceCalls, "a different tool version must retry")
+	assert.Equal(t, 2, fake.replaceCalls)
 
-	stored, err = fake.GetSBOMMeta(sbomName)
-	assert.NoError(t, err)
+	stored = fake.get(sbomName)
 	assert.Equal(t, helpersv1.Incomplete, stored.Annotations[helpersv1.StatusMetadataKey])
 	assert.Equal(t, "v2.0.0", stored.Annotations[helpersv1.ToolVersionMetadataKey])
+}
+
+// Test_processContainerWithMetadata_PreservesContentOnReprocessFailure guards against
+// silently wiping a previously-successful SBOM. GetSBOMMeta (used to fetch the SBOM on the
+// reprocessing path, e.g. after a tool-version bump) returns metadata only, with no Spec --
+// persisting that stripped object on a failed reprocess would destroy the existing, real SBOM
+// content and permanently lose vulnerability-scan coverage for the image.
+func Test_processContainerWithMetadata_PreservesContentOnReprocessFailure(t *testing.T) {
+	fake := newFakeSbomClient()
+	mgr := newTestManager(fake, "v2.0.0")
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	// Seed a previously-successful SBOM, created by an older tool version, with real content.
+	good := &v1beta1.SBOMSyft{}
+	good.Name = sbomName
+	good.Annotations = map[string]string{
+		helpersv1.StatusMetadataKey:      helpersv1.Learning,
+		helpersv1.ToolVersionMetadataKey: "v1.0.0",
+	}
+	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
+	fake.sboms[sbomName] = good
+
+	// A container start at the new version triggers reprocessing (version mismatch); the
+	// scan then fails (mgr's scanner always errors). The stored SBOM's real content and
+	// status must survive untouched -- reprocessing a content-bearing SBOM must never call
+	// ReplaceSBOM on failure, regardless of the retry budget.
+	for range maxScanRetries + 2 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+
+	raw := fake.get(sbomName)
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by a failed reprocess")
+	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
+	// The stored object is never persisted on this path (see handleGenericFailure), so even
+	// the tool-version bump that triggered the retry is not recorded -- only a successful
+	// reprocess would update it. The image keeps retrying on every container start until
+	// then, which is the accepted trade-off for never risking existing content.
+	assert.Equal(t, "v1.0.0", raw.Annotations[helpersv1.ToolVersionMetadataKey], "storage is untouched, so the original recorded version is unchanged")
+	assert.Equal(t, 0, fake.replaceCalls, "a failed reprocess of a content-bearing SBOM must never touch storage")
+}
+
+// Test_processContainerWithMetadata_PreservesContentOnScannerCrash is the handleScannerCrash
+// counterpart to Test_processContainerWithMetadata_PreservesContentOnReprocessFailure: repeated
+// sidecar OOM crashes while reprocessing a content-bearing SBOM must not clear its Spec and
+// pin it to TooLarge, the same class of data loss as a generic scan/source/syft error.
+func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing.T) {
+	fake := newFakeSbomClient()
+	mgr := newTestManagerWithScannerErr(fake, "v2.0.0", sbomscanner.ErrScannerCrashed)
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	good := &v1beta1.SBOMSyft{}
+	good.Name = sbomName
+	good.Annotations = map[string]string{
+		helpersv1.StatusMetadataKey:      helpersv1.Learning,
+		helpersv1.ToolVersionMetadataKey: "v1.0.0",
+	}
+	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
+	fake.sboms[sbomName] = good
+
+	// Each container start triggers reprocessing (version mismatch) and the sidecar
+	// "crashes" (ErrScannerCrashed); handleScannerCrash's own maxScanRetries threshold would
+	// normally pin the SBOM to TooLarge with an empty Spec after this many crashes.
+	for range maxScanRetries + 2 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+
+	raw := fake.get(sbomName)
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by a scanner crash loop")
+	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
+	assert.Equal(t, 0, fake.replaceCalls, "a scanner crash loop on a content-bearing SBOM must never touch storage")
+}
+
+// Test_processContainerWithMetadata_PreservesContentOnTooLarge is the ErrImageTooLarge
+// counterpart to the other content-preservation tests: totalSize in syftutil.toLayers is
+// computed from the currently-mounted layer paths, not a fixed property of the image, so a
+// content-bearing SBOM being reprocessed can also hit ErrImageTooLarge and must not have its
+// existing content wiped.
+func Test_processContainerWithMetadata_PreservesContentOnTooLarge(t *testing.T) {
+	fake := newFakeSbomClient()
+	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
+	imageID := "sha256:94cbbb94f8d6bdf2529d5f9c5279ac4c7411182f4e8e5a3d0b5e8f10a465f73a"
+	imageStatus, mounts := testImageStatusWithLayer(t, imageTag)
+	// MaxImageSize (1 byte) smaller than the seeded layer file guarantees NewSource returns
+	// ErrImageTooLarge.
+	mgr := newTestManagerInProcess(fake, "v2.0.0", 1)
+	notif, _, _, _ := testNotifAndImageStatus()
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	good := &v1beta1.SBOMSyft{}
+	good.Name = sbomName
+	good.Annotations = map[string]string{
+		helpersv1.StatusMetadataKey:      helpersv1.Learning,
+		helpersv1.ToolVersionMetadataKey: "v1.0.0",
+	}
+	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
+	fake.sboms[sbomName] = good
+
+	mgr.processContainerWithMetadata(notif, mounts, imageStatus, imageTag, imageID)
+
+	raw := fake.get(sbomName)
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must not be wiped by an ErrImageTooLarge reprocess")
+	assert.Equal(t, helpersv1.Learning, raw.Annotations[helpersv1.StatusMetadataKey], "status must be left untouched on failure")
+	assert.Equal(t, 0, fake.replaceCalls, "an ErrImageTooLarge reprocess of a content-bearing SBOM must never touch storage")
 }

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -292,9 +292,11 @@ func Test_processContainerWithMetadata_PreservesContentOnReprocessFailure(t *tes
 }
 
 // Test_processContainerWithMetadata_PreservesContentOnScannerCrash is the handleScannerCrash
-// counterpart to Test_processContainerWithMetadata_PreservesContentOnReprocessFailure: repeated
-// sidecar OOM crashes while reprocessing a content-bearing SBOM must pin it to TooLarge via an
-// annotation-only patch, never a full ReplaceSBOM that would clear its Spec.
+// counterpart to Test_processContainerWithMetadata_PreservesContentOnReprocessFailure. TooLarge
+// is a one-way door in the storage layer (all future writes to a TooLarge object are silently
+// dropped server-side), so repeated sidecar OOM crashes while reprocessing a content-bearing
+// SBOM must pin it to Incomplete (safely retryable) instead of TooLarge, via an annotation-only
+// patch that never touches its Spec.
 func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing.T) {
 	fake := newFakeSbomClient()
 	mgr := newTestManagerWithScannerErr(fake, "v2.0.0", sbomscanner.ErrScannerCrashed)
@@ -314,31 +316,32 @@ func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing
 
 	// Each container start triggers reprocessing (version mismatch) and the sidecar
 	// "crashes" (ErrScannerCrashed); handleScannerCrash's own maxScanRetries threshold pins
-	// the SBOM to TooLarge once exhausted, after which further attempts are skipped.
+	// the SBOM to Incomplete once exhausted, after which further attempts are skipped.
 	for range maxScanRetries + 2 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 	}
 
 	raw := fake.get(sbomName)
 	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
-	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey])
-	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive crash marks TooLarge; later attempts must skip")
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey], "content-bearing SBOMs must never be pinned TooLarge, a storage-layer one-way door")
+	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive crash marks Incomplete; later attempts must skip")
 	assert.Equal(t, 0, fake.replaceCalls, "scanner-crash marking must never use a full ReplaceSBOM")
 }
 
 // Test_processContainerWithMetadata_PreservesContentOnTooLarge is the ErrImageTooLarge
 // counterpart to the other content-preservation tests: totalSize in syftutil.toLayers is
 // computed from the currently-mounted layer paths, not a fixed property of the image, so a
-// content-bearing SBOM being reprocessed can also hit ErrImageTooLarge. Unlike the generic
-// failure/crash paths, ErrImageTooLarge is marked immediately (no retry budget), but must
-// still go through PatchSBOMAnnotations so the existing content is never wiped.
+// content-bearing SBOM being reprocessed can also hit ErrImageTooLarge. TooLarge is a one-way
+// door in the storage layer, so a content-bearing SBOM must never be pinned to it -- instead
+// this is treated as a generic (retryable, eventually Incomplete) failure, same as any other
+// generic error, and always through PatchSBOMAnnotations so existing content is never wiped.
 func Test_processContainerWithMetadata_PreservesContentOnTooLarge(t *testing.T) {
 	fake := newFakeSbomClient()
 	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
 	imageID := "sha256:94cbbb94f8d6bdf2529d5f9c5279ac4c7411182f4e8e5a3d0b5e8f10a465f73a"
 	imageStatus, mounts := testImageStatusWithLayer(t, imageTag)
 	// MaxImageSize (1 byte) smaller than the seeded layer file guarantees NewSource returns
-	// ErrImageTooLarge.
+	// ErrImageTooLarge on every attempt.
 	mgr := newTestManagerInProcess(fake, "v2.0.0", 1)
 	notif, _, _, _ := testNotifAndImageStatus()
 
@@ -354,11 +357,35 @@ func Test_processContainerWithMetadata_PreservesContentOnTooLarge(t *testing.T) 
 	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
 	fake.sboms[sbomName] = good
 
-	mgr.processContainerWithMetadata(notif, mounts, imageStatus, imageTag, imageID)
+	for range maxScanRetries + 2 {
+		mgr.processContainerWithMetadata(notif, mounts, imageStatus, imageTag, imageID)
+	}
 
 	raw := fake.get(sbomName)
 	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
-	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey])
-	assert.Equal(t, 1, fake.patchCalls)
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey], "content-bearing SBOMs must never be pinned TooLarge, a storage-layer one-way door")
+	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive failure marks Incomplete; later attempts must skip")
 	assert.Equal(t, 0, fake.replaceCalls, "ErrImageTooLarge marking must never use a full ReplaceSBOM")
+}
+
+// Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediately guards the unchanged
+// half of the ErrImageTooLarge behavior: an image with no prior content (a fresh reservation)
+// is still marked TooLarge immediately, with no retry budget -- TooLarge's storage-layer
+// one-way door is only a problem when it freezes real content, which a content-free SBOM
+// never had to begin with.
+func Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediately(t *testing.T) {
+	fake := newFakeSbomClient()
+	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
+	imageStatus, mounts := testImageStatusWithLayer(t, imageTag)
+	mgr := newTestManagerInProcess(fake, "v2.0.0", 1)
+	notif, _, _, imageID := testNotifAndImageStatus()
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	mgr.processContainerWithMetadata(notif, mounts, imageStatus, imageTag, imageID)
+
+	stored := fake.get(sbomName)
+	assert.Equal(t, helpersv1.TooLarge, stored.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, 1, fake.patchCalls, "a fresh reservation must mark TooLarge on the first occurrence, with no retry budget")
 }

--- a/pkg/storage/storage_interface.go
+++ b/pkg/storage/storage_interface.go
@@ -26,6 +26,11 @@ type SbomClient interface {
 	CreateSBOM(SBOM *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error)
 	GetSBOMMeta(name string) (*v1beta1.SBOMSyft, error)
 	ReplaceSBOM(SBOM *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error)
+	// PatchSBOMAnnotations updates only metadata.annotations via a merge patch, never sending
+	// spec. A nil value for a key deletes that annotation. Safe to call regardless of whether
+	// the caller holds the SBOM's real spec (e.g. after a metadata-only GetSBOMMeta fetch),
+	// since spec is never part of the patch payload.
+	PatchSBOMAnnotations(name string, annotations map[string]any) (*v1beta1.SBOMSyft, error)
 }
 
 type StorageClient interface {

--- a/pkg/storage/storage_mock.go
+++ b/pkg/storage/storage_mock.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
@@ -78,14 +79,31 @@ func (sc *StorageHttpClientMock) ReplaceSBOM(SBOM *v1beta1.SBOMSyft) (*v1beta1.S
 	return SBOM, nil
 }
 
+func (sc *StorageHttpClientMock) PatchSBOMAnnotations(_ string, annotations map[string]any) (*v1beta1.SBOMSyft, error) {
+	if sc.mockSBOM == nil {
+		return nil, nil
+	}
+	if sc.mockSBOM.Annotations == nil {
+		sc.mockSBOM.Annotations = map[string]string{}
+	}
+	for k, v := range annotations {
+		if v == nil {
+			delete(sc.mockSBOM.Annotations, k)
+			continue
+		}
+		sc.mockSBOM.Annotations[k] = fmt.Sprintf("%v", v)
+	}
+	return sc.mockSBOM, nil
+}
+
 // SeccompProfileClientMock is a mock implementation of SeccompProfileClient for testing
 type SeccompProfileClientMock struct {
-	Profiles      []*v1beta1.SeccompProfile
-	WatchEvents   chan watch.Event
-	WatchStopped  bool
-	GetError      error
-	ListError     error
-	WatchError    error
+	Profiles     []*v1beta1.SeccompProfile
+	WatchEvents  chan watch.Event
+	WatchStopped bool
+	GetError     error
+	ListError    error
+	WatchError   error
 }
 
 var _ SeccompProfileClient = (*SeccompProfileClientMock)(nil)

--- a/pkg/storage/v1/storage.go
+++ b/pkg/storage/v1/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -19,6 +20,7 @@ import (
 	"github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/generated/clientset/versioned/typed/softwarecomposition/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,6 +102,18 @@ func (sc *Storage) GetStorageClient() spdxv1beta1.SpdxV1beta1Interface {
 
 func (sc *Storage) ReplaceSBOM(SBOM *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error) {
 	return sc.storageClient.SBOMSyfts(sc.namespace).Update(context.Background(), SBOM, metav1.UpdateOptions{})
+}
+
+func (sc *Storage) PatchSBOMAnnotations(name string, annotations map[string]any) (*v1beta1.SBOMSyft, error) {
+	patch, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": annotations,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sc.storageClient.SBOMSyfts(sc.namespace).Patch(context.Background(), name, types.MergePatchType, patch, metav1.PatchOptions{})
 }
 
 func (sc *Storage) modifyName(n string) string {


### PR DESCRIPTION
## Overview
SBOM-generation failures (sidecar scan error, invalid/unparseable image source, syft cataloging error, oversized image) are reported via `reportFailure`, but the reserved SBOM object was never marked with a terminal status. Since the reprocessing switch in `processContainerWithMetadata` only special-cased `TooLarge` and `Learning`, a permanently-failing image fell through to the `default:` "processing was interrupted, retrying" branch and was silently reprocessed on **every** subsequent container start — repeated identical error logs and repeated backend failure reports, forever.

## What changed
- **Bounded retries for content-free images**: a new `Incomplete` case in the reprocessing switch, version-gated like the existing `Learning` case, plus a `failureRetries` counter (`handleGenericFailure`) that only pins an image `Incomplete` after `maxScanRetries` (3) *consecutive* failures — a single transient error (a sidecar blip, a registry hiccup) is self-healing, not permanent. `failureRetries` is a bounded, TTL'd `expirable.LRU` (1000 entries, 30 min) rather than a plain map, so it doesn't leak entries for images seen once and never again.
- **Content preservation**: marking a terminal status now goes through a new `storage.SbomClient.PatchSBOMAnnotations` — a JSON merge patch on `metadata.annotations` only, which structurally can never send `spec`. This matters because the reprocessing path fetches the SBOM via `GetSBOMMeta`, which the storage layer returns **without its Spec** (a metadata-only fetch) — persisting that object via a full `ReplaceSBOM` would silently destroy a previously-successful SBOM's real content (its CVE-scan data) the moment a later reprocess attempt failed. All SBOM-generation failure paths (generic scan/source/syft errors, repeated sidecar OOM crashes, and `ErrImageTooLarge`) now go through this patch-based marking, so retries are bounded uniformly whether or not the image previously had content — no separate case for "already had good data" is needed anymore.

## Residual trade-off (documented, not fixed here)
`failureRetries`' TTL resets on every write, so the retry count only accumulates for failures spaced under 30 minutes apart. This fully closes the loop for the reported symptom (a tight failure/crash-loop cadence) but a permanent failure recurring more slowly than that (e.g. an infrequently-restarted long-lived pod) could in principle still reprocess indefinitely without ever hitting 3 *consecutive* failures. Flagged for follow-up if it turns out to matter in practice.

## Additional Information
This is a **pre-existing, independent defect** discovered while working on #853/#854 (the digest-panic crash fix) — it already affected ordinary syft SBOM-generation failures, unrelated to digests. It's deliberately split into its own PR to keep each change minimal and independently reviewable, and does not depend on #854.

## How to Test
```
go build ./...
go vet ./...
go test ./pkg/sbommanager/... ./pkg/storage/...
```
`Test_processContainerWithMetadata_IncompleteReprocessing` reproduces the bounded-retry behavior: `maxScanRetries-1` failures don't touch storage, the `maxScanRetries`-th does, and a version bump grants a fresh retry budget. `Test_processContainerWithMetadata_PreservesContentOn{ReprocessFailure,ScannerCrash,TooLarge}` seed a content-bearing SBOM and drive each failure path past its retry threshold, asserting the SBOM's real content survives (only its annotations change) — each was verified to actually fail (reproducing the underlying data-loss bug) when its corresponding fix is reverted.

## Related issues/PRs
* Follow-up to #854 (fix for #853) — same root investigation, split out as an independent, pre-existing defect.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes




## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing SBOM content when reprocessing fails, including scanner crashes and oversized images.
  * Improved retry handling for repeated SBOM-generation failures.
  * Prevented unnecessary reprocessing when the tool version has not changed.
  * Reset retry behavior when a new tool version is detected.
  * SBOMs are now marked incomplete only after repeated failures without existing content.

* **Tests**
  * Added coverage for retry limits, version changes, scanner crashes, oversized images, and content preservation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM reprocessing reliability by retrying transient generation failures before marking results incomplete.
  * Preserved previously generated SBOM content when later scans fail, including scanner crashes and image-size errors.
  * Prevented repeated retries when an SBOM has already been marked incomplete for the current tool version.
  * Reset retry handling when the scanning tool version changes.
  * Freshly detected images that exceed size limits are now marked accordingly without unnecessary retries.
  * Updated status changes to avoid overwriting existing SBOM content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->