### PR TITLE
fix: unify SBOM scan-retry budgets to bound total attempts

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -91,13 +91,17 @@ type SbomManager struct {
 	version            string
 	scannerClient      sbomscanner.SBOMScannerClient
 	scannerMemLimit    int64
-	scanRetries        map[string]int // safe without mutex: only accessed from pool workers (pool size 1)
-	// failureRetries tracks consecutive generic SBOM-generation failures per sbomName. Bounded
-	// + TTL'd so short-lived images don't leak entries; a side effect is that the count resets
-	// if two failures for the same image are spaced more than failureRetryTTL apart, so it
-	// bounds retries for a tight failure cadence (e.g. a crash loop) rather than every possible
-	// one -- a slow-cadence permanent failure (long-lived pod, infrequent CronJob) can still
-	// reprocess indefinitely without ever accumulating enough consecutive failures to pin.
+	// failureRetries tracks consecutive SBOM-generation failures per sbomName, governing BOTH
+	// generic-failure (handleGenericFailure) and scanner-crash (handleScannerCrash) counting under
+	// the same TTL-reset policy -- see incrementFailureCount, the single source of truth for both.
+	// Previously scanner-crash counting lived in an untimed map that accumulated indefinitely
+	// across arbitrary time gaps; unifying onto this LRU means it now inherits the same 30-min
+	// TTL-reset that generic failures already had. That is an intentional consistency choice, not
+	// an oversight. Bounded + TTL'd so short-lived images don't leak entries; a side effect is that
+	// the count resets if two failures for the same image are spaced more than failureRetryTTL
+	// apart, so it bounds retries for a tight failure cadence (e.g. a crash loop) rather than every
+	// possible one -- a slow-cadence permanent failure (long-lived pod, infrequent CronJob) can
+	// still reprocess indefinitely without ever accumulating enough consecutive failures to pin.
 	failureRetries  *expirable.LRU[string, int]
 	pendingScans    map[string]pendingScan
 	pendingOrder    []string
@@ -151,7 +155,6 @@ func CreateSbomManager(ctx context.Context, cfg config.Config, socketPath string
 		version:            packageVersion("github.com/anchore/syft"),
 		scannerClient:      scannerClient,
 		scannerMemLimit:    scannerMemLimit,
-		scanRetries:        make(map[string]int),
 		failureRetries:     expirable.NewLRU[string, int](maxFailureRetryEntries, nil, failureRetryTTL),
 		pendingScans:       make(map[string]pendingScan),
 		failureReporter:    failureReporter,
@@ -443,7 +446,6 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		}
 		s.metrics.ReportSBOMScan("success")
 		s.metrics.ObserveSBOMScanDuration("success", time.Since(scanStart))
-		delete(s.scanRetries, sbomName)
 		syftDoc = result.SyftDocument
 	} else if s.scannerClient != nil {
 		s.metrics.SetSBOMScannerReady(false)
@@ -582,9 +584,19 @@ func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcac
 // (see the wipSbomHadContent doc comment in processContainerWithMetadata) -- in that case the
 // terminal status is Incomplete rather than TooLarge, since TooLarge is a one-way door in the
 // storage layer that would permanently freeze the SBOM's existing content.
+//
+// The retry budget is now shared with handleGenericFailure via incrementFailureCount, so
+// terminal-status classification (Incomplete vs TooLarge) is attempt-attributed: whichever
+// handler's call crosses the combined threshold decides the status based on that specific
+// attempt, not a blended view of prior mixed-category attempts. Safety is preserved by the
+// hadContent gate in this same function -- content-bearing SBOMs are always pinned Incomplete,
+// never TooLarge, regardless of which handler crossed the threshold, so TooLarge's one-way-door
+// risk to real content is never in play. The one residual edge is honest to disclose: a
+// contentless SBOM can occasionally reach TooLarge via a mix of generic+crash failures (rather
+// than 3 pure crashes). That is harmless -- a contentless TooLarge freezes no real content --
+// and is not a new risk introduced by unifying the counter.
 func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string, hadContent bool) {
-	s.scanRetries[sbomName]++
-	retryCount := s.scanRetries[sbomName]
+	retryCount := s.incrementFailureCount(sbomName)
 
 	logger.L().Error("SbomManager - SBOM scanner sidecar crashed during scan",
 		helpers.Error(scanErr),
@@ -605,7 +617,6 @@ func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollect
 		}
 		// Report OOM regardless of persist success — the user should know the scan failed
 		s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
-		delete(s.scanRetries, sbomName)
 	}
 }
 
