### PR TITLE
fix(sbommanager): decouple shared-data wait from single-worker pool to stop node-wide SBOM stall (#850)

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -258,7 +258,11 @@ func (s *SbomManager) ContainerCallback(notif containercollection.PubSubEvent) {
 		defer cancel()
 		sharedData, err := s.waitForSharedContainerData(ctx, notif.Container.Runtime.ContainerID)
 		if err != nil {
-			logger.L().Error("SbomManager - container not found in shared data",
+			logger.L().Ctx(s.ctx).Error("SbomManager - container not found in shared data",
+				helpers.Error(err),
+				helpers.String("namespace", notif.Container.K8s.Namespace),
+				helpers.String("pod", notif.Container.K8s.PodName),
+				helpers.String("container", notif.Container.K8s.ContainerName),
 				helpers.String("container ID", notif.Container.Runtime.ContainerID))
 			return
 		}

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -66,6 +66,8 @@ const (
 	maxPendingScans               = 1000
 	maxFailureRetryEntries        = 1000
 	failureRetryTTL               = 30 * time.Minute
+	// maxWaitForSharedContainerData bounds the wait for a container's shared data; mirrors containerprofilemanager's MaxWaitForSharedContainerData.
+	maxWaitForSharedContainerData = 10 * time.Minute
 )
 
 // pendingScan holds the data needed to retry a container scan after the sidecar becomes ready.
@@ -250,20 +252,20 @@ func (s *SbomManager) ContainerCallback(notif containercollection.PubSubEvent) {
 			helpers.String("container", notif.Container.K8s.ContainerName))
 		return
 	}
-	// enqueue the container for processing
-	s.pool.Submit(func() {
-		s.processContainer(notif, mounts, imageStatus)
-	}, utils.FuncName(s.processContainer))
-}
-
-func (s *SbomManager) processContainer(notif containercollection.PubSubEvent, mounts []string, imageStatus *runtime.ImageStatusResponse) {
-	sharedData, err := s.waitForSharedContainerData(notif.Container.Runtime.ContainerID)
-	if err != nil {
-		logger.L().Error("SbomManager - container not found in shared data",
-			helpers.String("container ID", notif.Container.Runtime.ContainerID))
-		return
-	}
-	s.processContainerWithMetadata(notif, mounts, imageStatus, sharedData.ImageTag, sharedData.ImageID)
+	// Wait for shared data off the single-worker pool so a short-lived container whose data never arrives can't head-of-line-block SBOM generation node-wide (#850); only real work is submitted to the pool.
+	go func() {
+		ctx, cancel := context.WithTimeout(s.ctx, maxWaitForSharedContainerData)
+		defer cancel()
+		sharedData, err := s.waitForSharedContainerData(ctx, notif.Container.Runtime.ContainerID)
+		if err != nil {
+			logger.L().Error("SbomManager - container not found in shared data",
+				helpers.String("container ID", notif.Container.Runtime.ContainerID))
+			return
+		}
+		s.pool.Submit(func() {
+			s.processContainerWithMetadata(notif, mounts, imageStatus, sharedData.ImageTag, sharedData.ImageID)
+		}, utils.FuncName(s.processContainerWithMetadata))
+	}()
 }
 
 func (s *SbomManager) processContainerWithMetadata(notif containercollection.PubSubEvent, mounts []string, imageStatus *runtime.ImageStatusResponse, imageTag, imageID string) {
@@ -568,8 +570,8 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 		helpers.String("sbomName", sbomName))
 }
 
