### PR TITLE
incluster-comp-pr-merged: use registry cache instead of GHA cache

### DIFF
--- a/.github/workflows/incluster-comp-pr-merged.yaml
+++ b/.github/workflows/incluster-comp-pr-merged.yaml
@@ -126,8 +126,8 @@ jobs:
           tags: ${{ inputs.IMAGE_NAME }}:${{ steps.image-prerelease-tag.outputs.IMAGE_TAG_PRERELEASE }}
           build-args: image_version=${{ inputs.IMAGE_TAG }}
           platforms: ${{ inputs.BUILD_PLATFORM }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ inputs.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ inputs.IMAGE_NAME }}:buildcache,mode=max
           push: true
 
       - name: Attest image provenance


### PR DESCRIPTION
## Summary
- Phase 3 of the `gha-buildx-cache-fix` task: `node-agent` vendors its own local copy of `kubescape/workflows`' `incluster-comp-pr-merged.yaml` (invoked via `uses: ./.github/workflows/incluster-comp-pr-merged.yaml`), and it still had the old cache config.
- `docker-build`'s `build-and-push` step used `cache-from: type=gha` / `cache-to: type=gha,mode=max`, which fails with `ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache` on `pull_request_target`-triggered runs that resolve to the default branch — GitHub issues those runs a **read-only** Actions-cache token (policy change 2026-06-26), and `pull_request_target` isn't on the trusted-trigger allowlist that gets a writable token.
- This mirrors the fix already merged upstream in `kubescape/workflows#89`: swap the cache backend to `type=registry,ref=<image>:buildcache`, which authenticates via Quay and never touches GitHub's Actions Cache Service, so the trigger-trust restriction doesn't apply.
- Minimal, isolated change — only the two cache lines. The fork has also drifted from canonical in other ways (older `run-tests` dispatch logic, a leftover `benchmark` job, no `workflow_dispatch` trigger), but those are out of scope here and can be a separate follow-up if a full resync is wanted.

## Test plan
- [ ] Merge a PR into `node-agent` main with the `release` or `trigger-integration-test` label and confirm the `docker-build` job's `Build and push` step no longer fails with "failed to reserve cache"
- [ ] Confirm the built image still pushes to Quay successfully with cache populated under the `:buildcache` tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to use a registry-based Docker layer cache.
  * This improves cache reuse across builds and can help reduce build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->