@@ -697,19 +708,32 @@ func (s *SbomManager) shouldRetryAtCurrentVersion(wipSbom *v1beta1.SBOMSyft, sbo
 	return true
 }
 
+// incrementFailureCount increments the shared per-sbomName failure budget (used by both
+// handleGenericFailure and handleScannerCrash) and returns the new count. Once the count
+// reaches maxScanRetries the LRU entry is removed, so a later successful attempt or a tool
+// version bump starts with a fresh budget.
+func (s *SbomManager) incrementFailureCount(sbomName string) int {
+	count, _ := s.failureRetries.Get(sbomName)
+	count++
+	if count >= maxScanRetries {
+		s.failureRetries.Remove(sbomName)
+	} else {
+		s.failureRetries.Add(sbomName, count)
+	}
+	return count
+}
+
 // handleGenericFailure responds to a non-deterministic SBOM-generation failure (source
 // construction, syft cataloging, or sidecar scan error). markSBOMStatus only ever patches
 // annotations, never Spec, so it's always safe to call regardless of whether the SBOM
 // previously had real content -- but the image is only pinned Incomplete after
 // maxScanRetries consecutive failures, so a single transient error doesn't lose coverage.
+// The retry budget is shared with handleScannerCrash via incrementFailureCount, so failures
+// alternating between generic and scanner-crash categories count against the same budget.
 func (s *SbomManager) handleGenericFailure(sbomName string) {
-	count, _ := s.failureRetries.Get(sbomName)
-	count++
-	if count < maxScanRetries {
-		s.failureRetries.Add(sbomName, count)
+	if s.incrementFailureCount(sbomName) < maxScanRetries {
 		return
 	}
-	s.failureRetries.Remove(sbomName)
 	s.markSBOMStatus(sbomName, helpersv1.Incomplete, nil)
 }
 

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -66,6 +66,11 @@ const (
 	maxPendingScans               = 1000
 	maxFailureRetryEntries        = 1000
 	failureRetryTTL               = 30 * time.Minute
+	// crashLoopRetryTTL is deliberately much longer than failureRetryTTL: a sidecar OOM crash
+	// stalls the shared scanner for every image on the node, so a chronically-crashing image
+	// with restarts spaced further apart than failureRetryTTL must still eventually be pinned,
+	// or it can stall the node's scanning indefinitely.
+	crashLoopRetryTTL = 24 * time.Hour
 )
 
 // pendingScan holds the data needed to retry a container scan after the sidecar becomes ready.
@@ -91,23 +96,22 @@ type SbomManager struct {
 	version            string
 	scannerClient      sbomscanner.SBOMScannerClient
 	scannerMemLimit    int64
-	// failureRetries tracks consecutive SBOM-generation failures per sbomName, governing BOTH
-	// generic-failure (handleGenericFailure) and scanner-crash (handleScannerCrash) counting under
-	// the same TTL-reset policy -- see incrementFailureCount, the single source of truth for both.
-	// Previously scanner-crash counting lived in an untimed map that accumulated indefinitely
-	// across arbitrary time gaps; unifying onto this LRU means it now inherits the same 30-min
-	// TTL-reset that generic failures already had. That is an intentional consistency choice, not
-	// an oversight. Bounded + TTL'd so short-lived images don't leak entries; a side effect is that
-	// the count resets if two failures for the same image are spaced more than failureRetryTTL
-	// apart, so it bounds retries for a tight failure cadence (e.g. a crash loop) rather than every
-	// possible one -- a slow-cadence permanent failure (long-lived pod, infrequent CronJob) can
-	// still reprocess indefinitely without ever accumulating enough consecutive failures to pin.
-	failureRetries  *expirable.LRU[string, int]
-	pendingScans    map[string]pendingScan
-	pendingOrder    []string
-	pendingMu       sync.Mutex
-	failureReporter sbommanager.SbomFailureReporter
-	metrics         metricsmanager.MetricsManager
+	// failureRetries is the combined per-sbomName failure budget shared by handleGenericFailure
+	// and handleScannerCrash via incrementFailureCount, bounding total mixed-category attempts
+	// to maxScanRetries. TTL'd so short-lived images don't leak entries; a failure gap wider than
+	// failureRetryTTL resets the count, so this bounds a tight failure cadence, not every possible
+	// one. Crossing this threshold alone never produces TooLarge -- see crashLoopRetries.
+	failureRetries *expirable.LRU[string, int]
+	// crashLoopRetries counts scanner crashes per sbomName (handleScannerCrash only, unaffected
+	// by interleaved generic failures), on crashLoopRetryTTL rather than failureRetryTTL, so it
+	// is the sole path to a TooLarge classification and survives the wider gaps a slow-cadence
+	// crash loop needs.
+	crashLoopRetries *expirable.LRU[string, int]
+	pendingScans     map[string]pendingScan
+	pendingOrder     []string
+	pendingMu        sync.Mutex
+	failureReporter  sbommanager.SbomFailureReporter
+	metrics          metricsmanager.MetricsManager
 }
 
 var _ sbommanager.SbomManagerClient = (*SbomManager)(nil)
@@ -156,6 +160,7 @@ func CreateSbomManager(ctx context.Context, cfg config.Config, socketPath string
 		scannerClient:      scannerClient,
 		scannerMemLimit:    scannerMemLimit,
 		failureRetries:     expirable.NewLRU[string, int](maxFailureRetryEntries, nil, failureRetryTTL),
+		crashLoopRetries:   expirable.NewLRU[string, int](maxFailureRetryEntries, nil, crashLoopRetryTTL),
 		pendingScans:       make(map[string]pendingScan),
 		failureReporter:    failureReporter,
 		metrics:            metrics,
@@ -528,6 +533,7 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 
 	// prepare the SBOM
 	s.failureRetries.Remove(sbomName)
+	s.crashLoopRetries.Remove(sbomName)
 	delete(wipSbom.Annotations, NodeNameMetadataKey)
 	wipSbom.Spec.Metadata.Report.CreatedAt = wipSbom.CreationTimestamp
 	wipSbom.Spec.Metadata.Tool.Name = "syft"
@@ -585,18 +591,13 @@ func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcac
 // terminal status is Incomplete rather than TooLarge, since TooLarge is a one-way door in the
 // storage layer that would permanently freeze the SBOM's existing content.
 //
-// The retry budget is now shared with handleGenericFailure via incrementFailureCount, so
-// terminal-status classification (Incomplete vs TooLarge) is attempt-attributed: whichever
-// handler's call crosses the combined threshold decides the status based on that specific
-// attempt, not a blended view of prior mixed-category attempts. Safety is preserved by the
-// hadContent gate in this same function -- content-bearing SBOMs are always pinned Incomplete,
-// never TooLarge, regardless of which handler crossed the threshold, so TooLarge's one-way-door
-// risk to real content is never in play. The one residual edge is honest to disclose: a
-// contentless SBOM can occasionally reach TooLarge via a mix of generic+crash failures (rather
-// than 3 pure crashes). That is harmless -- a contentless TooLarge freezes no real content --
-// and is not a new risk introduced by unifying the counter.
+// TooLarge is only reachable via crashLoopRetries, the dedicated crash-only backstop -- a pin
+// triggered by the shared failureRetries budget alone (which may include generic failures) always
+// falls back to Incomplete, since a threshold crossing that includes even one non-crash failure
+// isn't evidence the image doesn't fit in the scanner's memory limit.
 func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollection.PubSubEvent, scanErr error, imageTag, imageID string, hadContent bool) {
 	retryCount := s.incrementFailureCount(sbomName)
+	crashLoopCount := s.incrementCrashLoopCount(sbomName)
 
 	logger.L().Error("SbomManager - SBOM scanner sidecar crashed during scan",
 		helpers.Error(scanErr),
@@ -605,19 +606,23 @@ func (s *SbomManager) handleScannerCrash(sbomName string, notif containercollect
 		helpers.String("container", notif.Container.K8s.ContainerName),
 		helpers.String("sbomName", sbomName),
 		helpers.Int("retryCount", retryCount),
+		helpers.Int("crashLoopCount", crashLoopCount),
 		helpers.Int("maxRetries", maxScanRetries))
 
-	if retryCount >= maxScanRetries {
-		if hadContent {
-			s.markSBOMStatus(sbomName, helpersv1.Incomplete, nil)
-		} else {
-			s.markSBOMStatus(sbomName, helpersv1.TooLarge, map[string]any{
-				ScannerMemoryLimitAnnotation: fmt.Sprintf("%d", s.scannerMemLimit),
-			})
-		}
-		// Report OOM regardless of persist success — the user should know the scan failed
-		s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
+	crashLoopTriggered := crashLoopCount >= maxScanRetries
+	if retryCount < maxScanRetries && !crashLoopTriggered {
+		return
 	}
+
+	if !hadContent && crashLoopTriggered {
+		s.markSBOMStatus(sbomName, helpersv1.TooLarge, map[string]any{
+			ScannerMemoryLimitAnnotation: fmt.Sprintf("%d", s.scannerMemLimit),
+		})
+	} else {
+		s.markSBOMStatus(sbomName, helpersv1.Incomplete, nil)
+	}
+	// Report OOM regardless of persist success — the user should know the scan failed
+	s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonScannerOOMKilled, scanErr)
 }
 
 func (s *SbomManager) startScannerReadinessWatcher() {
@@ -709,9 +714,10 @@ func (s *SbomManager) shouldRetryAtCurrentVersion(wipSbom *v1beta1.SBOMSyft, sbo
 }
 
 // incrementFailureCount increments the shared per-sbomName failure budget (used by both
-// handleGenericFailure and handleScannerCrash) and returns the new count. Once the count
-// reaches maxScanRetries the LRU entry is removed, so a later successful attempt or a tool
-// version bump starts with a fresh budget.
+// handleGenericFailure and handleScannerCrash) and returns the new count. The entry is removed
+// once count reaches maxScanRetries so the pin only fires once per threshold crossing -- a fresh
+// budget afterward comes from a successful scan (which resets it explicitly on the success path)
+// or the TTL simply expiring; a tool-version bump alone does not touch this LRU.
 func (s *SbomManager) incrementFailureCount(sbomName string) int {
 	count, _ := s.failureRetries.Get(sbomName)
 	count++
@@ -719,6 +725,22 @@ func (s *SbomManager) incrementFailureCount(sbomName string) int {
 		s.failureRetries.Remove(sbomName)
 	} else {
 		s.failureRetries.Add(sbomName, count)
+	}
+	return count
+}
+
+// incrementCrashLoopCount increments the long-TTL, crash-only backstop counter for sbomName and
+// returns the new count. Every scanner crash increments this alongside incrementFailureCount, but
+// unlike that shared budget, this one never mixes in generic failures and never expires within
+// the timescale of a typical restart gap, so a crash loop with sparse cadence still accumulates
+// to a pin instead of resetting indefinitely.
+func (s *SbomManager) incrementCrashLoopCount(sbomName string) int {
+	count, _ := s.crashLoopRetries.Get(sbomName)
+	count++
+	if count >= maxScanRetries {
+		s.crashLoopRetries.Remove(sbomName)
+	} else {
+		s.crashLoopRetries.Add(sbomName, count)
 	}
 	return count
 }

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -574,13 +574,18 @@ func Test_processContainerWithMetadata_CrashLoopBackstopSurvivesSparseCadence(t 
 		version:          "v2.0.0",
 		scannerMemLimit:  4096,
 		failureRetries:   expirable.NewLRU[string, int](maxFailureRetryEntries, nil, 5*time.Millisecond),
-		crashLoopRetries: expirable.NewLRU[string, int](maxFailureRetryEntries, nil, 500*time.Millisecond),
+		crashLoopRetries: expirable.NewLRU[string, int](maxFailureRetryEntries, nil, 5*time.Second),
 	}
 
 	for i := range 3 {
 		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
 		if i < 2 {
-			time.Sleep(20 * time.Millisecond) // exceeds the 5ms failureRetries TTL, well inside the 500ms crashLoopRetries TTL
+			// exceeds the 5ms failureRetries TTL; crashLoopRetries' 5s TTL is never waited on by
+			// this test (only failureRetries needs to actually expire), so it's set generously
+			// wide to rule out a GC pause or a loaded CI runner expiring it and flipping the
+			// assertion to Incomplete -- a confusing false failure that would look like a
+			// regression rather than a runner hiccup.
+			time.Sleep(20 * time.Millisecond)
 		}
 	}
 

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
@@ -118,20 +119,25 @@ func newFailureRetries() *expirable.LRU[string, int] {
 	return expirable.NewLRU[string, int](maxFailureRetryEntries, nil, failureRetryTTL)
 }
 
+func newCrashLoopRetries() *expirable.LRU[string, int] {
+	return expirable.NewLRU[string, int](maxFailureRetryEntries, nil, crashLoopRetryTTL)
+}
+
 func newTestManager(fake *fakeSbomClient, version string) *SbomManager {
 	return newTestManagerWithScannerErr(fake, version, errors.New("scan failed"))
 }
 
 func newTestManagerWithScannerErr(fake *fakeSbomClient, version string, scannerErr error) *SbomManager {
 	return &SbomManager{
-		cfg:            config.Config{NodeName: "node-1"},
-		ctx:            context.Background(),
-		processing:     mapset.NewSet[string](),
-		storageClient:  fake,
-		scannerClient:  &fakeScannerClient{err: scannerErr},
-		metrics:        metricsmanager.NewMetricsNoop(),
-		version:        version,
-		failureRetries: newFailureRetries(),
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		scannerClient:    &fakeScannerClient{err: scannerErr},
+		metrics:          metricsmanager.NewMetricsNoop(),
+		version:          version,
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
 	}
 }
 
@@ -139,12 +145,13 @@ func newTestManagerWithScannerErr(fake *fakeSbomClient, version string, scannerE
 // processContainerWithMetadata takes the in-process (syftutil.NewSource) fallback path.
 func newTestManagerInProcess(fake *fakeSbomClient, version string, maxImageSize int64) *SbomManager {
 	return &SbomManager{
-		cfg:            config.Config{NodeName: "node-1", MaxImageSize: maxImageSize},
-		ctx:            context.Background(),
-		processing:     mapset.NewSet[string](),
-		storageClient:  fake,
-		version:        version,
-		failureRetries: newFailureRetries(),
+		cfg:              config.Config{NodeName: "node-1", MaxImageSize: maxImageSize},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		version:          version,
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
 	}
 }
 
@@ -370,14 +377,15 @@ func Test_processContainerWithMetadata_MixedFailureCategoriesShareBudget(t *test
 	fake.sboms[sbomName] = good
 
 	mgr := &SbomManager{
-		cfg:            config.Config{NodeName: "node-1"},
-		ctx:            context.Background(),
-		processing:     mapset.NewSet[string](),
-		storageClient:  fake,
-		scannerClient:  &alternatingScannerClient{},
-		metrics:        metricsmanager.NewMetricsNoop(),
-		version:        "v2.0.0",
-		failureRetries: newFailureRetries(),
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		scannerClient:    &alternatingScannerClient{},
+		metrics:          metricsmanager.NewMetricsNoop(),
+		version:          "v2.0.0",
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
 	}
 
 	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
@@ -459,4 +467,124 @@ func Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediately(t *tes
 	stored := fake.get(sbomName)
 	assert.Equal(t, helpersv1.TooLarge, stored.Annotations[helpersv1.StatusMetadataKey])
 	assert.Equal(t, 1, fake.patchCalls, "a fresh reservation must mark TooLarge on the first occurrence, with no retry budget")
+}
+
+// genericThenCrashScannerClient returns a generic error on its first two calls, then
+// sbomscanner.ErrScannerCrashed on the third -- used to reproduce the exact mixed-failure
+// sequence from the review finding on PR #857 (2 generic failures + 1 crash).
+type genericThenCrashScannerClient struct{ calls int }
+
+func (a *genericThenCrashScannerClient) CreateSBOM(_ context.Context, _ sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+	a.calls++
+	if a.calls < 3 {
+		return nil, errors.New("scan failed")
+	}
+	return nil, sbomscanner.ErrScannerCrashed
+}
+func (a *genericThenCrashScannerClient) Ready() bool  { return true }
+func (a *genericThenCrashScannerClient) Close() error { return nil }
+
+// Test_processContainerWithMetadata_MixedFailureCategoriesPinIncomplete is the regression test
+// for the review blocker on PR #857: a contentless image (hadContent == false, no prior
+// successful scan) that reaches the shared threshold via two generic failures plus a single
+// scanner crash must be pinned Incomplete, not TooLarge -- TooLarge is only reachable when
+// crashLoopRetries' crash-only backstop itself crosses the threshold, which one crash does not.
+func Test_processContainerWithMetadata_MixedFailureCategoriesPinIncomplete(t *testing.T) {
+	fake := newFakeSbomClient()
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	mgr := &SbomManager{
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		scannerClient:    &genericThenCrashScannerClient{},
+		metrics:          metricsmanager.NewMetricsNoop(),
+		version:          "v2.0.0",
+		scannerMemLimit:  1024,
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
+	}
+
+	for range 3 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+
+	raw := fake.get(sbomName)
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey], "a mix of generic failures and a single crash must never be classified TooLarge")
+	_, hasMemLimitAnnotation := raw.Annotations[ScannerMemoryLimitAnnotation]
+	assert.False(t, hasMemLimitAnnotation, "the TooLarge-only memory-limit annotation must not be set on an Incomplete pin")
+}
+
+// Test_processContainerWithMetadata_MarksContentlessImageTooLargeOnPureCrashLoop guards the
+// still-supported TooLarge path: a contentless image (no prior successful scan) that crashes the
+// scanner sidecar 3 consecutive times with no interleaved generic failures must still be pinned
+// TooLarge, with the scanner memory limit recorded -- this is the signal crashLoopRetries exists
+// to preserve.
+func Test_processContainerWithMetadata_MarksContentlessImageTooLargeOnPureCrashLoop(t *testing.T) {
+	fake := newFakeSbomClient()
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	mgr := &SbomManager{
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		scannerClient:    &fakeScannerClient{err: sbomscanner.ErrScannerCrashed},
+		metrics:          metricsmanager.NewMetricsNoop(),
+		version:          "v2.0.0",
+		scannerMemLimit:  2048,
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
+	}
+
+	for range 3 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+
+	raw := fake.get(sbomName)
+	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, "2048", raw.Annotations[ScannerMemoryLimitAnnotation])
+}
+
+// Test_processContainerWithMetadata_CrashLoopBackstopSurvivesSparseCadence is the regression test
+// for review finding #2 on PR #857: a chronically-crashing image whose restarts are spaced wider
+// apart than failureRetryTTL must still eventually be pinned, via crashLoopRetries' longer TTL,
+// even though the shared failureRetries budget keeps expiring and never itself reaches
+// maxScanRetries. A short-TTL failureRetries and a longer-but-still-short crashLoopRetries are
+// constructed directly (rather than via the production TTL constants) so the test can force real
+// expiry with millisecond-scale sleeps instead of waiting on failureRetryTTL/crashLoopRetryTTL.
+func Test_processContainerWithMetadata_CrashLoopBackstopSurvivesSparseCadence(t *testing.T) {
+	fake := newFakeSbomClient()
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	mgr := &SbomManager{
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              context.Background(),
+		processing:       mapset.NewSet[string](),
+		storageClient:    fake,
+		scannerClient:    &fakeScannerClient{err: sbomscanner.ErrScannerCrashed},
+		metrics:          metricsmanager.NewMetricsNoop(),
+		version:          "v2.0.0",
+		scannerMemLimit:  4096,
+		failureRetries:   expirable.NewLRU[string, int](maxFailureRetryEntries, nil, 5*time.Millisecond),
+		crashLoopRetries: expirable.NewLRU[string, int](maxFailureRetryEntries, nil, 500*time.Millisecond),
+	}
+
+	for i := range 3 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+		if i < 2 {
+			time.Sleep(20 * time.Millisecond) // exceeds the 5ms failureRetries TTL, well inside the 500ms crashLoopRetries TTL
+		}
+	}
+
+	raw := fake.get(sbomName)
+	assert.Equal(t, helpersv1.TooLarge, raw.Annotations[helpersv1.StatusMetadataKey], "the crash-only backstop must still pin TooLarge even though the shared budget kept expiring between crashes")
+	assert.Equal(t, "4096", raw.Annotations[ScannerMemoryLimitAnnotation])
 }

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -131,7 +131,6 @@ func newTestManagerWithScannerErr(fake *fakeSbomClient, version string, scannerE
 		scannerClient:  &fakeScannerClient{err: scannerErr},
 		metrics:        metricsmanager.NewMetricsNoop(),
 		version:        version,
-		scanRetries:    make(map[string]int),
 		failureRetries: newFailureRetries(),
 	}
 }