-func (s *SbomManager) waitForSharedContainerData(containerID string) (*objectcache.WatchedContainerData, error) {
-	return backoff.Retry(context.Background(), func() (*objectcache.WatchedContainerData, error) {
+func (s *SbomManager) waitForSharedContainerData(ctx context.Context, containerID string) (*objectcache.WatchedContainerData, error) {
+	return backoff.Retry(ctx, func() (*objectcache.WatchedContainerData, error) {
 		if sharedData := s.k8sObjectCache.GetSharedContainerData(containerID); sharedData != nil {
 			return sharedData, nil
 		}

--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -66,8 +66,13 @@ const (
 	maxPendingScans               = 1000
 	maxFailureRetryEntries        = 1000
 	failureRetryTTL               = 30 * time.Minute
-	// maxWaitForSharedContainerData bounds the wait for a container's shared data; mirrors containerprofilemanager's MaxWaitForSharedContainerData.
-	maxWaitForSharedContainerData = 10 * time.Minute
+	// maxWaitForSharedContainerData bounds the per-container wait for shared data. It must be
+	// >= the producer's budget, else the consumer gives up while the producer is still
+	// populating the data and the container silently never gets an SBOM: the producer
+	// (ContainerWatcher.setSharedWatchedContainerData) retries via cenkalti/backoff
+	// NewExponentialBackOff, whose DefaultMaxElapsedTime is 15m. Waits are cancelled early on
+	// container-remove, so this cap is only reached for a container still alive at 15m.
+	maxWaitForSharedContainerData = 15 * time.Minute
 	// crashLoopRetryTTL is deliberately much longer than failureRetryTTL: a sidecar OOM crash
 	// stalls the shared scanner for every image on the node, so a chronically-crashing image
 	// with restarts spaced further apart than failureRetryTTL must still eventually be pinned,
@@ -114,6 +119,11 @@ type SbomManager struct {
 	pendingMu        sync.Mutex
 	failureReporter  sbommanager.SbomFailureReporter
 	metrics          metricsmanager.MetricsManager
+	// waitCancels holds the cancel func for each in-flight shared-data wait, keyed by container
+	// ID, so a container-remove event cancels the wait immediately instead of leaking a goroutine
+	// (retaining notif/mounts/imageStatus) until the timeout (#850).
+	waitCancels   map[string]context.CancelFunc
+	waitCancelsMu sync.Mutex
 }
 
 var _ sbommanager.SbomManagerClient = (*SbomManager)(nil)
@@ -166,6 +176,7 @@ func CreateSbomManager(ctx context.Context, cfg config.Config, socketPath string
 		pendingScans:       make(map[string]pendingScan),
 		failureReporter:    failureReporter,
 		metrics:            metrics,
+		waitCancels:        make(map[string]context.CancelFunc),
 	}
 	if scannerClient != nil {
 		sm.startScannerReadinessWatcher()
@@ -220,8 +231,15 @@ func (s *SbomManager) getMountedVolumes(pid string) ([]string, error) {
 }
 
 func (s *SbomManager) ContainerCallback(notif containercollection.PubSubEvent) {
-	// only consider container start events
-	if notif.Type != containercollection.EventTypeAddContainer {
+	switch notif.Type {
+	case containercollection.EventTypeAddContainer:
+		// handled below
+	case containercollection.EventTypeRemoveContainer:
+		// Cancel any in-flight shared-data wait: the data is deleted on remove, so the wait can
+		// no longer succeed and would otherwise park a goroutine until the timeout (#850).
+		s.cancelWait(notif.Container.Runtime.ContainerID)
+		return
+	default:
 		return
 	}
 	if utils.IsHostContainer(notif.Container) {
@@ -260,24 +278,72 @@ func (s *SbomManager) ContainerCallback(notif containercollection.PubSubEvent) {
 			helpers.String("container", notif.Container.K8s.ContainerName))
 		return
 	}
-	// Wait for shared data off the single-worker pool so a short-lived container whose data never arrives can't head-of-line-block SBOM generation node-wide (#850); only real work is submitted to the pool.
+	s.awaitAndSubmit(notif, mounts, imageStatus)
+}
+
+// awaitAndSubmit waits off the single-worker pool for the container's shared data and, once it
+// is available, submits the actual SBOM work to the pool. It returns immediately; the wait runs
+// in a background goroutine bounded by maxWaitForSharedContainerData and cancelled early on
+// container-remove. Keeping the wait off the pool is what stops a short-lived container from
+// head-of-line-blocking SBOM generation for the whole node (#850).
+func (s *SbomManager) awaitAndSubmit(notif containercollection.PubSubEvent, mounts []string, imageStatus *runtime.ImageStatusResponse) {
+	containerID := notif.Container.Runtime.ContainerID
+	ctx, cancel := context.WithTimeout(s.ctx, maxWaitForSharedContainerData)
+	s.registerWaitCancel(containerID, cancel)
 	go func() {
-		ctx, cancel := context.WithTimeout(s.ctx, maxWaitForSharedContainerData)
 		defer cancel()
-		sharedData, err := s.waitForSharedContainerData(ctx, notif.Container.Runtime.ContainerID)
+		defer s.unregisterWaitCancel(containerID)
+		sharedData, err := s.waitForSharedContainerData(ctx, containerID)
 		if err != nil {
+			// Deadline/cancellation is the expected outcome for a container that exits before its
+			// shared data lands (#848 noise); only genuinely unexpected failures warrant Error.
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				logger.L().Debug("SbomManager - gave up waiting for shared container data",
+					helpers.Error(err),
+					helpers.String("namespace", notif.Container.K8s.Namespace),
+					helpers.String("pod", notif.Container.K8s.PodName),
+					helpers.String("container", notif.Container.K8s.ContainerName),
+					helpers.String("container ID", containerID))
+				return
+			}
 			logger.L().Ctx(s.ctx).Error("SbomManager - container not found in shared data",
 				helpers.Error(err),
 				helpers.String("namespace", notif.Container.K8s.Namespace),
 				helpers.String("pod", notif.Container.K8s.PodName),
 				helpers.String("container", notif.Container.K8s.ContainerName),
-				helpers.String("container ID", notif.Container.Runtime.ContainerID))
+				helpers.String("container ID", containerID))
+			return
+		}
+		// Don't enqueue new work once the manager is shutting down.
+		if s.ctx.Err() != nil {
 			return
 		}
 		s.pool.Submit(func() {
 			s.processContainerWithMetadata(notif, mounts, imageStatus, sharedData.ImageTag, sharedData.ImageID)
 		}, utils.FuncName(s.processContainerWithMetadata))
 	}()
+}
+
+func (s *SbomManager) registerWaitCancel(containerID string, cancel context.CancelFunc) {
+	s.waitCancelsMu.Lock()
+	s.waitCancels[containerID] = cancel
+	s.waitCancelsMu.Unlock()
+}
+
+func (s *SbomManager) unregisterWaitCancel(containerID string) {
+	s.waitCancelsMu.Lock()
+	delete(s.waitCancels, containerID)
+	s.waitCancelsMu.Unlock()
+}
+
+// cancelWait cancels and drops the in-flight shared-data wait for containerID, if any.
+func (s *SbomManager) cancelWait(containerID string) {
+	s.waitCancelsMu.Lock()
+	if cancel, ok := s.waitCancels[containerID]; ok {
+		cancel()
+		delete(s.waitCancels, containerID)
+	}
+	s.waitCancelsMu.Unlock()
 }
 
 func (s *SbomManager) processContainerWithMetadata(notif containercollection.PubSubEvent, mounts []string, imageStatus *runtime.ImageStatusResponse, imageTag, imageID string) {

--- a/pkg/sbommanager/v1/sbom_manager_sharedwait_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_sharedwait_test.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_waitForSharedContainerData_HonorsContextDeadline is the regression guard for #850:
+// a container whose shared data never arrives must not block the caller indefinitely. Before
+// the fix the wait ran on context.Background() to backoff's 15m DefaultMaxElapsedTime, which
+// on the single-worker SBOM pool head-of-line-blocked SBOM generation node-wide.
+func Test_waitForSharedContainerData_HonorsContextDeadline(t *testing.T) {
+	sm := &SbomManager{k8sObjectCache: &objectcache.K8sObjectCacheMock{}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	data, err := sm.waitForSharedContainerData(ctx, "never-populated")
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.Nil(t, data)
+	assert.Less(t, elapsed, 5*time.Second, "wait must be bounded by the context deadline, not backoff's 15m default")
+}
+
+// Test_waitForSharedContainerData_ReturnsWhenDataArrives verifies the happy path still resolves:
+// once the shared data is populated, the bounded wait returns it without error.
+func Test_waitForSharedContainerData_ReturnsWhenDataArrives(t *testing.T) {
+	cache := &objectcache.K8sObjectCacheMock{}
+	cache.SetSharedContainerData("c-1", &objectcache.WatchedContainerData{ImageTag: "tag", ImageID: "id"})
+	sm := &SbomManager{k8sObjectCache: cache}
+
+	ctx, cancel := context.WithTimeout(context.Background(), maxWaitForSharedContainerData)
+	defer cancel()
+
+	data, err := sm.waitForSharedContainerData(ctx, "c-1")
+
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+	assert.Equal(t, "tag", data.ImageTag)
+	assert.Equal(t, "id", data.ImageID)
+}

--- a/pkg/sbommanager/v1/sbom_manager_sharedwait_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_sharedwait_test.go
@@ -2,30 +2,50 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	mapset "github.com/deckarep/golang-set/v2"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	"github.com/kubescape/node-agent/pkg/config"
 	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/workerpool"
 	"github.com/stretchr/testify/assert"
 )
 
-// Test_waitForSharedContainerData_HonorsContextDeadline is the regression guard for #850:
-// a container whose shared data never arrives must not block the caller indefinitely. Before
-// the fix the wait ran on context.Background() to backoff's 15m DefaultMaxElapsedTime, which
-// on the single-worker SBOM pool head-of-line-blocked SBOM generation node-wide.
+// Test_waitForSharedContainerData_HonorsContextDeadline is the regression guard for the wait
+// being bounded: a container whose shared data never arrives must stop at the context deadline,
+// not run to backoff's 15m DefaultMaxElapsedTime. The wait runs in a goroutine so that if the
+// bound regresses (ctx -> context.Background()) the test fails cleanly at 2s instead of blocking
+// the whole package's test binary for 15m and panicking on go test's default timeout.
 func Test_waitForSharedContainerData_HonorsContextDeadline(t *testing.T) {
 	sm := &SbomManager{k8sObjectCache: &objectcache.K8sObjectCacheMock{}}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
+	type result struct {
+		data *objectcache.WatchedContainerData
+		err  error
+	}
+	done := make(chan result, 1)
 	start := time.Now()
-	data, err := sm.waitForSharedContainerData(ctx, "never-populated")
-	elapsed := time.Since(start)
+	go func() {
+		data, err := sm.waitForSharedContainerData(ctx, "never-populated")
+		done <- result{data, err}
+	}()
 
-	assert.Error(t, err)
-	assert.Nil(t, data)
-	assert.Less(t, elapsed, 5*time.Second, "wait must be bounded by the context deadline, not backoff's 15m default")
+	select {
+	case r := <-done:
+		assert.ErrorIs(t, r.err, context.DeadlineExceeded, "the context deadline must be what stopped the wait")
+		assert.Nil(t, r.data)
+		assert.Less(t, time.Since(start), 2*time.Second, "wait must end near the 200ms deadline, not backoff's 15m default")
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait did not honor the context deadline (regression: unbounded context) — would otherwise block for backoff's 15m default")
+	}
 }
 
 // Test_waitForSharedContainerData_ReturnsWhenDataArrives verifies the happy path still resolves:
@@ -44,4 +64,122 @@ func Test_waitForSharedContainerData_ReturnsWhenDataArrives(t *testing.T) {
 	assert.NotNil(t, data)
 	assert.Equal(t, "tag", data.ImageTag)
 	assert.Equal(t, "id", data.ImageID)
+}
+
+// signalingSbomClient signals on created the moment CreateSBOM is called, then returns an error so
+// processContainerWithMetadata bails immediately (before the syft path). Receiving on created
+// therefore proves the submitted work actually ran on the pool worker.
+type signalingSbomClient struct {
+	*fakeSbomClient
+	created chan string
+}
+
+func (c *signalingSbomClient) CreateSBOM(sbom *v1beta1.SBOMSyft) (*v1beta1.SBOMSyft, error) {
+	c.created <- sbom.Name
+	return nil, errors.New("signaled: stop processing here")
+}
+
+func addContainerNotif(containerID string) containercollection.PubSubEvent {
+	return containercollection.PubSubEvent{
+		Type: containercollection.EventTypeAddContainer,
+		Container: &containercollection.Container{
+			Runtime: containercollection.RuntimeMetadata{
+				BasicRuntimeMetadata: types.BasicRuntimeMetadata{ContainerID: containerID},
+			},
+			K8s: containercollection.K8sMetadata{
+				BasicK8sMetadata: types.BasicK8sMetadata{
+					Namespace:     "default",
+					PodName:       "pod-" + containerID,
+					ContainerName: containerID,
+				},
+			},
+		},
+	}
+}
+
+// Test_awaitAndSubmit_StuckContainerDoesNotBlockOthers is the #850 regression guard for the fix
+// itself: it proves the shared-data wait no longer occupies the single pool worker. Container A's
+// data never arrives (a stuck/short-lived container); container B's is already present. If the
+// wait ran inline on the pool worker again, A would head-of-line-block B — so B's work reaching
+// the worker while A is stuck is exactly what the fix guarantees.
+func Test_awaitAndSubmit_StuckContainerDoesNotBlockOthers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // unblocks container A's still-waiting goroutine at test end
+
+	imageTag := "quay.io/kubescape/kubevuln:v0.3.2"
+	imageID := "sha256:94cbbb94f8d6bdf2529d5f9c5279ac4c7411182f4e8e5a3d0b5e8f10a465f73a"
+	cache := &objectcache.K8sObjectCacheMock{}
+	cache.SetSharedContainerData("cB", &objectcache.WatchedContainerData{ImageTag: imageTag, ImageID: imageID})
+
+	sig := &signalingSbomClient{fakeSbomClient: newFakeSbomClient(), created: make(chan string, 1)}
+	sm := &SbomManager{
+		cfg:              config.Config{NodeName: "node-1"},
+		ctx:              ctx,
+		k8sObjectCache:   cache,
+		pool:             workerpool.New(1),
+		processing:       mapset.NewSet[string](),
+		storageClient:    sig,
+		version:          "v1.0.0",
+		failureRetries:   newFailureRetries(),
+		crashLoopRetries: newCrashLoopRetries(),
+		waitCancels:      make(map[string]context.CancelFunc),
+	}
+
+	// Container A is stuck: awaitAndSubmit must return without blocking on the wait.
+	returned := make(chan struct{})
+	go func() {
+		sm.awaitAndSubmit(addContainerNotif("cA"), nil, nil)
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("awaitAndSubmit blocked on the shared-data wait (#850 regression: wait not off the pool)")
+	}
+
+	// Container B has data present: its SBOM work must reach the pool worker promptly even though
+	// A is still stuck, proving the stuck container does not head-of-line-block the node.
+	sm.awaitAndSubmit(addContainerNotif("cB"), nil, nil)
+	select {
+	case <-sig.created:
+	case <-time.After(5 * time.Second):
+		t.Fatal("container B's SBOM work never reached the pool worker while A was stuck (#850 regression)")
+	}
+}
+
+// Test_cancelWait_StopsInFlightWait proves the container-remove path cancels the wait promptly so
+// a short-lived container can't park a goroutine for the full timeout.
+func Test_cancelWait_StopsInFlightWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sm := &SbomManager{
+		ctx:            ctx,
+		k8sObjectCache: &objectcache.K8sObjectCacheMock{}, // data never arrives for "cX"
+		pool:           workerpool.New(1),
+		processing:     mapset.NewSet[string](),
+		waitCancels:    make(map[string]context.CancelFunc),
+	}
+
+	sm.awaitAndSubmit(addContainerNotif("cX"), nil, nil)
+
+	// The wait is registered; a remove event must cancel it, dropping the registry entry.
+	assert.Eventually(t, func() bool {
+		sm.waitCancelsMu.Lock()
+		_, registered := sm.waitCancels["cX"]
+		sm.waitCancelsMu.Unlock()
+		return registered
+	}, time.Second, 5*time.Millisecond, "wait should be registered while in flight")
+
+	sm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: addContainerNotif("cX").Container,
+	})
+
+	assert.Eventually(t, func() bool {
+		sm.waitCancelsMu.Lock()
+		_, registered := sm.waitCancels["cX"]
+		sm.waitCancelsMu.Unlock()
+		return !registered
+	}, 2*time.Second, 5*time.Millisecond, "remove event must cancel and drop the in-flight wait")
 }


### PR DESCRIPTION
## Overview

Current behavior: A single short-lived container can silently halt SBOM generation node-wide. SbomManager runs a single-worker pool, and the shared-container-data wait executed on that worker via backoff.Retry(context.Background(), …) with no timeout — running to backoff v5's 15m DefaultMaxElapsedTime on a context that is never cancelled. Since shared data is deleted on the container-remove event, a container that exits before its data is populated holds the sole worker for the full window, head-of-line-blocking SBOM generation for every other container on the node.

Future behavior: The shared-data wait is decoupled from the single-worker pool. ContainerCallback now performs the wait in a per-container goroutine — bounded by a timeout and cancelled early on the container-remove event — and submits only the actual SBOM work to the pool once metadata is available. A stuck/short-lived container can no longer occupy the worker (so other containers' SBOMs proceed unblocked) nor park a goroutine past its own lifetime.

## Additional Information

- waitForSharedContainerData now takes a context.Context, bounded via context.WithTimeout(s.ctx, maxWaitForSharedContainerData) instead of context.Background(). The bound is 15m, tied to the producer's budget: the shared data is populated by ContainerWatcher.setSharedWatchedContainerData, which retries via cenkalti/backoff NewExponentialBackOff (15m DefaultMaxElapsedTime). A shorter consumer window would give up while the producer is still succeeding, silently dropping the SBOM.
- The per-container wait is cancelled on the container-remove event via a map[containerID]context.CancelFunc guarded by a mutex (populated when the wait starts, drained/cancelled in ContainerCallback's EventTypeRemoveContainer branch). This keeps the fix from trading a worker stall for an unbounded goroutine leak — a short-lived container's wait ends at its actual lifetime rather than parking a goroutine (retaining notif/mounts/imageStatus) for the full timeout. A guard also prevents new work being enqueued to the pool during shutdown.
- The pool-of-1 invariant is intentionally preserved — I did not raise the worker count, because scanRetries is documented as mutex-free precisely because the pool size is 1 (pool > 1 would introduce a data race).
- The shared-data-wait failure log now distinguishes cause: Debug when the wait ends in context.DeadlineExceeded/Canceled (the benign #848 outcome for a container that exits before its data lands, including cancellation on container-remove), and Error only for genuinely unexpected failures. It also gained .Ctx(s.ctx) and namespace/pod/container fields for consistency with the rest of the file.
- Out of scope: SBOM generation remains serial (pool size 1) by design — that was not the bug; cmd/main.go's non-cancellable root context and the pre-existing Set-after-Delete ordering race between the producer and DeleteSharedContainerData are left untouched.

## How to Test

- Run the package tests (with the race detector): go test -race ./pkg/sbommanager/v1/
- Test_awaitAndSubmit_StuckContainerDoesNotBlockOthers is the #850 regression guard for the fix itself — container A's data never arrives while B's is present, and it asserts awaitAndSubmit returns without blocking and B's work reaches the pool worker while A is stuck (deleting the goroutine wrapper fails it).
- Test_waitForSharedContainerData_HonorsContextDeadline asserts the wait stops at the context deadline with context.DeadlineExceeded rather than backoff's 15m default; Test_cancelWait_StopsInFlightWait covers container-remove cancellation; Test_waitForSharedContainerData_ReturnsWhenDataArrives covers the happy path.
- In-cluster: deploy a frequently-firing short-lived workload (e.g. a CronJob every few minutes) alongside a newly-deployed long-lived workload on the same node; confirm the long-lived workload's sbomsyft CR is still written promptly instead of stalling.

## Related issues/PRs:

- Resolved #850

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the maximum wait for shared container data to 15 minutes to avoid prolonged delays.
  * Container processing now performs shared-data waiting asynchronously and is bounded by the provided timeout.
  * Container removal now properly cancels pending data waits to prevent resource leaks.
  * Waiting behavior stops promptly when timeouts expire.
* **Tests**
  * Added regression tests covering context deadline handling, immediate data return, non-blocking behavior across containers, and cancellation of pending waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->