@@ -145,7 +144,6 @@ func newTestManagerInProcess(fake *fakeSbomClient, version string, maxImageSize 
 		processing:     mapset.NewSet[string](),
 		storageClient:  fake,
 		version:        version,
-		scanRetries:    make(map[string]int),
 		failureRetries: newFailureRetries(),
 	}
 }
@@ -326,6 +324,79 @@ func Test_processContainerWithMetadata_PreservesContentOnScannerCrash(t *testing
 	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey], "content-bearing SBOMs must never be pinned TooLarge, a storage-layer one-way door")
 	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive crash marks Incomplete; later attempts must skip")
 	assert.Equal(t, 0, fake.replaceCalls, "scanner-crash marking must never use a full ReplaceSBOM")
+}
+
+// alternatingScannerClient is a sbomscanner.SBOMScannerClient that alternates its returned
+// error between a generic error and sbomscanner.ErrScannerCrashed on successive CreateSBOM
+// calls (even calls -> generic error, odd calls -> scanner crash). It lets a test drive
+// processContainerWithMetadata through mixed failure categories in a deterministic order.
+type alternatingScannerClient struct {
+	calls int
+}
+
+func (a *alternatingScannerClient) CreateSBOM(_ context.Context, _ sbomscanner.ScanRequest) (*sbomscanner.ScanResult, error) {
+	a.calls++
+	if a.calls%2 == 0 {
+		return nil, errors.New("scan failed")
+	}
+	return nil, sbomscanner.ErrScannerCrashed
+}
+func (a *alternatingScannerClient) Ready() bool  { return true }
+func (a *alternatingScannerClient) Close() error { return nil }
+
+// Test_processContainerWithMetadata_MixedFailureCategoriesShareBudget is the regression test for
+// issue #856. Before the fix, generic failures and scanner crashes each had an independent
+// counter compared against maxScanRetries, so an image alternating between the two categories
+// could take up to 5-6 attempts before reaching a terminal status. With the counters unified
+// onto a single shared budget (incrementFailureCount), the SBOM must be pinned at exactly the
+// 3rd COMBINED attempt across mixed failure categories.
+func Test_processContainerWithMetadata_MixedFailureCategoriesShareBudget(t *testing.T) {
+	fake := newFakeSbomClient()
+	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
+	imageID := "sha256:94cbbb94f8d6bdf2529d5f9c5279ac4c7411182f4e8e5a3d0b5e8f10a465f73a"
+
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	// Seed a previously-successful, content-bearing SBOM created by an older tool version so
+	// every call triggers reprocessing (version mismatch).
+	good := &v1beta1.SBOMSyft{}
+	good.Name = sbomName
+	good.Annotations = map[string]string{
+		helpersv1.StatusMetadataKey:      helpersv1.Learning,
+		helpersv1.ToolVersionMetadataKey: "v1.0.0",
+	}
+	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
+	fake.sboms[sbomName] = good
+
+	mgr := &SbomManager{
+		cfg:            config.Config{NodeName: "node-1"},
+		ctx:            context.Background(),
+		processing:     mapset.NewSet[string](),
+		storageClient:  fake,
+		scannerClient:  &alternatingScannerClient{},
+		metrics:        metricsmanager.NewMetricsNoop(),
+		version:        "v2.0.0",
+		failureRetries: newFailureRetries(),
+	}
+
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+
+	// The first two mixed-category failures must stay below the shared threshold and never
+	// touch storage.
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	assert.Equal(t, 0, fake.patchCalls, "the first two combined failures must not mark a terminal status")
+
+	// The 3rd combined attempt crosses the shared budget and pins the SBOM Incomplete -- proving
+	// the counters are unified, not independent (which would have needed up to 5-6 attempts).
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	assert.Equal(t, 1, fake.patchCalls, "the 3rd combined failure must pin the SBOM at the shared threshold")
+	assert.Equal(t, 0, fake.replaceCalls, "failure marking must never use a full ReplaceSBOM")
+
+	raw := fake.get(sbomName)
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey])
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
 }
 
 // Test_processContainerWithMetadata_PreservesContentOnTooLarge is the ErrImageTooLarge


### PR DESCRIPTION
## Overview

`SbomManager` tracked SBOM-generation retry attempts via two independent counters, both compared against the same `maxScanRetries` (3):
- `scanRetries` (plain map, no TTL) — incremented only by `handleScannerCrash` for consecutive sidecar OOM crashes.
- `failureRetries` (TTL'd LRU) — incremented only by `handleGenericFailure` for consecutive generic SBOM-generation failures.

Because the counters were independent, an image alternating between failure categories could take more than `maxScanRetries` total attempts (e.g. 2 generic failures + 3 crashes = 5) before ever reaching a terminal status.

This PR unifies both onto the existing TTL'd `failureRetries` LRU via a shared `incrementFailureCount` helper, so the retry budget now bounds *total* attempts per `sbomName` regardless of failure category.

Two intentional behavior consequences are documented inline rather than left silent:
- Scanner-crash counting now inherits the 30-min TTL-reset that generic failures already had (a crash loop with gaps >30min between crashes won't accumulate to a pin).
- Terminal-status classification (`Incomplete` vs `TooLarge`) is now attempt-attributed — whichever handler's call crosses the combined threshold decides, based on that attempt. Safety is preserved by the existing `hadContent` gate, which is untouched: content-bearing SBOMs are always pinned `Incomplete`, never `TooLarge`.

## How to Test

```
go build ./...
go test ./pkg/sbommanager/v1/... -run . -v
```

The new `Test_processContainerWithMetadata_MixedFailureCategoriesShareBudget` reproduces the bug scenario from the issue: alternating generic-failure/scanner-crash calls now pin a terminal status at exactly the 3rd combined attempt instead of up to 5-6.

## Related issues/PRs

* Resolved #856
* Follow-up to #855, which introduced `failureRetries` alongside the pre-existing `scanRetries`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: oh-my-claudecode:ralph,oh-my-claudecode:ai-slop-cleaner,oh-my-claudecode:cancel | cmds: /clear,/oh-my-claudecode:ralplan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SBOM retry handling by consolidating generic failure and scanner-crash retries into shared, TTL-bounded counters, with clearer crash-loop vs. general failure classification.
  * Refined terminal status selection for contentless images: **TooLarge** is set only on a pure crash-loop backstop; otherwise **Incomplete** is used.
  * Preserved existing SBOM artifacts and updated how terminal status is written (annotation patching).
* **Tests**
  * Added regression tests covering mixed failure-category sharing, pure crash-loop **TooLarge** behavior (including scanner memory limit capture), and TTL-expiry survival across sparse restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->