### PR TITLE
fix(containerprofile): split oversized chunks on HTTP 413 instead of ending learning

### DIFF
--- a/docs/features/container-profile-split-on-413.md
+++ b/docs/features/container-profile-split-on-413.md
@@ -1,0 +1,196 @@
+# Container Profile Split on HTTP 413
+
+An HTTP 413 ("Request Entity Too Large") from storage's `QueueManager` signals that a single delta—one transaction body—exceeded the wire's byte capacity. This is a **transport** rejection, not a lifecycle signal. Prior behavior mapped a 413 onto `ObjectTooLargeError` (storage's authoritative "aggregate too large" sentinel), which ended learning for the entire container, discarding all future deltas forever.
+
+A single oversized delta does not mean the container's *aggregate* profile is full. Storage merges deltas server-side, dedupes findings, and only emits a true `ObjectTooLargeError` when the aggregate's findings count exceeds its limit—a separate check entirely. This change splits an oversized delta into two independently-named halves, re-enqueues both, and lets learning continue. The transport limit is no longer conflated with the aggregate limit, and containers survive an occasional large delta.
+
+## Why a 413 is not "too large"
+
+Storage operates at two levels:
+
+| Signal | Source | Meaning | Response |
+|---|---|---|---|
+| HTTP 413 `Content-Length` check | `QueueManager.Create()` (kubescape/storage pkg/queuemanager/manager.go:144-148) | This **one delta** exceeds the wire cap (default ~2.5 MB) | Node-agent: halve and retry; do not end learning |
+| `ObjectTooLargeError` sentinel | Storage's aggregate findings-count check (kubescape/storage pkg/registry/file/containerprofile_processor.go) | The container's **cumulative profile** (after merge and dedup) exceeds findings cap (e.g. 100K) | Node-agent: end learning authoritatively (`OnQueueError` → `deleteContainer`) |
+| `ObjectCompletedError` sentinel | Storage's completion check | Container has finished reporting (age, findings completed) | Node-agent: end learning authoritatively |
+
+Today, a 413 is incorrectly treated as a terminal `ObjectTooLargeError`, so one large delta ends the entire container. The fix: only the **sentinels** end learning. A bare 413 triggers reactive halving instead.
+
+## Reactive halving
+
+When a delta is rejected with 413, `splitProfile()` (pkg/containerprofilemanager/v1/queue/containerprofile_split.go) partitions its data into two profiles with:
+
+- **Same base aggregate name** — both halves carry the same `ObjectMeta.Name` prefix, differing only in the one-time UUID suffix. Storage's own `SplitProfileName` function recovers the base by cutting on the last hyphen, so both halves aggregate into the same server-side profile.
+- **Per-field partition** — `Capabilities`, `Execs`, `Opens`, `Syscalls`, `Endpoints`, `IdentifiedCallStacks`, `Ingress`, `Egress`, and `PolicyByRuleId` are split across the two halves by element. Each field's `a` half takes `ceil(len/2)` elements, `b` takes the rest. Per-field splitting (rather than random bin-packing) guarantees that whichever field dominates the byte size is itself halved on the first round, which bounds convergence.
+- **Verbatim baseline** — `Architectures`, `ImageID`, `ImageTag`, `SeccompProfile`, `LabelSelector`, and all annotations/labels are **copied identically** into both halves. This non-split baseline (`K`) is replicated, so a depth-*d* leaf is `K + P/2^d`, where `P` is the partitionable payload.
+
+### Convergence
+
+Assuming the baseline `K` is smaller than storage's cap (the usual case):
+
+```
+K + P/2^d < cap   =>   d = ceil(log2(P / (cap - K)))
+```
+
+With a default `MaxSplitDepth = 4`, this covers roughly a **16x overshoot** of the cap. Each round takes one `RetryInterval` (default 5 seconds), so a 3.23 MB chunk against a 2.5 MB cap converges in ~1 round of wall-clock time.
+
+If `K >= cap` (e.g. the `SeccompProfile` alone exceeds storage's limit), splitting cannot converge at any depth. The byte-progress guard detects when neither half is meaningfully smaller than the parent (`max(size(a), size(b)) >= size(p)`) and stops splitting at that point, treating it as a floor case (see below). This is a node-agent estimator bug, not a storage limitation, and surfaces as a Warning drop counter so the issue can be escalated.
+
+Both halves **retry at the queue's natural tick rate** (no busy-loop). The `queueSize` captured at the start of `processAllItems` (pkg/containerprofilemanager/v1/queue/containerprofile_queue.go) ensures splits land on the **next** tick, so split storms are naturally rate-limited by the queue's existing backpressure.
+
+### Non-convergent floor case
+
+If a delta has **≤ 1 partitionable element** (e.g. one huge `Endpoint` that is the entire profile), it cannot be split usefully. The chunk is dropped and replaced with a **stitch chunk**—a metadata-only stand-in that preserves the report-timestamp chain (see §3 below) but clears the payloads that could not be split. The stitch is a couple of KB and cannot itself be rejected with 413.
+
+Dropping the chunk (rather than ending learning) is a deliberate degradation trade-off: one delta is lost, but the container keeps learning and eventually completes. The drop counter signals that node-agent's size estimator (mixing byte-size and element-count heuristics) is overshooting; this is tracked as a separate node-agent bug.
+
+## Naming and aggregation
+
+The original chunk has an `ObjectMeta.Name` in the form `<base>-<uuid>`, where `<uuid>` is a 32-hex one-time slug generated by `InstanceID.GetOneTimeSlug`. When the chunk splits, both halves get **fresh UUIDs** via `freshOneTimeSlug()` (pkg/containerprofilemanager/v1/queue/containerprofile_split.go):
+
+```
+parent:  myapp-production-abc123def456...
+a:       myapp-production-xyz789uvw012...  (fresh UUID)
+b:       myapp-production-ghi345jkl678...  (fresh UUID)
+```
+
+Storage's aggregation key is per-object—it parses the name with `SplitProfileName`, recovering the base (`myapp-production`) and treating each UUID as a distinct `time_series` row within that aggregate. Both halves' rows merge into the same aggregate, so the data is unified server-side.
+
+The one-time slug cannot use a scheme like `-part1`/`-part2` because `SplitProfileName` cuts on the **last** hyphen—a hyphenated suffix would be mistaken for the UUID, scattering data into phantom aggregates.
+
+## The report chain (timestamp interposition)
+
+This is the most delicate part of the design. Storage's `consolidateContinuousTimeSeries` function (kubescape/storage pkg/registry/file/containerprofile_processor.go:631-659) walks a container's time-series rows in reverse chronological order, merging each row `j` with row `i+1` **only when** `timeSeries[j].PreviousReportTimestamp == timeSeries[i+1].ReportTimestamp`. This linear-chain walk reconstructs the container's lifecycle—every row must link back to the prior report.
+
+If two halves share the parent's timestamp pair `(P, T]` (where `P` is previous and `T` is report), they form a broken fork:
+
+```
+rows (ORDER BY reportTimestamp DESC) = [a(P,T), b(P,T)]
+merge:  a.prev(P) == b.rt(T)?   NO  → chain breaks, len(newTimeSeries) = 2
+```
+
+The `updateProfileStatus` function (kubescape/storage pkg/registry/file/containerprofile_processor.go:672) then sees two rows instead of one and sets `Learning` status, preventing completion forever—the profile is stuck in learning limbo despite all data being present. This was a real, verified defect in design review: **any container that ever splits stays in `Learning` forever and never completes**.
+
+The fix: interpose a fresh timestamp `X` strictly between `P` and `T`, via `chainHalves()` (pkg/containerprofilemanager/v1/queue/containerprofile_split.go), giving `a` the interval `(P, X]` and `b` the interval `(X, T]`:
+
+```
+rows = [b(X,T), a(P,X)]
+merge: b.prev(X) == a.rt(X)?   YES  → merges to [(P,T)]
+```
+
+Storage's consolidation collapses the two rows back to the original interval, so the **next** real report—whose `previousReportTimestamp` points at `T`—still links up. The chain is linear and unbroken.
+
+### Timestamp preservation and parsing
+
+Only `X` is manufactured. The two halves preserve the parent's endpoints byte-for-byte:
+
+- `a.previousReportTimestamp` = parent's original string (unchanged)
+- `b.reportTimestamp` = parent's original string (unchanged)
+- `a.reportTimestamp` = `b.previousReportTimestamp` = `X.String()` (manufactured)
+
+Timestamps come from `time.Now().String()` (see pkg/containerprofilemanager/v1/monitoring.go:184-185), which emits the Go time layout `"2006-01-02 15:04:05.999999999 -0700 MST"` **plus** a monotonic-clock suffix like `" m=+0.000019007"`. The `time.Parse` function cannot parse that suffix; it fails with `extra text: " m=+0.000019007"`.
+
+The `parseReportTimestamp()` function (pkg/containerprofilemanager/v1/queue/containerprofile_split.go) handles this by:
+
+1. Stripping the monotonic suffix: `s, _, _ = strings.Cut(s, " m=")`
+2. Attempting to parse with the primary layout `"2006-01-02 15:04:05.999999999 -0700 MST"`
+3. Falling back to a numeric-zone layout `"2006-01-02 15:04:05.999999999 -0700 -0700"` for non-whole-hour timezones (Nepal `+0545`, Iran `+0330`, etc.)
+
+Both layouts are required: Go's zone-letter abbreviations (`MST`, `CEST`) fail to parse for non-whole-hour offsets, but numeric offsets like `+0545` do parse. This was a blocking defect in design review: without stripping the monotonic suffix, **every production `chainHalves` call would fail to parse and refuse to split**, silently dropping chunks instead of recovering them.
+
+### Zero-time first-report hazard
+
+On a container's first report, `previousReportTimestamp` is the zero time. A true midpoint between year 1 and now lands around year 1013. Storage's `ListTimeSeriesExpired` function (kubescape/storage pkg/registry/file/sqlite.go:349-356) compares `reportTimestamp` as a **raw string**, so a year-1013 timestamp matches the expiry check unconditionally and the profile is marked `Completed`/`Partial`—re-ending learning on the most common split case (a large delta on a container's initial burst of learning).
+
+The solution: `interposeTimestamp()` (pkg/containerprofilemanager/v1/queue/containerprofile_split.go) never takes a midpoint. Instead:
+
+```
+if prev is zero time:
+    X = rt.Add(-1ms)              // step back by delta
+else:
+    X = rt.Add(-min(delta, (rt-prev)/2))
+if !(prev < X < T):
+    return false                  // refuse to split
+```
+
+This keeps `X` far from `prev` when `prev` is ancient, and ensures the `P < X < T` invariant holds.
+
+### Stitch chunks (metadata-only repairs)
+
+When a chunk is dropped (floor case, depth exhaustion, etc.), a **stitch chunk** via `stitchChunk()` (pkg/containerprofilemanager/v1/queue/containerprofile_split.go) is enqueued in its place. A stitch carries:
+
+- The same `previousReportTimestamp` and `reportTimestamp` strings (byte-for-byte, so the chain link is preserved)
+- The same annotations and labels
+- A fresh one-time UUID (a new `Name`)
+- A `Spec` with payloads cleared: `Capabilities`, `Execs`, `Opens`, `Syscalls`, `Endpoints`, `IdentifiedCallStacks`, `Ingress`, `Egress`, and `PolicyByRuleId` are empty, but `SeccompProfile`, `ImageID`, and `ImageTag` are **preserved verbatim**
+
+Why preserve only three fields? Storage's `mergeContainerProfileTS` (kubescape/storage pkg/registry/file/containerprofile_processor.go:855-881) merges most fields by **append**, but these three by **unconditional assignment** (lines 863, 865, 866)—the last merge wins. Rows merge in DESC order, so the oldest row wins. Clearing `SeccompProfile`/`ImageID`/`ImageTag` would zero them on the aggregate.
+
+A stitch is a couple of KB and cannot exceed the 413 cap. If it is rejected with 413 (which should never happen), it is dropped without re-stitching via the `IsStitch` flag (pkg/containerprofilemanager/v1/queue/containerprofile_queue.go), to avoid an infinite loop. This gap (one half of a pair lost) forks the chain, leaving the profile stuck in `Learning`—a known limitation tracked as a follow-up against the queue's LRU eviction and `MaxAttempts` retry exhaustion.
+
+### Temporary shim
+
+This entire timestamp-interposition mechanism is a **temporary shim**. Once storage's `consolidateContinuousTimeSeries` is updated to collapse rows sharing an identical `(previousReportTimestamp, reportTimestamp)` pair within a series (tracked as kubescape/storage follow-up), this code can be removed and splits can leave both timestamps untouched, eliminating the parsing and zero-time hazards entirely.
+
+## Bounds and queue integration
+
+### MaxSplitDepth
+
+`MaxSplitDepth` defaults to 4 (pkg/containerprofilemanager/v1/queue/containerprofile_split.go `DefaultMaxSplitDepth`), bounding a single lineage at `2^4 = 16` leaves. This tripwire catches:
+
+- **Pathological input** — a chunk 16x over the cap (indicating a node-agent size-estimator bug)
+- **LRU eviction worst case** — the queue's `MaxQueueSize` evicts FIFO from the head while splits append to the tail. Capping one lineage at 16 leaves (net queue growth +15 per lineage) ensures split storms don't silently evict unrelated healthy profiles.
+
+Each halving round takes one `RetryInterval` (default 5 seconds), so depth 4 represents a maximum ~20-second wall-clock convergence time under pathological input.
+
+### Inheritance and attempts
+
+When a chunk is split, both halves (pkg/containerprofilemanager/v1/queue/containerprofile_queue.go `requeueSplit`):
+
+- Inherit the parent's `Attempts` counter (not reset to 0), so the retry budget is a real bound
+- Get `SplitDepth = parent.SplitDepth + 1`
+- Retain `IsStitch = false` (so they can split further if needed)
+
+Inheriting `Attempts` keeps the budget honest: a payload alternating between retryable failures and 413s cannot refresh its budget indefinitely by splitting.
+
+## Observability
+
+Two counters track split behavior (pkg/containerprofilemanager/v1/queue/containerprofile_queue.go `GetQueueStats`):
+
+| Counter | Method | Meaning |
+|---|---|---|
+| Splits | `ReportContainerProfileSplit()` (metricsmanager.MetricsManager) | Chunks successfully halved after 413. Increasing rate suggests node-agent's size estimator is firing; review byte-cap and element-count heuristics (separate node-agent issue). One-round convergence is normal; sustained deep convergence suggests estimator drift. |
+| Drops | `ReportContainerProfileChunkDropped(reason)` | Chunks discarded because they could not be split further. Rising drop count on production clusters warrants investigation. |
+
+Drop reasons are typed constants (pkg/containerprofilemanager/v1/queue/containerprofile_queue.go):
+
+| Reason | Meaning |
+|---|---|
+| `dropReasonUnsplittable` | Floor case (≤1 partitionable element), unconstructable chain timestamp, or no byte progress (`max(size(a), size(b)) >= size(p)`) |
+| `dropReasonDepthExhausted` | `MaxSplitDepth` reached before convergence |
+| `dropReasonStitchRejected` | A stitch chunk was itself rejected with 413. The chain fork is left open (known limitation). |
+| `dropReasonEnqueueFailed` | The stitch replacement could not be enqueued (rare; the queue is full or degraded). |
+
+## Tests
+
+- `pkg/containerprofilemanager/v1/queue/containerprofile_split_test.go` — comprehensive unit tests of the split algorithm:
+  - Chain linearity (`TestChainHalves*`, `TestConsolidationAfterSplit*`) — ensures the timestamp interposition is correct and consolidation reconstructs the original interval
+  - Zero-time and boundary cases (`TestInterposeTimestampZeroTime*`, `TestParseReportTimestampMonotonic*`)
+  - Non-convergence (`TestSplitWithBaselineOverflow*`) and floor-case drops (`TestSplitFloorCase*`)
+  - Determinism (`TestHalvePolicies*`)
+  - Stitching (`TestStitchPreservesFields*`)
+
+- `pkg/containerprofilemanager/v1/queue/containerprofile_queue_test.go` — queue-level integration:
+  - Split dispatch and requeue (`Test*ClassifyFailureSplit*`, `Test*ProcessAllItemsSplit*`)
+  - Depth bounds (`Test*MaxSplitDepth*`)
+  - Stitch-rejection loop prevention (`Test*StitchRejected*`)
+
+- End-to-end: no new e2e tests are added (the split is internal; no new public API). Existing learning-completion tests should pass without change (profiles should complete normally even when internal chunks split).
+
+## Known limitations
+
+1. **Node-agent estimator.** The `MaxTsProfileSize` threshold mixes byte-size and element-count heuristics. This PR tolerates occasional 413s via splitting, but the root cause (the estimator) is tracked separately and remains a node-agent bug.
+
+2. **LRU eviction and MaxAttempts gaps.** If exactly one half of a split pair is evicted from the queue (by LRU due to `MaxQueueSize`) or exhausts `MaxAttempts` retries before landing, the chain fork persists and the profile hangs in `Learning`. This gap is pre-existing (the same failure mode applies today via the pre-existing `MaxAttempts` drop path and is not new). A comprehensive fix requires explicit half-tracking across queue evictions, tracked as a follow-up against the queue's LRU and retry-budget design.
+
+3. **No "too-large ends learning" signal on transport rejection.** Prior to this change, a 413 ended learning loudly with an `ObjectTooLargeError` status. Now, a 413 silently splits (or is silently dropped if unsplittable). Storage's own sentinels (`ObjectTooLargeError`, `ObjectCompletedError`) still end learning authoritatively and will log. But if a container is stuck splitting/dropping chunks forever with no terminal status ever reached, that silent degradation may require the drop counters and debug logs to diagnose. This trade-off (silently degrade one delta vs. silently end the container) is intentional.

--- a/docs/features/container-profile-split-on-413.md
+++ b/docs/features/container-profile-split-on-413.md
@@ -174,16 +174,17 @@ Drop reasons are typed constants (pkg/containerprofilemanager/v1/queue/container
 ## Tests
 
 - `pkg/containerprofilemanager/v1/queue/containerprofile_split_test.go` — comprehensive unit tests of the split algorithm:
-  - Chain linearity (`TestChainHalves*`, `TestConsolidationAfterSplit*`) — ensures the timestamp interposition is correct and consolidation reconstructs the original interval
-  - Zero-time and boundary cases (`TestInterposeTimestampZeroTime*`, `TestParseReportTimestampMonotonic*`)
-  - Non-convergence (`TestSplitWithBaselineOverflow*`) and floor-case drops (`TestSplitFloorCase*`)
-  - Determinism (`TestHalvePolicies*`)
-  - Stitching (`TestStitchPreservesFields*`)
+  - Chain linearity (`TestChainHalves_ConsolidatesToParentInterval`, `TestSplitProfile_RecursiveChainStaysLinear`) — ensures the timestamp interposition is correct and consolidation (via a golden port of storage's own algorithm) reconstructs the original interval, including under recursive re-splitting
+  - Zero-time and boundary cases (`TestChainHalves_ZeroPreviousTimestamp`, `TestParseReportTimestamp_MonotonicSuffix`, `TestParseReportTimestamp_NumericZoneAbbreviation`)
+  - Non-convergence (`TestSplitProfile_NoProgressGuard`) and floor-case drops (`TestSplitProfile_FloorCase`)
+  - Determinism (`TestSplitProfile_Deterministic`)
+  - Stitching (`TestStitchChunk_PreservesAssignmentMergedScalars`)
 
-- `pkg/containerprofilemanager/v1/queue/containerprofile_queue_test.go` — queue-level integration:
-  - Split dispatch and requeue (`Test*ClassifyFailureSplit*`, `Test*ProcessAllItemsSplit*`)
-  - Depth bounds (`Test*MaxSplitDepth*`)
-  - Stitch-rejection loop prevention (`Test*StitchRejected*`)
+- `pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go` — queue-level integration:
+  - Split dispatch and requeue (`TestQueueSplitsProfileOnHTTP413`, `TestQueueDropsUnsplittableProfileOnHTTP413`)
+  - Depth bounds (`TestQueueRespectsMaxSplitDepth`)
+  - Stitch-rejection loop prevention (`TestQueueDoesNotStitchAStitch`)
+  - Persistence across a queue restart (`TestQueuePersistsSplitDepth`)
 
 - End-to-end: no new e2e tests are added (the split is internal; no new public API). Existing learning-completion tests should pass without change (profiles should complete normally even when internal chunks split).
 

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
@@ -8,11 +8,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/joncrlsn/dque"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
+	"github.com/kubescape/node-agent/pkg/metricsmanager"
 	"github.com/kubescape/node-agent/pkg/storage"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 )
@@ -49,7 +51,35 @@ type QueuedContainerProfile struct {
 	// retryable error. Items persisted before this field existed decode with Attempts
 	// at zero, so they simply get a full budget of retries.
 	Attempts int `json:"attempts"`
+	// SplitDepth counts how many times this item's lineage has been halved after an HTTP 413.
+	// Items persisted before this field existed decode with SplitDepth at zero.
+	SplitDepth int `json:"splitDepth"`
+	// IsStitch marks a metadata-only chunk emitted by dropChunk to repair the report chain.
+	// A stitch is never split and is never itself stitched - dropping a stitch leaves the chain
+	// forked, which is strictly better than an unbounded stitch->413->stitch loop.
+	IsStitch bool `json:"isStitch"`
 }
+
+// dropReason labels why a chunk was discarded by dropChunk. The set is closed and every value
+// is a compile-time constant, so it is safe as a metric label.
+type dropReason string
+
+const (
+	// dropReasonUnsplittable: splitProfile refused - floor case, unconstructable chain
+	// timestamp, or no byte progress. Collapsed into one reason because all three mean
+	// "this chunk cannot be made smaller".
+	dropReasonUnsplittable dropReason = "unsplittable"
+	// dropReasonDepthExhausted: MaxSplitDepth reached before the chunk became acceptable.
+	dropReasonDepthExhausted dropReason = "depth-exhausted"
+	// dropReasonStitchRejected: a stitch chunk was itself rejected. Not re-stitched, so this
+	// is the one drop that knowingly leaves the report chain forked.
+	dropReasonStitchRejected dropReason = "stitch-rejected"
+	// dropReasonEnqueueFailed: the replacement stitch could not be enqueued.
+	dropReasonEnqueueFailed dropReason = "enqueue-failed"
+)
+
+// ErrQueueNotRunning is returned by enqueueLocked once the queue has been closed.
+var ErrQueueNotRunning = errors.New("queue is not running")
 
 // QueuedContainerProfileBuilder creates a new QueuedContainerProfile instance for dque
 func QueuedContainerProfileBuilder() interface{} {
@@ -69,7 +99,14 @@ type QueueData struct {
 	errorCallback ErrorCallback
 	maxQueueSize  int
 	maxAttempts   int
+	maxSplitDepth int
 	retryInterval time.Duration
+	metrics       metricsmanager.MetricsManager
+
+	// Written by the queue processor goroutine and read by GetQueueStats, so they carry
+	// their own synchronization rather than widening qd.mu.
+	splits        atomic.Int64
+	chunksDropped atomic.Int64
 
 	stopChan chan struct{}
 	wg       sync.WaitGroup
@@ -83,9 +120,11 @@ type QueueConfig struct {
 	QueueDir        string
 	MaxQueueSize    int
 	MaxAttempts     int
+	MaxSplitDepth   int
 	RetryInterval   time.Duration
 	ItemsPerSegment int
 	ErrorCallback   ErrorCallback
+	MetricsManager  metricsmanager.MetricsManager
 }
 
 // NewQueueData creates a new QueueData instance with simple LRU behavior
@@ -102,6 +141,12 @@ func NewQueueData(ctx context.Context, creator storage.ProfileCreator, config Qu
 	}
 	if config.MaxAttempts <= 0 {
 		config.MaxAttempts = DefaultMaxAttempts
+	}
+	if config.MaxSplitDepth <= 0 {
+		config.MaxSplitDepth = DefaultMaxSplitDepth
+	}
+	if config.MetricsManager == nil {
+		config.MetricsManager = &metricsmanager.MetricsNoop{}
 	}
 	if config.RetryInterval == 0 {
 		config.RetryInterval = DefaultRetryInterval
@@ -143,7 +188,9 @@ func NewQueueData(ctx context.Context, creator storage.ProfileCreator, config Qu
 		errorCallback: config.ErrorCallback,
 		maxQueueSize:  config.MaxQueueSize,
 		maxAttempts:   config.MaxAttempts,
+		maxSplitDepth: config.MaxSplitDepth,
 		retryInterval: config.RetryInterval,
+		metrics:       config.MetricsManager,
 		stopChan:      make(chan struct{}),
 		running:       true,
 	}
@@ -174,29 +221,34 @@ func (qd *QueueData) Enqueue(profile *v1beta1.ContainerProfile, containerID stri
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
-	if !qd.running {
-		return fmt.Errorf("queue is not running")
-	}
-
-	// Create queued profile
-	queuedProfile := &QueuedContainerProfile{
+	if err := qd.enqueueLocked(&QueuedContainerProfile{
 		Profile:     profile,
 		ContainerID: containerID,
-	}
-
-	// Remove oldest items if we're at capacity
-	qd.enforceMaxSize()
-
-	// Add new item
-	err := qd.queue.Enqueue(queuedProfile)
-	if err != nil {
-		return fmt.Errorf("failed to enqueue profile: %w", err)
+	}); err != nil {
+		return err
 	}
 
 	logger.L().Debug("container profile enqueued",
 		helpers.String("name", profile.Name),
 		helpers.String("namespace", profile.Namespace),
 		helpers.Int("queueSize", qd.queue.Size()))
+
+	return nil
+}
+
+// enqueueLocked adds item to the queue, evicting the oldest items first.
+// Callers must hold qd.mu.
+func (qd *QueueData) enqueueLocked(item *QueuedContainerProfile) error {
+	if !qd.running {
+		return ErrQueueNotRunning
+	}
+
+	// Remove oldest items if we're at capacity
+	qd.enforceMaxSize()
+
+	if err := qd.queue.Enqueue(item); err != nil {
+		return fmt.Errorf("failed to enqueue profile: %w", err)
+	}
 
 	return nil
 }
@@ -250,6 +302,7 @@ func (qd *QueueData) processAllItems() {
 	logger.L().Debug("processing queue", helpers.Int("size", queueSize))
 
 	// Process each item in the queue
+processLoop:
 	for i := 0; i < queueSize; i++ {
 		// Try to get an item from the queue
 		iface, err := qd.queue.Dequeue()
@@ -273,52 +326,80 @@ func (qd *QueueData) processAllItems() {
 		// Attempt to create the profile
 		err = qd.creator.CreateContainerProfileDirect(queuedProfile.Profile)
 		if err != nil {
+			// An explicit switch, so that a future fourth failureKind cannot silently fall
+			// through to the retryable branch.
 			kind, reported := classifyFailure(err)
-			if kind == failureTerminal {
+			switch kind {
+			case failureTerminal:
 				logger.L().Debug("got rejected to create container profile, skipping",
 					helpers.String("name", queuedProfile.Profile.Name),
 					helpers.Error(err))
 
 				// Call error callback if provided to propagate the error. The sentinel is
 				// reported rather than err itself, so that the manager can map it onto the
-				// right terminal container status even when the transport lost the sentinel
-				// (an HTTP 413 from storage's QueueManager carries no sentinel at all).
+				// right terminal container status even when the transport lost the sentinel.
 				if qd.errorCallback != nil {
 					qd.errorCallback.OnQueueError(queuedProfile.Profile, queuedProfile.ContainerID, reported)
 				}
-				continue
-			}
 
-			// Retryable failure. Bound the number of retries so that an item which never
-			// succeeds cannot occupy the queue indefinitely: requeuing appends to the tail
-			// while enforceMaxSize evicts from the head, so an unbounded retry would push
-			// out newer profiles that could have been saved.
-			queuedProfile.Attempts++
-			if queuedProfile.Attempts >= qd.maxAttempts {
-				logger.L().Warning("dropping container profile after too many failed attempts",
+			case failureSplit:
+				// A bare 413 rejects this one delta for its size; it says nothing about the
+				// container, so learning continues and only the chunk is shed.
+				switch {
+				case queuedProfile.IsStitch:
+					qd.dropChunk(queuedProfile, dropReasonStitchRejected)
+				case queuedProfile.SplitDepth >= qd.maxSplitDepth:
+					qd.dropChunk(queuedProfile, dropReasonDepthExhausted)
+				default:
+					a, b, ok := splitProfile(queuedProfile.Profile)
+					if !ok {
+						qd.dropChunk(queuedProfile, dropReasonUnsplittable)
+						continue
+					}
+
+					logger.L().Debug("splitting container profile rejected with 413",
+						helpers.String("name", queuedProfile.Profile.Name),
+						helpers.String("namespace", queuedProfile.Profile.Namespace),
+						helpers.Int("splitDepth", queuedProfile.SplitDepth),
+						helpers.Int("elements", countPartitionableElements(&queuedProfile.Profile.Spec)),
+						helpers.Int("bytes", serializedSize(queuedProfile.Profile)))
+
+					qd.splits.Add(1)
+					qd.metrics.ReportContainerProfileSplit()
+					qd.requeueSplit(queuedProfile, a, b)
+				}
+
+			case failureRetryable:
+				// Bound the number of retries so that an item which never succeeds cannot
+				// occupy the queue indefinitely: requeuing appends to the tail while
+				// enforceMaxSize evicts from the head, so an unbounded retry would push out
+				// newer profiles that could have been saved.
+				queuedProfile.Attempts++
+				if queuedProfile.Attempts >= qd.maxAttempts {
+					logger.L().Warning("dropping container profile after too many failed attempts",
+						helpers.String("name", queuedProfile.Profile.Name),
+						helpers.String("namespace", queuedProfile.Profile.Namespace),
+						helpers.String("containerID", queuedProfile.ContainerID),
+						helpers.Int("attempts", queuedProfile.Attempts),
+						helpers.Error(err))
+					continue
+				}
+
+				logger.L().Debug("failed to create container profile, requeuing",
 					helpers.String("name", queuedProfile.Profile.Name),
-					helpers.String("namespace", queuedProfile.Profile.Namespace),
-					helpers.String("containerID", queuedProfile.ContainerID),
 					helpers.Int("attempts", queuedProfile.Attempts),
 					helpers.Error(err))
-				continue
-			}
 
-			logger.L().Debug("failed to create container profile, requeuing",
-				helpers.String("name", queuedProfile.Profile.Name),
-				helpers.Int("attempts", queuedProfile.Attempts),
-				helpers.Error(err))
+				qd.requeueImmediate(queuedProfile)
 
-			qd.requeueImmediate(queuedProfile)
+				// Check for "too many requests" error
+				if strings.Contains(err.Error(), "the server has received too many requests and has asked us to try again later") {
+					logger.L().Debug("server overloaded, breaking processing loop and waiting for next interval",
+						helpers.String("name", queuedProfile.Profile.Name),
+						helpers.Error(err))
 
-			// Check for "too many requests" error
-			if strings.Contains(err.Error(), "the server has received too many requests and has asked us to try again later") {
-				logger.L().Debug("server overloaded, breaking processing loop and waiting for next interval",
-					helpers.String("name", queuedProfile.Profile.Name),
-					helpers.Error(err))
-
-				// Break from the for loop
-				break
+					break processLoop
+				}
 			}
 
 		} else {
@@ -334,16 +415,100 @@ func (qd *QueueData) requeueImmediate(queuedProfile *QueuedContainerProfile) {
 	qd.mu.Lock()
 	defer qd.mu.Unlock()
 
-	if qd.running {
-		// Enforce max size before requeuing
-		qd.enforceMaxSize()
+	if err := qd.enqueueLocked(queuedProfile); err != nil {
+		logger.L().Debug("failed to requeue container profile",
+			helpers.String("name", queuedProfile.Profile.Name),
+			helpers.Error(err))
+	}
+}
 
-		err := qd.queue.Enqueue(queuedProfile)
-		if err != nil {
-			logger.L().Error("failed to requeue container profile",
-				helpers.String("name", queuedProfile.Profile.Name),
-				helpers.Error(err))
+// requeueSplit enqueues both halves of a split chunk under a single lock acquisition, so the
+// two halves are never separated by a concurrent Enqueue or by an intervening eviction sweep.
+//
+// Both halves inherit parent.Attempts, take SplitDepth = parent.SplitDepth+1, and are explicitly
+// IsStitch = false (the zero value - stated because a half must always remain splittable).
+//
+// Callers must NOT hold qd.mu.
+func (qd *QueueData) requeueSplit(parent *QueuedContainerProfile, a, b *v1beta1.ContainerProfile) {
+	half := func(profile *v1beta1.ContainerProfile) *QueuedContainerProfile {
+		return &QueuedContainerProfile{
+			Profile:     profile,
+			ContainerID: parent.ContainerID,
+			Attempts:    parent.Attempts,
+			SplitDepth:  parent.SplitDepth + 1,
+			IsStitch:    false,
 		}
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	if err := qd.enqueueLocked(half(a)); err != nil {
+		logger.L().Debug("failed to enqueue the first half of a split container profile",
+			helpers.String("name", a.Name),
+			helpers.Error(err))
+		return
+	}
+
+	if err := qd.enqueueLocked(half(b)); err != nil {
+		// Exactly one half of a pair survived, which forks the container's report chain.
+		logger.L().Warning("failed to enqueue the second half of a split container profile, its report chain is now forked",
+			helpers.String("name", b.Name),
+			helpers.String("namespace", b.Namespace),
+			helpers.String("containerID", parent.ContainerID),
+			helpers.Error(err))
+	}
+}
+
+// dropChunk discards a chunk that was rejected for its size and cannot be split further.
+//
+// It deliberately does NOT call errorCallback.OnQueueError: that path ends learning for the
+// whole container, which is the behaviour this change exists to remove. Losing one delta is
+// strictly better than losing every future delta.
+//
+// It enqueues a stitch chunk in the dropped chunk's place so the report chain stays linear
+// (see chainHalves); without it, dropping one half of a pair forks the chain and hangs the
+// profile in Learning. A dropped stitch is never re-stitched: that would loop forever, since
+// neither drop path touches Attempts.
+//
+// Callers must NOT hold qd.mu.
+func (qd *QueueData) dropChunk(dropped *QueuedContainerProfile, reason dropReason) {
+	logger.L().Warning("dropping oversized container profile chunk",
+		helpers.String("name", dropped.Profile.Name),
+		helpers.String("namespace", dropped.Profile.Namespace),
+		helpers.String("containerID", dropped.ContainerID),
+		helpers.String("reason", string(reason)),
+		helpers.Int("splitDepth", dropped.SplitDepth),
+		helpers.Int("bytes", serializedSize(dropped.Profile)))
+
+	qd.chunksDropped.Add(1)
+	qd.metrics.ReportContainerProfileChunkDropped(string(reason))
+
+	if dropped.IsStitch {
+		return
+	}
+
+	stitch := &QueuedContainerProfile{
+		Profile:     stitchChunk(dropped.Profile),
+		ContainerID: dropped.ContainerID,
+		Attempts:    dropped.Attempts,
+		SplitDepth:  qd.maxSplitDepth,
+		IsStitch:    true,
+	}
+
+	qd.mu.Lock()
+	err := qd.enqueueLocked(stitch)
+	qd.mu.Unlock()
+
+	if err != nil {
+		logger.L().Warning("failed to enqueue replacement stitch chunk, the report chain is now forked",
+			helpers.String("name", stitch.Profile.Name),
+			helpers.String("namespace", stitch.Profile.Namespace),
+			helpers.String("containerID", dropped.ContainerID),
+			helpers.Error(err))
+
+		qd.chunksDropped.Add(1)
+		qd.metrics.ReportContainerProfileChunkDropped(string(dropReasonEnqueueFailed))
 	}
 }
 
@@ -357,11 +522,20 @@ func (qd *QueueData) GetQueueSize() int {
 
 // GetQueueStats returns basic statistics about the queue
 func (qd *QueueData) GetQueueStats() map[string]interface{} {
+	// running is written under qd.mu by Close, so it must be read under it too.
+	qd.mu.Lock()
+	running := qd.running
+	size := qd.GetQueueSize()
+	qd.mu.Unlock()
+
 	return map[string]interface{}{
-		"size":          qd.GetQueueSize(),
+		"size":          size,
 		"maxQueueSize":  qd.maxQueueSize,
+		"maxSplitDepth": qd.maxSplitDepth,
 		"retryInterval": qd.retryInterval.String(),
-		"running":       qd.running,
+		"running":       running,
+		"splits":        qd.splits.Load(),
+		"chunksDropped": qd.chunksDropped.Load(),
 	}
 }
 

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
@@ -444,9 +444,38 @@ func (qd *QueueData) requeueSplit(parent *QueuedContainerProfile, a, b *v1beta1.
 	defer qd.mu.Unlock()
 
 	if err := qd.enqueueLocked(half(a)); err != nil {
-		logger.L().Debug("failed to enqueue the first half of a split container profile",
+		// The parent was already dequeued, so neither half reaches the queue: this is a
+		// total loss of the chunk, not just a fork, and must be at least as loud as the
+		// second-half case below. Unlike that case, nothing of the parent's data survives
+		// to carry its (previousReportTimestamp, reportTimestamp] interval forward, so the
+		// stitch is built from parent.Profile itself - that interval is exactly what needs
+		// repairing since it never reached the queue in any form.
+		logger.L().Warning("failed to enqueue the first half of a split container profile, both halves are lost",
 			helpers.String("name", a.Name),
+			helpers.String("namespace", a.Namespace),
+			helpers.String("containerID", parent.ContainerID),
 			helpers.Error(err))
+
+		qd.chunksDropped.Add(1)
+		qd.metrics.ReportContainerProfileChunkDropped(string(dropReasonEnqueueFailed))
+
+		stitch := &QueuedContainerProfile{
+			Profile:     stitchChunk(parent.Profile),
+			ContainerID: parent.ContainerID,
+			Attempts:    parent.Attempts,
+			SplitDepth:  qd.maxSplitDepth,
+			IsStitch:    true,
+		}
+		if stitchErr := qd.enqueueLocked(stitch); stitchErr != nil {
+			logger.L().Warning("failed to enqueue replacement stitch chunk after a lost split, the report chain is now forked",
+				helpers.String("name", stitch.Profile.Name),
+				helpers.String("namespace", stitch.Profile.Namespace),
+				helpers.String("containerID", parent.ContainerID),
+				helpers.Error(stitchErr))
+
+			qd.chunksDropped.Add(1)
+			qd.metrics.ReportContainerProfileChunkDropped(string(dropReasonEnqueueFailed))
+		}
 		return
 	}
 
@@ -457,6 +486,9 @@ func (qd *QueueData) requeueSplit(parent *QueuedContainerProfile, a, b *v1beta1.
 			helpers.String("namespace", b.Namespace),
 			helpers.String("containerID", parent.ContainerID),
 			helpers.Error(err))
+
+		qd.chunksDropped.Add(1)
+		qd.metrics.ReportContainerProfileChunkDropped(string(dropReasonEnqueueFailed))
 	}
 }
 

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/node-agent/pkg/storage"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
-	"github.com/kubescape/storage/pkg/registry/file"
 )
 
 const (
@@ -29,12 +28,20 @@ const (
 	ItemsPerSegment = 100
 	// DefaultMaxQueueSize is the default maximum size of the queue
 	DefaultMaxQueueSize = 1000
+	// DefaultMaxAttempts is the default number of times a single queued profile is retried
+	// before it is dropped. Without a bound, a profile that can never be accepted is
+	// retried forever, and because the queue is disk-persistent it survives pod restarts.
+	DefaultMaxAttempts = 10
 )
 
 // QueuedContainerProfile represents a container profile queued for creation
 type QueuedContainerProfile struct {
 	Profile     *v1beta1.ContainerProfile `json:"profile"`
 	ContainerID string                    `json:"containerID"`
+	// Attempts counts how many times creation of this profile has failed with a
+	// retryable error. Items persisted before this field existed decode with Attempts
+	// at zero, so they simply get a full budget of retries.
+	Attempts int `json:"attempts"`
 }
 
 // QueuedContainerProfileBuilder creates a new QueuedContainerProfile instance for dque
@@ -54,6 +61,7 @@ type QueueData struct {
 	creator       storage.ProfileCreator
 	errorCallback ErrorCallback
 	maxQueueSize  int
+	maxAttempts   int
 	retryInterval time.Duration
 
 	stopChan chan struct{}
@@ -67,6 +75,7 @@ type QueueConfig struct {
 	QueueName       string
 	QueueDir        string
 	MaxQueueSize    int
+	MaxAttempts     int
 	RetryInterval   time.Duration
 	ItemsPerSegment int
 	ErrorCallback   ErrorCallback
@@ -83,6 +92,9 @@ func NewQueueData(ctx context.Context, creator storage.ProfileCreator, config Qu
 	}
 	if config.MaxQueueSize == 0 {
 		config.MaxQueueSize = DefaultMaxQueueSize
+	}
+	if config.MaxAttempts <= 0 {
+		config.MaxAttempts = DefaultMaxAttempts
 	}
 	if config.RetryInterval == 0 {
 		config.RetryInterval = DefaultRetryInterval
@@ -123,6 +135,7 @@ func NewQueueData(ctx context.Context, creator storage.ProfileCreator, config Qu
 		creator:       creator,
 		errorCallback: config.ErrorCallback,
 		maxQueueSize:  config.MaxQueueSize,
+		maxAttempts:   config.MaxAttempts,
 		retryInterval: config.RetryInterval,
 		stopChan:      make(chan struct{}),
 		running:       true,
@@ -253,20 +266,40 @@ func (qd *QueueData) processAllItems() {
 		// Attempt to create the profile
 		err = qd.creator.CreateContainerProfileDirect(queuedProfile.Profile)
 		if err != nil {
-			if err.Error() == file.ObjectTooLargeError.Error() || err.Error() == file.ObjectCompletedError.Error() {
+			kind, reported := classifyFailure(err)
+			if kind == failureTerminal {
 				logger.L().Debug("got rejected to create container profile, skipping",
 					helpers.String("name", queuedProfile.Profile.Name),
 					helpers.Error(err))
 
-				// Call error callback if provided to propagate the error
+				// Call error callback if provided to propagate the error. The sentinel is
+				// reported rather than err itself, so that the manager can map it onto the
+				// right terminal container status even when the transport lost the sentinel
+				// (an HTTP 413 from storage's QueueManager carries no sentinel at all).
 				if qd.errorCallback != nil {
-					qd.errorCallback.OnQueueError(queuedProfile.Profile, queuedProfile.ContainerID, err)
+					qd.errorCallback.OnQueueError(queuedProfile.Profile, queuedProfile.ContainerID, reported)
 				}
+				continue
+			}
+
+			// Retryable failure. Bound the number of retries so that an item which never
+			// succeeds cannot occupy the queue indefinitely: requeuing appends to the tail
+			// while enforceMaxSize evicts from the head, so an unbounded retry would push
+			// out newer profiles that could have been saved.
+			queuedProfile.Attempts++
+			if queuedProfile.Attempts >= qd.maxAttempts {
+				logger.L().Warning("dropping container profile after too many failed attempts",
+					helpers.String("name", queuedProfile.Profile.Name),
+					helpers.String("namespace", queuedProfile.Profile.Namespace),
+					helpers.String("containerID", queuedProfile.ContainerID),
+					helpers.Int("attempts", queuedProfile.Attempts),
+					helpers.Error(err))
 				continue
 			}
 
 			logger.L().Debug("failed to create container profile, requeuing",
 				helpers.String("name", queuedProfile.Profile.Name),
+				helpers.Int("attempts", queuedProfile.Attempts),
 				helpers.Error(err))
 
 			qd.requeueImmediate(queuedProfile)

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue.go
@@ -31,7 +31,14 @@ const (
 	// DefaultMaxAttempts is the default number of times a single queued profile is retried
 	// before it is dropped. Without a bound, a profile that can never be accepted is
 	// retried forever, and because the queue is disk-persistent it survives pod restarts.
-	DefaultMaxAttempts = 10
+	//
+	// The bound exists to shed permanently-failing items, not to give up on a reachable
+	// storage, so it is deliberately generous: at DefaultRetryInterval this is roughly
+	// 30 minutes, which comfortably outlasts a storage rollout, image pull or node
+	// eviction. Dropping a profile loses data the container has already stopped tracking,
+	// so a tight bound would trade the infinite-retry bug for silent loss during an
+	// ordinary restart.
+	DefaultMaxAttempts = 360
 )
 
 // QueuedContainerProfile represents a container profile queued for creation

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
@@ -16,32 +16,35 @@ const (
 	failureRetryable failureKind = iota
 	// failureTerminal means the profile can never be accepted, so learning ends for the container.
 	failureTerminal
+	// failureSplit means the payload was rejected by the transport for its size alone.
+	// It says nothing about the aggregate, so learning must continue: the chunk is halved
+	// and both halves are requeued.
+	failureSplit
 )
 
 // classifyFailure maps an error returned by storage.ProfileCreator onto the queue's reaction.
 //
-// For terminal failures it also returns the sentinel to hand to ErrorCallback, so that
+// For failureTerminal it also returns the sentinel to hand to ErrorCallback, so that
 // ContainerProfileManager.handleSaveProfileError can end learning with the right status.
+// That contract applies to failureTerminal only: for failureSplit the raw error is returned
+// for logging, and it must never reach ErrorCallback.
 //
-// Sentinels reach us in three shapes, all of which must be recognised:
+// Failures reach us in three shapes, all of which must be recognised:
 //
-//   - wrapped, when storage is used as a library (errors.Is matches);
-//   - as the message of a k8s StatusError, when the apiserver relays the sentinel verbatim
+//   - a wrapped sentinel, when storage is used as a library (errors.Is matches);
+//   - a sentinel as the message of a k8s StatusError, when the apiserver relays it verbatim
 //     (StatusError.Error() returns only the message, so a substring match is needed - storage
 //     wraps the sentinel in a size-specific prefix on some paths);
-//   - as an HTTP 413 with a plain-text body, when storage's QueueManager rejects the request
+//   - a bare HTTP 413 with a plain-text body, when storage's QueueManager rejects the request
 //     on Content-Length before it ever reaches the registry. This carries no sentinel at all,
 //     which is why it must be matched on the status code.
+//
+// The two sentinel checks run before the status-code check so that an authoritative sentinel
+// always wins over a bare status code: a 413 whose body happens to relay ObjectTooLargeError
+// is a genuine aggregate verdict and stays terminal.
 func classifyFailure(err error) (failureKind, error) {
 	if err == nil {
 		return failureRetryable, nil
-	}
-
-	// QueueManager rejects oversized requests up front with 413 and a plain-text body, so
-	// there is no Status object to carry a reason. IsRequestEntityTooLargeError matches on
-	// the status code alone, which is what makes this work.
-	if apierrors.IsRequestEntityTooLargeError(err) {
-		return failureTerminal, file.ObjectTooLargeError
 	}
 
 	if matchesSentinel(err, file.ObjectTooLargeError) {
@@ -50,6 +53,13 @@ func classifyFailure(err error) (failureKind, error) {
 
 	if matchesSentinel(err, file.ObjectCompletedError) {
 		return failureTerminal, file.ObjectCompletedError
+	}
+
+	// A bare 413 is a transport rejection of one delta, not a verdict on the aggregate, so
+	// the chunk is halved rather than the container abandoned. IsRequestEntityTooLargeError
+	// matches on the status code alone, which is what makes this work against a plain-text body.
+	if apierrors.IsRequestEntityTooLargeError(err) {
+		return failureSplit, err
 	}
 
 	return failureRetryable, err

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
@@ -67,6 +67,23 @@ func classifyFailure(err error) (failureKind, error) {
 
 // matchesSentinel reports whether err carries the given storage sentinel, either as a
 // wrapped error or as text in the message relayed by the apiserver.
+//
+// The substring fallback is deliberately restricted to *apierrors.StatusError: that's the
+// only shape where the message is known to be a sentinel relayed verbatim by the apiserver
+// (StatusError.Error() returns only the message, and storage wraps the sentinel in a
+// size-specific prefix on some paths, so errors.Is alone can't match it). Applying
+// strings.Contains to every error shape would let any error whose text happens to embed
+// "object is too large" or "object is completed" - e.g. from a proxy or ingress - classify
+// as terminal and end learning for the container, even though it isn't a real sentinel.
 func matchesSentinel(err, sentinel error) bool {
-	return errors.Is(err, sentinel) || strings.Contains(err.Error(), sentinel.Error())
+	if errors.Is(err, sentinel) {
+		return true
+	}
+
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return strings.Contains(statusErr.ErrStatus.Message, sentinel.Error())
+	}
+
+	return false
 }

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors.go
@@ -1,0 +1,62 @@
+package queue
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/kubescape/storage/pkg/registry/file"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// failureKind describes how the queue should react to a failed profile creation.
+type failureKind int
+
+const (
+	// failureRetryable means the failure may resolve on its own, so the item is requeued.
+	failureRetryable failureKind = iota
+	// failureTerminal means the profile can never be accepted, so learning ends for the container.
+	failureTerminal
+)
+
+// classifyFailure maps an error returned by storage.ProfileCreator onto the queue's reaction.
+//
+// For terminal failures it also returns the sentinel to hand to ErrorCallback, so that
+// ContainerProfileManager.handleSaveProfileError can end learning with the right status.
+//
+// Sentinels reach us in three shapes, all of which must be recognised:
+//
+//   - wrapped, when storage is used as a library (errors.Is matches);
+//   - as the message of a k8s StatusError, when the apiserver relays the sentinel verbatim
+//     (StatusError.Error() returns only the message, so a substring match is needed - storage
+//     wraps the sentinel in a size-specific prefix on some paths);
+//   - as an HTTP 413 with a plain-text body, when storage's QueueManager rejects the request
+//     on Content-Length before it ever reaches the registry. This carries no sentinel at all,
+//     which is why it must be matched on the status code.
+func classifyFailure(err error) (failureKind, error) {
+	if err == nil {
+		return failureRetryable, nil
+	}
+
+	// QueueManager rejects oversized requests up front with 413 and a plain-text body, so
+	// there is no Status object to carry a reason. IsRequestEntityTooLargeError matches on
+	// the status code alone, which is what makes this work.
+	if apierrors.IsRequestEntityTooLargeError(err) {
+		return failureTerminal, file.ObjectTooLargeError
+	}
+
+	if matchesSentinel(err, file.ObjectTooLargeError) {
+		return failureTerminal, file.ObjectTooLargeError
+	}
+
+	if matchesSentinel(err, file.ObjectCompletedError) {
+		return failureTerminal, file.ObjectCompletedError
+	}
+
+	return failureRetryable, err
+}
+
+// matchesSentinel reports whether err carries the given storage sentinel, either as a
+// wrapped error or as text in the message relayed by the apiserver.
+func matchesSentinel(err, sentinel error) bool {
+	return errors.Is(err, sentinel) || strings.Contains(err.Error(), sentinel.Error())
+}

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
@@ -1,0 +1,272 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/registry/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// genericStatusError reproduces what client-go builds when the response body is not a
+// Status object, which is what storage's QueueManager returns for an oversized request.
+func genericStatusError(code int) error {
+	return apierrors.NewGenericServerResponse(
+		code, "POST",
+		schema.GroupResource{Group: "spdx.softwarecomposition.kubescape.io", Resource: "containerprofiles"},
+		"cattle-cluster-agent", "", 0, false,
+	)
+}
+
+// relayedStatusError reproduces what client-go builds when the apiserver relays a plain
+// (non-Status) error from the storage registry: the message is carried verbatim.
+func relayedStatusError(message string) error {
+	return &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusInternalServerError,
+		Reason:  metav1.StatusReasonUnknown,
+		Message: message,
+	}}
+}
+
+func TestClassifyFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		wantKind     failureKind
+		wantSentinel error
+	}{
+		{
+			name:     "nil error is not a failure",
+			err:      nil,
+			wantKind: failureRetryable,
+		},
+		{
+			// The ISO Gruppe regression: QueueManager rejects on Content-Length with a
+			// plain-text 413, so the error carries neither sentinel.
+			name:         "http 413 from QueueManager is terminal and reported as too large",
+			err:          genericStatusError(http.StatusRequestEntityTooLarge),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectTooLargeError,
+		},
+		{
+			name:         "wrapped ObjectTooLargeError is terminal",
+			err:          fmt.Errorf("saving profile: %w", file.ObjectTooLargeError),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectTooLargeError,
+		},
+		{
+			name:         "bare ObjectTooLargeError relayed by the apiserver is terminal",
+			err:          relayedStatusError(file.ObjectTooLargeError.Error()),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectTooLargeError,
+		},
+		{
+			// storage prefixes the sentinel with the limit on the application-profile and
+			// network-neighborhood paths, so exact string equality is not enough.
+			name:         "prefixed ObjectTooLargeError relayed by the apiserver is terminal",
+			err:          relayedStatusError("application profile size exceeds the limit of 40000: object is too large"),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectTooLargeError,
+		},
+		{
+			name:         "bare ObjectCompletedError relayed by the apiserver is terminal",
+			err:          relayedStatusError(file.ObjectCompletedError.Error()),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectCompletedError,
+		},
+		{
+			name:         "wrapped ObjectCompletedError is terminal",
+			err:          fmt.Errorf("saving profile: %w", file.ObjectCompletedError),
+			wantKind:     failureTerminal,
+			wantSentinel: file.ObjectCompletedError,
+		},
+		{
+			name:     "server timeout is retryable",
+			err:      relayedStatusError("the server has received too many requests and has asked us to try again later"),
+			wantKind: failureRetryable,
+		},
+		{
+			name:     "connection refused is retryable",
+			err:      errors.New("dial tcp 10.96.0.1:443: connect: connection refused"),
+			wantKind: failureRetryable,
+		},
+		{
+			name:     "conflict is retryable",
+			err:      genericStatusError(http.StatusConflict),
+			wantKind: failureRetryable,
+		},
+		{
+			name:     "internal server error is retryable",
+			err:      genericStatusError(http.StatusInternalServerError),
+			wantKind: failureRetryable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, reported := classifyFailure(tt.err)
+			assert.Equal(t, tt.wantKind, kind)
+
+			if tt.wantKind == failureTerminal {
+				// The sentinel is what ContainerProfileManager.handleSaveProfileError
+				// matches on to pick the terminal container status.
+				assert.Equal(t, tt.wantSentinel, reported)
+			} else {
+				assert.Equal(t, tt.err, reported)
+			}
+		})
+	}
+}
+
+// TestClassifyFailure_413IsNotRequeued guards the specific regression: before this fix a
+// 413 matched neither sentinel by string equality and was requeued forever.
+func TestClassifyFailure_413IsNotRequeued(t *testing.T) {
+	err := genericStatusError(http.StatusRequestEntityTooLarge)
+
+	// Establish that the old exact-equality check really does miss this error, so the
+	// test fails loudly if someone reintroduces it.
+	assert.NotEqual(t, file.ObjectTooLargeError.Error(), err.Error())
+	assert.NotEqual(t, file.ObjectCompletedError.Error(), err.Error())
+
+	kind, reported := classifyFailure(err)
+	assert.Equal(t, failureTerminal, kind)
+	assert.Equal(t, file.ObjectTooLargeError, reported)
+}
+
+// alwaysFailingCreator returns the same error for every create and counts the calls.
+type alwaysFailingCreator struct {
+	mu    sync.Mutex
+	err   error
+	calls int
+}
+
+func (c *alwaysFailingCreator) CreateContainerProfileDirect(*v1beta1.ContainerProfile) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.err
+}
+
+func (c *alwaysFailingCreator) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// recordingCallback captures the errors the queue reports through ErrorCallback.
+type recordingCallback struct {
+	mu     sync.Mutex
+	errors []error
+}
+
+func (r *recordingCallback) OnQueueError(_ *v1beta1.ContainerProfile, _ string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errors = append(r.errors, err)
+}
+
+func (r *recordingCallback) captured() []error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]error(nil), r.errors...)
+}
+
+func startQueue(t *testing.T, creator *alwaysFailingCreator, cb ErrorCallback, maxAttempts int) *QueueData {
+	t.Helper()
+
+	qd, err := NewQueueData(context.Background(), creator, QueueConfig{
+		QueueName:       "test-queue",
+		QueueDir:        t.TempDir(),
+		MaxQueueSize:    10,
+		MaxAttempts:     maxAttempts,
+		RetryInterval:   20 * time.Millisecond,
+		ItemsPerSegment: 10,
+		ErrorCallback:   cb,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = qd.Close() })
+
+	qd.Start()
+	return qd
+}
+
+func testProfile() *v1beta1.ContainerProfile {
+	return &v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "cattle-cluster-agent", Namespace: "cattle-system"},
+	}
+}
+
+// TestQueueEndsLearningOnHTTP413 is the regression test for the ISO Gruppe report: an
+// oversized profile rejected by storage's QueueManager must end learning instead of being
+// retried every RetryInterval forever.
+func TestQueueEndsLearningOnHTTP413(t *testing.T) {
+	creator := &alwaysFailingCreator{err: genericStatusError(http.StatusRequestEntityTooLarge)}
+	cb := &recordingCallback{}
+	qd := startQueue(t, creator, cb, DefaultMaxAttempts)
+
+	require.NoError(t, qd.Enqueue(testProfile(), "container-id"))
+
+	// The item is consumed once and reported as too large.
+	assert.Eventually(t, func() bool {
+		return len(cb.captured()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "expected the profile to be reported through OnQueueError")
+
+	assert.Equal(t, []error{file.ObjectTooLargeError}, cb.captured(),
+		"the sentinel must be reported so the manager sets status=too-large and ends learning")
+	assert.Equal(t, 0, qd.GetQueueSize(), "the rejected profile must not stay in the queue")
+
+	// Give the processor several more ticks to prove there is no retry loop.
+	callsAfterReport := creator.callCount()
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, callsAfterReport, creator.callCount(), "a 413 must not be retried")
+	assert.Equal(t, 1, creator.callCount(), "the profile must be attempted exactly once")
+}
+
+// TestQueueDropsProfileAfterMaxAttempts covers the general case: any error that never
+// resolves must stop consuming the queue rather than starving newer profiles.
+func TestQueueDropsProfileAfterMaxAttempts(t *testing.T) {
+	const maxAttempts = 3
+
+	creator := &alwaysFailingCreator{err: errors.New("dial tcp 10.96.0.1:443: connect: connection refused")}
+	cb := &recordingCallback{}
+	qd := startQueue(t, creator, cb, maxAttempts)
+
+	require.NoError(t, qd.Enqueue(testProfile(), "container-id"))
+
+	assert.Eventually(t, func() bool {
+		return creator.callCount() >= maxAttempts && qd.GetQueueSize() == 0
+	}, 2*time.Second, 10*time.Millisecond, "expected the profile to be dropped after %d attempts", maxAttempts)
+
+	// The retry budget is a hard bound, so no further attempts happen.
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, maxAttempts, creator.callCount(), "attempts must be capped at MaxAttempts")
+	assert.Equal(t, 0, qd.GetQueueSize())
+	assert.Empty(t, cb.captured(), "a retryable failure must not end learning for the container")
+}
+
+// TestNewQueueDataDefaultsMaxAttempts pins the default so an unset config cannot restore
+// the unbounded-retry behaviour.
+func TestNewQueueDataDefaultsMaxAttempts(t *testing.T) {
+	for _, configured := range []int{0, -1} {
+		qd, err := NewQueueData(context.Background(), &alwaysFailingCreator{}, QueueConfig{
+			QueueName:       "test-queue",
+			QueueDir:        t.TempDir(),
+			ItemsPerSegment: 10,
+			MaxAttempts:     configured,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, DefaultMaxAttempts, qd.maxAttempts)
+		require.NoError(t, qd.Close())
+	}
+}

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/node-agent/pkg/metricsmanager"
 	"github.com/kubescape/node-agent/pkg/storage"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file"
@@ -112,6 +113,17 @@ func TestClassifyFailure(t *testing.T) {
 			err:          fmt.Errorf("saving profile: %w", file.ObjectCompletedError),
 			wantKind:     failureTerminal,
 			wantSentinel: file.ObjectCompletedError,
+		},
+		{
+			// This is precisely the input whose classification changed from terminal to
+			// retryable: matchesSentinel's substring fallback used to run against every
+			// error shape, so a plain error whose text merely mentions the sentinel (e.g.
+			// relayed by a proxy or ingress, not by the apiserver as a StatusError) would
+			// misclassify as terminal and end learning. It is now restricted to
+			// *apierrors.StatusError, where the message is known to be a relayed sentinel.
+			name:     "non-StatusError error merely mentioning the sentinel is retryable",
+			err:      errors.New("proxy error: upstream said object is too large"),
+			wantKind: failureRetryable,
 		},
 		{
 			name:     "server timeout is retryable",
@@ -609,4 +621,83 @@ func TestNewQueueDataDefaultsMaxSplitDepth(t *testing.T) {
 		assert.Equal(t, DefaultMaxSplitDepth, qd.maxSplitDepth)
 		require.NoError(t, qd.Close())
 	}
+}
+
+// spyMetrics wraps MetricsNoop and records split/drop calls, so tests can assert on the
+// exact reasons reported without depending on GetQueueStats's internal counters alone.
+type spyMetrics struct {
+	*metricsmanager.MetricsNoop
+	mu      sync.Mutex
+	splits  int
+	dropped []string
+}
+
+func newSpyMetrics() *spyMetrics {
+	return &spyMetrics{MetricsNoop: &metricsmanager.MetricsNoop{}}
+}
+
+func (s *spyMetrics) ReportContainerProfileSplit() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.splits++
+}
+
+func (s *spyMetrics) ReportContainerProfileChunkDropped(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.dropped = append(s.dropped, reason)
+}
+
+func (s *spyMetrics) droppedReasons() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.dropped...)
+}
+
+// TestEnqueueLocked_ReturnsErrQueueNotRunning pins the mechanism requeueSplit's first-half
+// failure path depends on: once the queue is no longer running, enqueueLocked refuses rather
+// than touching the underlying dque.
+func TestEnqueueLocked_ReturnsErrQueueNotRunning(t *testing.T) {
+	qd := startQueue(t, &alwaysFailingCreator{}, &recordingCallback{}, QueueConfig{})
+
+	qd.mu.Lock()
+	qd.running = false
+	qd.mu.Unlock()
+
+	err := qd.enqueueLocked(&QueuedContainerProfile{Profile: testProfile(), ContainerID: "container-id"})
+	assert.ErrorIs(t, err, ErrQueueNotRunning)
+	assert.Equal(t, 0, qd.GetQueueSize())
+}
+
+// TestRequeueSplit_QueueNotRunningDropsBothHalvesAndAttemptsStitch covers the path a previous
+// review found untested: when the queue stops running between a chunk being dequeued for
+// splitting and its halves being re-enqueued - reachable during Close while processAllItems is
+// still mid-flight - requeueSplit must not silently lose the chunk. Both the lost-halves case
+// and the stitch-also-failed case must be logged and counted, never swallowed.
+func TestRequeueSplit_QueueNotRunningDropsBothHalvesAndAttemptsStitch(t *testing.T) {
+	spy := newSpyMetrics()
+	qd := startQueue(t, &alwaysFailingCreator{}, &recordingCallback{}, QueueConfig{MetricsManager: spy})
+
+	parent := testProfile()
+	parent.Spec.Capabilities = []string{"cap-a", "cap-b"}
+	a, b, ok := splitProfile(parent)
+	require.True(t, ok, "fixture must be splittable")
+
+	queuedParent := &QueuedContainerProfile{
+		Profile:     parent,
+		ContainerID: "container-id",
+		Attempts:    2,
+		SplitDepth:  1,
+	}
+
+	qd.mu.Lock()
+	qd.running = false
+	qd.mu.Unlock()
+
+	qd.requeueSplit(queuedParent, a, b)
+
+	assert.Equal(t, 0, qd.GetQueueSize(), "neither half nor the stitch can land while the queue isn't running")
+	assert.Equal(t, int64(2), qd.chunksDropped.Load(),
+		"both the lost-halves case and the stitch-also-failed case must be counted")
+	assert.Equal(t, []string{string(dropReasonEnqueueFailed), string(dropReasonEnqueueFailed)}, spy.droppedReasons())
 }

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
@@ -255,6 +255,16 @@ func TestQueueDropsProfileAfterMaxAttempts(t *testing.T) {
 	assert.Empty(t, cb.captured(), "a retryable failure must not end learning for the container")
 }
 
+// TestDefaultRetryBudgetOutlastsARestart guards the other side of the bound: the budget
+// must be generous enough that a reachable-but-restarting storage does not cause profiles
+// to be dropped. A tight bound would trade the infinite-retry bug for silent data loss.
+func TestDefaultRetryBudgetOutlastsARestart(t *testing.T) {
+	budget := time.Duration(DefaultMaxAttempts) * DefaultRetryInterval
+
+	assert.GreaterOrEqual(t, budget, 15*time.Minute,
+		"the default retry budget (%s) must outlast a storage rollout, image pull or node eviction", budget)
+}
+
 // TestNewQueueDataDefaultsMaxAttempts pins the default so an unset config cannot restore
 // the unbounded-retry behaviour.
 func TestNewQueueDataDefaultsMaxAttempts(t *testing.T) {

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_errors_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/node-agent/pkg/storage"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/kubescape/storage/pkg/registry/file"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +41,17 @@ func relayedStatusError(message string) error {
 	}}
 }
 
+// relayedStatusErrorWithCode is relayedStatusError but with an explicit HTTP code, so tests
+// can reproduce a 413 whose body happens to relay a sentinel's text.
+func relayedStatusErrorWithCode(code int, message string) error {
+	return &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    int32(code),
+		Reason:  metav1.StatusReasonUnknown,
+		Message: message,
+	}}
+}
+
 func TestClassifyFailure(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -53,9 +66,18 @@ func TestClassifyFailure(t *testing.T) {
 		},
 		{
 			// The ISO Gruppe regression: QueueManager rejects on Content-Length with a
-			// plain-text 413, so the error carries neither sentinel.
-			name:         "http 413 from QueueManager is terminal and reported as too large",
-			err:          genericStatusError(http.StatusRequestEntityTooLarge),
+			// plain-text 413, so the error carries neither sentinel. A bare 413 is a
+			// transport rejection of one delta, not an aggregate verdict, so it is split
+			// rather than terminal.
+			name:     "bare http 413 is split, not terminal",
+			err:      genericStatusError(http.StatusRequestEntityTooLarge),
+			wantKind: failureSplit,
+		},
+		{
+			// Pins the §5.1 reordering: an authoritative sentinel always wins over a bare
+			// status code, even when that status code happens to be 413.
+			name:         "413 that relays ObjectTooLargeError is terminal, not split",
+			err:          relayedStatusErrorWithCode(http.StatusRequestEntityTooLarge, file.ObjectTooLargeError.Error()),
 			wantKind:     failureTerminal,
 			wantSentinel: file.ObjectTooLargeError,
 		},
@@ -129,9 +151,10 @@ func TestClassifyFailure(t *testing.T) {
 	}
 }
 
-// TestClassifyFailure_413IsNotRequeued guards the specific regression: before this fix a
-// 413 matched neither sentinel by string equality and was requeued forever.
-func TestClassifyFailure_413IsNotRequeued(t *testing.T) {
+// TestClassifyFailure_413IsSplitNotTerminal guards the specific regression: before this fix a
+// 413 matched neither sentinel by string equality and was requeued forever; after it, a bare
+// 413 must classify as failureSplit (not failureTerminal, and not failureRetryable either).
+func TestClassifyFailure_413IsSplitNotTerminal(t *testing.T) {
 	err := genericStatusError(http.StatusRequestEntityTooLarge)
 
 	// Establish that the old exact-equality check really does miss this error, so the
@@ -140,21 +163,25 @@ func TestClassifyFailure_413IsNotRequeued(t *testing.T) {
 	assert.NotEqual(t, file.ObjectCompletedError.Error(), err.Error())
 
 	kind, reported := classifyFailure(err)
-	assert.Equal(t, failureTerminal, kind)
-	assert.Equal(t, file.ObjectTooLargeError, reported)
+	assert.Equal(t, failureSplit, kind)
+	assert.Equal(t, err, reported)
 }
 
-// alwaysFailingCreator returns the same error for every create and counts the calls.
+// alwaysFailingCreator returns the same error for every create, counts the calls, and records
+// every profile it was asked to create (regardless of outcome) so tests can inspect what the
+// queue actually attempted to send - including dropChunk's replacement stitch chunks.
 type alwaysFailingCreator struct {
-	mu    sync.Mutex
-	err   error
-	calls int
+	mu       sync.Mutex
+	err      error
+	calls    int
+	profiles []*v1beta1.ContainerProfile
 }
 
-func (c *alwaysFailingCreator) CreateContainerProfileDirect(*v1beta1.ContainerProfile) error {
+func (c *alwaysFailingCreator) CreateContainerProfileDirect(p *v1beta1.ContainerProfile) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.calls++
+	c.profiles = append(c.profiles, p.DeepCopy())
 	return c.err
 }
 
@@ -162,6 +189,39 @@ func (c *alwaysFailingCreator) callCount() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.calls
+}
+
+func (c *alwaysFailingCreator) attemptedProfiles() []*v1beta1.ContainerProfile {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*v1beta1.ContainerProfile(nil), c.profiles...)
+}
+
+// sizeGatedCreator rejects a create with a bare 413 while the profile still has more than
+// threshold partitionable elements, and records everything it accepts. This gates on element
+// count rather than bytes or elapsed time, so convergence is exact and deterministic.
+type sizeGatedCreator struct {
+	mu        sync.Mutex
+	threshold int
+	accepted  []*v1beta1.ContainerProfile
+}
+
+func (c *sizeGatedCreator) CreateContainerProfileDirect(p *v1beta1.ContainerProfile) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if countPartitionableElements(&p.Spec) > c.threshold {
+		return genericStatusError(http.StatusRequestEntityTooLarge)
+	}
+
+	c.accepted = append(c.accepted, p.DeepCopy())
+	return nil
+}
+
+func (c *sizeGatedCreator) acceptedProfiles() []*v1beta1.ContainerProfile {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]*v1beta1.ContainerProfile(nil), c.accepted...)
 }
 
 // recordingCallback captures the errors the queue reports through ErrorCallback.
@@ -182,18 +242,29 @@ func (r *recordingCallback) captured() []error {
 	return append([]error(nil), r.errors...)
 }
 
-func startQueue(t *testing.T, creator *alwaysFailingCreator, cb ErrorCallback, maxAttempts int) *QueueData {
+// startQueue starts a QueueData for testing. cfg is an overlay: any zero-valued field is
+// filled with a fast test default. ErrorCallback is always taken from cb, not cfg.
+func startQueue(t *testing.T, creator storage.ProfileCreator, cb ErrorCallback, cfg QueueConfig) *QueueData {
 	t.Helper()
 
-	qd, err := NewQueueData(context.Background(), creator, QueueConfig{
-		QueueName:       "test-queue",
-		QueueDir:        t.TempDir(),
-		MaxQueueSize:    10,
-		MaxAttempts:     maxAttempts,
-		RetryInterval:   20 * time.Millisecond,
-		ItemsPerSegment: 10,
-		ErrorCallback:   cb,
-	})
+	if cfg.QueueName == "" {
+		cfg.QueueName = "test-queue"
+	}
+	if cfg.QueueDir == "" {
+		cfg.QueueDir = t.TempDir()
+	}
+	if cfg.MaxQueueSize == 0 {
+		cfg.MaxQueueSize = 10
+	}
+	if cfg.RetryInterval == 0 {
+		cfg.RetryInterval = 20 * time.Millisecond
+	}
+	if cfg.ItemsPerSegment == 0 {
+		cfg.ItemsPerSegment = 10
+	}
+	cfg.ErrorCallback = cb
+
+	qd, err := NewQueueData(context.Background(), creator, cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = qd.Close() })
 
@@ -201,36 +272,279 @@ func startQueue(t *testing.T, creator *alwaysFailingCreator, cb ErrorCallback, m
 	return qd
 }
 
+// testProfile returns a minimal but production-shaped profile: a real (previousReportTimestamp,
+// reportTimestamp] pair built from actual time.Now() calls (never time.Date, which would mask
+// the monotonic-suffix bug - see parseReportTimestamp) plus a ReportSeriesIdMetadataKey
+// annotation. Without these, queue-level split tests would silently only exercise
+// chainHalves's refuse-and-drop path while appearing to pass.
+//
+// The name already carries a one-time-slug suffix (base + "-" + 32 hex chars), matching what
+// every real profile name looks like (GetOneTimeSlug). freshOneTimeSlug regenerates a
+// same-length suffix on top of it, so splitting never inflates the name - a short, sluggless
+// name would make the regenerated 32-hex suffix dwarf a small partitionable payload and trip
+// the byte-progress guard for reasons that have nothing to do with what a test is checking.
 func testProfile() *v1beta1.ContainerProfile {
+	prev := time.Now().Add(-time.Hour)
+	rt := time.Now()
+
 	return &v1beta1.ContainerProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "cattle-cluster-agent", Namespace: "cattle-system"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cattle-cluster-agent-0123456789abcdef0123456789abcdef",
+			Namespace: "cattle-system",
+			Annotations: map[string]string{
+				helpersv1.ReportSeriesIdMetadataKey:          "test-series-id",
+				helpersv1.PreviousReportTimestampMetadataKey: prev.String(),
+				helpersv1.ReportTimestampMetadataKey:         rt.String(),
+			},
+		},
 	}
 }
 
-// TestQueueEndsLearningOnHTTP413 is the regression test for the ISO Gruppe report: an
-// oversized profile rejected by storage's QueueManager must end learning instead of being
-// retried every RetryInterval forever.
-func TestQueueEndsLearningOnHTTP413(t *testing.T) {
+// trackPeakQueueSize polls qd's queue size in the background and reports the maximum observed.
+// Split tests use it to assert the queue never actually hit MaxQueueSize during the run, since
+// hitting the cap would silently invalidate a "no data lost" assertion via LRU eviction.
+func trackPeakQueueSize(qd *QueueData) (peak func() int, stop func()) {
+	var mu sync.Mutex
+	var max int
+	var once sync.Once
+
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if s := qd.GetQueueSize(); s > max {
+					mu.Lock()
+					max = s
+					mu.Unlock()
+				}
+			}
+		}
+	}()
+
+	return func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return max
+		}, func() {
+			once.Do(func() { close(done) })
+		}
+}
+
+// TestQueueSplitsProfileOnHTTP413 replaces TestQueueEndsLearningOnHTTP413: after the fix, a
+// bare 413 no longer ends learning. The queue must instead halve the rejected chunk and keep
+// retrying both halves until storage accepts them.
+func TestQueueSplitsProfileOnHTTP413(t *testing.T) {
+	profile := testProfile()
+	profile.Spec.Capabilities = []string{"cap-0", "cap-1", "cap-2", "cap-3", "cap-4", "cap-5", "cap-6", "cap-7"}
+
+	creator := &sizeGatedCreator{threshold: 2}
+	cb := &recordingCallback{}
+	qd := startQueue(t, creator, cb, QueueConfig{MaxQueueSize: 32, RetryInterval: 20 * time.Millisecond})
+
+	peak, stop := trackPeakQueueSize(qd)
+	defer stop()
+
+	require.NoError(t, qd.Enqueue(profile, "container-id"))
+
+	assert.Eventually(t, func() bool {
+		return qd.GetQueueSize() == 0 && len(creator.acceptedProfiles()) > 0
+	}, 5*time.Second, 20*time.Millisecond, "expected the split chunks to eventually be accepted")
+
+	stop()
+	accepted := creator.acceptedProfiles()
+	require.NotEmpty(t, accepted)
+
+	baseName, _ := file.SplitProfileName(profile.Name)
+	seen := map[string]bool{}
+	var union []string
+	var rows []tsRow
+
+	for _, p := range accepted {
+		for _, c := range p.Spec.Capabilities {
+			assert.False(t, seen[c], "capability %q duplicated across accepted chunks", c)
+			seen[c] = true
+			union = append(union, c)
+		}
+
+		name, _ := file.SplitProfileName(p.Name)
+		assert.Equal(t, baseName, name, "every accepted chunk must share the original's aggregate base name")
+
+		rows = append(rows, rowOf(p))
+	}
+
+	assert.ElementsMatch(t, profile.Spec.Capabilities, union, "the union of accepted chunks must equal the original set exactly")
+	assert.Empty(t, cb.captured(), "learning must never end on a 413 path")
+
+	sortRowsDesc(rows)
+	assertChainIsLinear(t, rows,
+		profile.Annotations[helpersv1.PreviousReportTimestampMetadataKey],
+		profile.Annotations[helpersv1.ReportTimestampMetadataKey])
+
+	golden := consolidateGolden(rows)
+	require.Len(t, golden, 1)
+
+	assert.Less(t, peak(), 32, "the queue must never reach MaxQueueSize during the run")
+}
+
+// TestQueueDropsUnsplittableProfileOnHTTP413 is the floor case and the single most important
+// regression guard for D2: a chunk that cannot be split further must still not end learning.
+func TestQueueDropsUnsplittableProfileOnHTTP413(t *testing.T) {
+	profile := testProfile()
+	profile.Spec.Capabilities = []string{"only"}
+	profile.Spec.SeccompProfile = v1beta1.SingleSeccompProfile{Name: "seccomp-1"}
+	profile.Spec.ImageID = "sha256:deadbeef"
+	profile.Spec.ImageTag = "v1.2.3"
+
 	creator := &alwaysFailingCreator{err: genericStatusError(http.StatusRequestEntityTooLarge)}
 	cb := &recordingCallback{}
-	qd := startQueue(t, creator, cb, DefaultMaxAttempts)
+	qd := startQueue(t, creator, cb, QueueConfig{MaxQueueSize: 8})
 
-	require.NoError(t, qd.Enqueue(testProfile(), "container-id"))
+	peak, stop := trackPeakQueueSize(qd)
+	defer stop()
 
-	// The item is consumed once and reported as too large.
+	require.NoError(t, qd.Enqueue(profile, "container-id"))
+
 	assert.Eventually(t, func() bool {
-		return len(cb.captured()) == 1
-	}, 2*time.Second, 10*time.Millisecond, "expected the profile to be reported through OnQueueError")
+		return qd.GetQueueSize() == 0 && creator.callCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "expected the original and its replacement stitch to both be attempted")
 
-	assert.Equal(t, []error{file.ObjectTooLargeError}, cb.captured(),
-		"the sentinel must be reported so the manager sets status=too-large and ends learning")
-	assert.Equal(t, 0, qd.GetQueueSize(), "the rejected profile must not stay in the queue")
-
-	// Give the processor several more ticks to prove there is no retry loop.
-	callsAfterReport := creator.callCount()
+	// No further attempts: the stitch is never itself re-stitched.
+	callsAfterDrain := creator.callCount()
 	time.Sleep(200 * time.Millisecond)
-	assert.Equal(t, callsAfterReport, creator.callCount(), "a 413 must not be retried")
-	assert.Equal(t, 1, creator.callCount(), "the profile must be attempted exactly once")
+	assert.Equal(t, callsAfterDrain, creator.callCount())
+
+	stop()
+	attempts := creator.attemptedProfiles()
+	require.Len(t, attempts, 2, "exactly the original and its stitch replacement must be attempted")
+
+	original := attempts[0]
+	assert.Equal(t, []string{"only"}, original.Spec.Capabilities)
+
+	stitch := attempts[1]
+	assert.Equal(t, profile.Spec.SeccompProfile, stitch.Spec.SeccompProfile)
+	assert.Equal(t, profile.Spec.ImageID, stitch.Spec.ImageID)
+	assert.Equal(t, profile.Spec.ImageTag, stitch.Spec.ImageTag)
+	assert.Empty(t, stitch.Spec.Capabilities)
+	assert.Equal(t, profile.Annotations[helpersv1.PreviousReportTimestampMetadataKey], stitch.Annotations[helpersv1.PreviousReportTimestampMetadataKey])
+	assert.Equal(t, profile.Annotations[helpersv1.ReportTimestampMetadataKey], stitch.Annotations[helpersv1.ReportTimestampMetadataKey])
+
+	assert.Empty(t, cb.captured(), "learning must never end on a 413 path, even in the floor case")
+	assert.Equal(t, 0, qd.GetQueueSize())
+	assert.Less(t, peak(), 8)
+}
+
+// TestQueueRespectsMaxSplitDepth bounds the split storm: with MaxSplitDepth set low, a
+// richly-populated profile that always 413s must still terminate rather than split forever.
+func TestQueueRespectsMaxSplitDepth(t *testing.T) {
+	const maxSplitDepth = 2
+
+	profile := testProfile()
+	profile.Spec.Capabilities = []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+
+	creator := &alwaysFailingCreator{err: genericStatusError(http.StatusRequestEntityTooLarge)}
+	cb := &recordingCallback{}
+	qd := startQueue(t, creator, cb, QueueConfig{MaxQueueSize: 64, MaxSplitDepth: maxSplitDepth})
+
+	peak, stop := trackPeakQueueSize(qd)
+	defer stop()
+
+	require.NoError(t, qd.Enqueue(profile, "container-id"))
+
+	// The queue can transiently read size 0 between an item being dequeued and its split
+	// children (or stitch replacement) being re-enqueued within the same tick, so require
+	// size 0 to hold across a settle window before treating the queue as actually drained -
+	// otherwise this flakes by snapshotting callCount mid-tree-expansion.
+	require.Eventually(t, func() bool {
+		if qd.GetQueueSize() != 0 {
+			return false
+		}
+		time.Sleep(50 * time.Millisecond)
+		return qd.GetQueueSize() == 0
+	}, 5*time.Second, 20*time.Millisecond, "expected the queue to drain rather than split forever")
+
+	// The tree bounded by MaxSplitDepth, plus one stitch per dropped leaf, must stop growing.
+	callsAfterDrain := creator.callCount()
+	time.Sleep(200 * time.Millisecond)
+	assert.Equal(t, callsAfterDrain, creator.callCount(), "attempts must stop once the queue has drained")
+
+	stop()
+	assert.LessOrEqual(t, creator.callCount(), 1<<(maxSplitDepth+2),
+		"total attempts must be bounded by the depth cap, not grow without limit")
+	assert.Empty(t, cb.captured())
+	assert.Less(t, peak(), 64)
+}
+
+// TestQueueDoesNotStitchAStitch is the B2 regression guard: without the IsStitch check, a
+// dropped stitch would itself be stitched, forever, since neither drop path touches Attempts.
+func TestQueueDoesNotStitchAStitch(t *testing.T) {
+	profile := testProfile()
+	profile.Spec.Capabilities = []string{"only"} // floor case: cannot split, must be dropped
+
+	creator := &alwaysFailingCreator{err: genericStatusError(http.StatusRequestEntityTooLarge)}
+	cb := &recordingCallback{}
+	qd := startQueue(t, creator, cb, QueueConfig{MaxQueueSize: 8, RetryInterval: 10 * time.Millisecond})
+
+	require.NoError(t, qd.Enqueue(profile, "container-id"))
+
+	assert.Eventually(t, func() bool {
+		return qd.GetQueueSize() == 0 && creator.callCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Run for many more ticks than a runaway stitch->413->stitch loop would need to explode.
+	time.Sleep(300 * time.Millisecond)
+
+	assert.LessOrEqual(t, creator.callCount(), 3, "a dropped stitch must never itself be re-stitched")
+	assert.Equal(t, 0, qd.GetQueueSize(), "the queue must drain rather than grow without limit")
+	assert.Empty(t, cb.captured())
+}
+
+// TestQueuePersistsSplitDepth closes §8 assumption 4: SplitDepth and IsStitch must survive
+// dque's gob-based persistence, or IsStitch failing to persist would silently restore the B2
+// stitch->413->stitch loop across a restart.
+func TestQueuePersistsSplitDepth(t *testing.T) {
+	dir := t.TempDir()
+	creator := &alwaysFailingCreator{}
+	cb := &recordingCallback{}
+
+	cfg := QueueConfig{
+		QueueName:       "test-queue",
+		QueueDir:        dir,
+		MaxQueueSize:    10,
+		RetryInterval:   time.Hour, // long enough that the processor never runs during this test
+		ItemsPerSegment: 10,
+		ErrorCallback:   cb,
+	}
+
+	qd, err := NewQueueData(context.Background(), creator, cfg)
+	require.NoError(t, err)
+
+	item := &QueuedContainerProfile{
+		Profile:     testProfile(),
+		ContainerID: "container-id",
+		Attempts:    5,
+		SplitDepth:  3,
+		IsStitch:    true,
+	}
+	require.NoError(t, qd.queue.Enqueue(item))
+	require.NoError(t, qd.Close())
+
+	reopened, err := NewQueueData(context.Background(), creator, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	iface, err := reopened.queue.Dequeue()
+	require.NoError(t, err)
+	got, ok := iface.(*QueuedContainerProfile)
+	require.True(t, ok)
+
+	assert.Equal(t, 3, got.SplitDepth)
+	assert.True(t, got.IsStitch)
+	assert.Equal(t, 5, got.Attempts)
 }
 
 // TestQueueDropsProfileAfterMaxAttempts covers the general case: any error that never
@@ -240,7 +554,7 @@ func TestQueueDropsProfileAfterMaxAttempts(t *testing.T) {
 
 	creator := &alwaysFailingCreator{err: errors.New("dial tcp 10.96.0.1:443: connect: connection refused")}
 	cb := &recordingCallback{}
-	qd := startQueue(t, creator, cb, maxAttempts)
+	qd := startQueue(t, creator, cb, QueueConfig{MaxAttempts: maxAttempts})
 
 	require.NoError(t, qd.Enqueue(testProfile(), "container-id"))
 
@@ -277,6 +591,22 @@ func TestNewQueueDataDefaultsMaxAttempts(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, DefaultMaxAttempts, qd.maxAttempts)
+		require.NoError(t, qd.Close())
+	}
+}
+
+// TestNewQueueDataDefaultsMaxSplitDepth pins the default so an unset config cannot restore
+// unbounded splitting.
+func TestNewQueueDataDefaultsMaxSplitDepth(t *testing.T) {
+	for _, configured := range []int{0, -1} {
+		qd, err := NewQueueData(context.Background(), &alwaysFailingCreator{}, QueueConfig{
+			QueueName:       "test-queue",
+			QueueDir:        t.TempDir(),
+			ItemsPerSegment: 10,
+			MaxSplitDepth:   configured,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, DefaultMaxSplitDepth, qd.maxSplitDepth)
 		require.NoError(t, qd.Close())
 	}
 }

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_queue_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,16 +12,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// MockProfileCreator implements ProfileCreator for testing
+// MockProfileCreator implements ProfileCreator for testing.
+//
+// ShouldFail and FailCount are set once at construction, before the queue's processor
+// goroutine starts, so they need no synchronization. CallCount and CreatedProfiles are
+// written by that goroutine and read by the test goroutine after a time.Sleep, so they are
+// guarded by mu.
 type MockProfileCreator struct {
-	CreatedProfiles []*v1beta1.ContainerProfile
-	ShouldFail      bool
-	FailCount       int
-	CallCount       int
+	mu              sync.Mutex
+	createdProfiles []*v1beta1.ContainerProfile
+	callCount       int
+
+	ShouldFail bool
+	FailCount  int
 }
 
 func (m *MockProfileCreator) CreateContainerProfileDirect(profile *v1beta1.ContainerProfile) error {
-	m.CallCount++
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.callCount++
 
 	if m.ShouldFail {
 		if m.FailCount > 0 {
@@ -29,14 +40,28 @@ func (m *MockProfileCreator) CreateContainerProfileDirect(profile *v1beta1.Conta
 		}
 		// If FailCount is 0 but ShouldFail is true, continue failing (unless FailCount was initially set)
 		// This allows for "fail N times then succeed" behavior
-		if m.FailCount == 0 && m.CallCount <= 1 {
+		if m.FailCount == 0 && m.callCount <= 1 {
 			// This means ShouldFail was set but no specific FailCount, so always fail
 			return fmt.Errorf("mock always fails")
 		}
 	}
 
-	m.CreatedProfiles = append(m.CreatedProfiles, profile)
+	m.createdProfiles = append(m.createdProfiles, profile)
 	return nil
+}
+
+// CreatedProfiles returns a snapshot of every profile successfully created so far.
+func (m *MockProfileCreator) CreatedProfiles() []*v1beta1.ContainerProfile {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*v1beta1.ContainerProfile(nil), m.createdProfiles...)
+}
+
+// CallCount returns how many times CreateContainerProfileDirect has been called so far.
+func (m *MockProfileCreator) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
 }
 
 func TestQueueBasicOperations(t *testing.T) {
@@ -90,8 +115,8 @@ func TestQueueBasicOperations(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 
 	// Check that profile was created
-	if len(mockCreator.CreatedProfiles) != 1 {
-		t.Errorf("Expected 1 created profile, got %d", len(mockCreator.CreatedProfiles))
+	if len(mockCreator.CreatedProfiles()) != 1 {
+		t.Errorf("Expected 1 created profile, got %d", len(mockCreator.CreatedProfiles()))
 	}
 
 	// Check queue is empty after successful processing
@@ -204,13 +229,13 @@ func TestQueueRetryMechanism(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	// Should have been called at least 3 times (2 failures + 1 success)
-	if mockCreator.CallCount < 3 {
-		t.Errorf("Expected at least 3 calls (2 failures + 1 success), got %d", mockCreator.CallCount)
+	if mockCreator.CallCount() < 3 {
+		t.Errorf("Expected at least 3 calls (2 failures + 1 success), got %d", mockCreator.CallCount())
 	}
 
 	// Should eventually succeed
-	if len(mockCreator.CreatedProfiles) != 1 {
-		t.Errorf("Expected 1 successfully created profile, got %d", len(mockCreator.CreatedProfiles))
+	if len(mockCreator.CreatedProfiles()) != 1 {
+		t.Errorf("Expected 1 successfully created profile, got %d", len(mockCreator.CreatedProfiles()))
 	}
 
 	// Queue should be empty after success
@@ -281,13 +306,13 @@ func TestQueuePersistence(t *testing.T) {
 	time.Sleep(1200 * time.Millisecond)
 
 	// Should have processed the persisted item
-	if len(mockCreator2.CreatedProfiles) != 1 {
-		t.Errorf("Expected 1 created profile after reload, got %d", len(mockCreator2.CreatedProfiles))
+	if len(mockCreator2.CreatedProfiles()) != 1 {
+		t.Errorf("Expected 1 created profile after reload, got %d", len(mockCreator2.CreatedProfiles()))
 		return // Avoid panic on next line
 	}
 
-	if mockCreator2.CreatedProfiles[0].Name != "persistence-test-profile" {
-		t.Errorf("Expected profile name 'persistence-test-profile', got '%s'", mockCreator2.CreatedProfiles[0].Name)
+	if mockCreator2.CreatedProfiles()[0].Name != "persistence-test-profile" {
+		t.Errorf("Expected profile name 'persistence-test-profile', got '%s'", mockCreator2.CreatedProfiles()[0].Name)
 	}
 }
 
@@ -460,8 +485,8 @@ func TestQueueConcurrentOperations(t *testing.T) {
 
 	// Check that all items were processed
 	expectedTotal := numGoroutines * itemsPerGoroutine
-	if len(mockCreator.CreatedProfiles) != expectedTotal {
-		t.Errorf("Expected %d created profiles, got %d", expectedTotal, len(mockCreator.CreatedProfiles))
+	if len(mockCreator.CreatedProfiles()) != expectedTotal {
+		t.Errorf("Expected %d created profiles, got %d", expectedTotal, len(mockCreator.CreatedProfiles()))
 	}
 
 	// Queue should be empty after processing
@@ -591,8 +616,8 @@ func TestQueueWithDifferentConfigurations(t *testing.T) {
 			// Wait based on retry interval
 			time.Sleep(tc.config.RetryInterval + 50*time.Millisecond)
 
-			if len(mockCreator.CreatedProfiles) != 1 {
-				t.Errorf("Expected 1 created profile with config %s, got %d", tc.name, len(mockCreator.CreatedProfiles))
+			if len(mockCreator.CreatedProfiles()) != 1 {
+				t.Errorf("Expected 1 created profile with config %s, got %d", tc.name, len(mockCreator.CreatedProfiles()))
 			}
 		})
 	}

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_split.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_split.go
@@ -1,0 +1,380 @@
+package queue
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/names"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/registry/file"
+)
+
+// DefaultMaxSplitDepth bounds how many times a single original chunk may be halved.
+//
+// With the byte-progress guard in splitProfile this is a tripwire rather than the primary
+// bound: needing depth > 4 implies the chunk overshot storage's cap by more than 16x (a
+// ~40MB delta against a 2.5MB cap), which is a node-agent estimator bug that should surface
+// as a Warning promptly instead of being absorbed by split storms. It also caps one
+// lineage's peak queue occupancy at 16 leaves; enforceMaxSize evicts FIFO from the head
+// while splits append to the tail, so an unbounded lineage would silently evict the oldest
+// in-flight halves of *other* lineages.
+const DefaultMaxSplitDepth = 4
+
+// goTimeLayout is time.Time.String()'s layout. node-agent writes report timestamps with
+// .String() (monitoring.go:184-185) and storage compares and sorts them as raw strings, so
+// any manufactured timestamp must round-trip through exactly this layout - RFC3339 would
+// silently break both the chain match and the ORDER BY.
+//
+// Note this layout does NOT cover the trailing monotonic-clock reading that time.Now().String()
+// appends; parseReportTimestamp cuts that first.
+const goTimeLayout = "2006-01-02 15:04:05.999999999 -0700 MST"
+
+// goTimeLayoutNumeric is the same layout for zones whose UTC offset is not a whole number of
+// hours. For those, String() renders the abbreviation as a bare numeric offset - Kathmandu
+// prints "+0545 +0545", not "+0545 NPT" - which the MST element above cannot parse. Whole-hour
+// numeric zones ("+0700 +07") still parse under goTimeLayout, so this is a fallback, not a
+// replacement. Affected zones include Asia/Kathmandu, Asia/Tehran, Asia/Kabul, Asia/Colombo,
+// Asia/Yangon, Australia/Eucla, Australia/Lord_Howe, Pacific/Chatham and Pacific/Marquesas.
+const goTimeLayoutNumeric = "2006-01-02 15:04:05.999999999 -0700 -0700"
+
+// splitDelta is how far chainHalves steps back from the parent's report timestamp to place the
+// interposed one. It is capped again at half the parent's interval, so it never leaves the
+// parent's span.
+const splitDelta = time.Millisecond
+
+// splitProfile partitions p into two profiles that together carry exactly p's data and
+// no duplicates, and interposes a fresh report timestamp so the two halves form a linear
+// two-link chain across p's original reporting interval (see chainHalves).
+//
+// Every non-partitionable field, and every annotation and label other than the two report
+// timestamps, is copied verbatim into both halves. ObjectMeta.Name is freshly generated per
+// half over the same base name.
+//
+// It reports false - meaning "this chunk cannot usefully be split, drop it" - when any of:
+//   - p carries at most one partitionable element (the floor case);
+//   - a valid interposed timestamp cannot be constructed (see chainHalves);
+//   - neither half is meaningfully smaller than p (the byte-progress guard below).
+func splitProfile(p *v1beta1.ContainerProfile) (*v1beta1.ContainerProfile, *v1beta1.ContainerProfile, bool) {
+	if p == nil || countPartitionableElements(&p.Spec) <= 1 {
+		return nil, nil, false
+	}
+
+	// The generated deep copy carries Architectures, ImageID, ImageTag, SeccompProfile, the
+	// embedded LabelSelector and every annotation and label into both halves for free, and
+	// stays correct if storage adds a scalar field.
+	a, b := p.DeepCopy(), p.DeepCopy()
+
+	// Per-field (rather than global-index) halving guarantees that whichever field dominates
+	// the byte size is itself halved on the very first round.
+	a.Spec.Capabilities, b.Spec.Capabilities = halve(p.Spec.Capabilities)
+	a.Spec.Execs, b.Spec.Execs = halve(p.Spec.Execs)
+	a.Spec.Opens, b.Spec.Opens = halve(p.Spec.Opens)
+	a.Spec.Syscalls, b.Spec.Syscalls = halve(p.Spec.Syscalls)
+	a.Spec.Endpoints, b.Spec.Endpoints = halve(p.Spec.Endpoints)
+	a.Spec.IdentifiedCallStacks, b.Spec.IdentifiedCallStacks = halve(p.Spec.IdentifiedCallStacks)
+	a.Spec.Ingress, b.Spec.Ingress = halve(p.Spec.Ingress)
+	a.Spec.Egress, b.Spec.Egress = halve(p.Spec.Egress)
+	a.Spec.PolicyByRuleId, b.Spec.PolicyByRuleId = halvePolicies(p.Spec.PolicyByRuleId)
+
+	// Every field with len <= 1 leaves its single element in a, so b can come out empty even
+	// though p had two or more elements. Move one element across, otherwise recursion on a
+	// would not strictly reduce and the split would make no progress.
+	if countPartitionableElements(&b.Spec) == 0 {
+		moveOneElement(&a.Spec, &b.Spec)
+	}
+
+	a.Name, b.Name = freshOneTimeSlug(p.Name), freshOneTimeSlug(p.Name)
+
+	if !chainHalves(p, a, b) {
+		return nil, nil, false
+	}
+
+	// Splitting has to actually shrink something. This catches only literal non-progress: a
+	// tighter, cap-aware threshold would false-drop chunks one round from success, and
+	// node-agent cannot know storage's cap.
+	parentSize := serializedSize(p)
+	if serializedSize(a) >= parentSize || serializedSize(b) >= parentSize {
+		return nil, nil, false
+	}
+
+	return a, b, true
+}
+
+// chainHalves rewrites the report-timestamp annotations of a and b so that, given a parent
+// spanning (P, T], a spans (P, X] and b spans (X, T] for some P < X < T.
+//
+// This exists because storage's consolidateContinuousTimeSeries walks a strictly linear
+// chain, matching each row's previousReportTimestamp against the next row's
+// reportTimestamp. Two rows sharing an identical (P, T] pair fork that chain permanently,
+// and updateProfileStatus then early-returns on
+//
+//	len(newTimeSeries) != 1 || !isZeroTime(newTimeSeries[0].PreviousReportTimestamp)
+//
+// leaving the profile in Learning forever. Note the second clause: completion requires the
+// consolidated chain to trace all the way back to the container's first report, so a single
+// missing link is permanently disqualifying.
+//
+// Only X is manufactured. a keeps the parent's previousReportTimestamp string and b keeps the
+// parent's reportTimestamp string byte-for-byte, and the single manufactured X.String() is
+// written to both a's reportTimestamp and b's previousReportTimestamp - so storage's chain
+// match compares that string against itself and cannot fail for formatting reasons.
+//
+// TEMPORARY SHIM. Delete this function, and revert splitProfile to leaving both timestamp
+// annotations untouched, once storage's consolidateContinuousTimeSeries collapses rows that
+// share a (previousReportTimestamp, reportTimestamp) pair within a series. This is the ONLY
+// place in the queue package that knows the report chain exists; keep it that way.
+//
+// It reports false if no valid X can be constructed, in which case the caller must not split.
+func chainHalves(parent, a, b *v1beta1.ContainerProfile) bool {
+	rt, ok := parseReportTimestamp(parent.Annotations[helpersv1.ReportTimestampMetadataKey])
+	if !ok {
+		return false
+	}
+
+	// P is the zero time on a container's very first report, which is a common, valid state.
+	var prev time.Time
+	prevRaw := parent.Annotations[helpersv1.PreviousReportTimestampMetadataKey]
+	if !isZeroTimeString(prevRaw) {
+		if prev, ok = parseReportTimestamp(prevRaw); !ok {
+			return false
+		}
+	}
+
+	x, ok := interposeTimestamp(prev, rt, splitDelta)
+	if !ok {
+		return false
+	}
+
+	interposed := x.String()
+	a.Annotations[helpersv1.ReportTimestampMetadataKey] = interposed
+	b.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = interposed
+
+	return true
+}
+
+// interposeTimestamp returns a time strictly between prev and rt.
+//
+// prev is the zero time on a container's very first report, so a true midpoint of
+// (year 1, now) lands near year 1013 - and ListTimeSeriesExpired compares reportTimestamp
+// as a raw string, so such a row matches "expired" unconditionally and the profile is
+// marked Completed/Partial. That is the very outcome the split exists to prevent, on what is
+// likely the most common split case (the initial learning burst). So this never takes a
+// midpoint: it steps back from rt by at most delta, and by at most half the interval.
+func interposeTimestamp(prev, rt time.Time, delta time.Duration) (time.Time, bool) {
+	step := delta
+	if !prev.IsZero() {
+		if half := rt.Sub(prev) / 2; half < step {
+			step = half
+		}
+	}
+
+	x := rt.Add(-step)
+	if !prev.Before(x) || !x.Before(rt) {
+		return x, false
+	}
+
+	return x, true
+}
+
+// parseReportTimestamp parses a report-timestamp annotation written by saveContainerProfile
+// (monitoring.go:184-185).
+//
+// Those strings come from time.Now().String(), and time.Now() carries a monotonic clock
+// reading which String() appends as a trailing " m=+0.000012034". goTimeLayout cannot parse
+// that - time.Parse fails with `extra text: " m=+0.000012034"` - so the suffix MUST be cut
+// before parsing. Skipping this makes every production chainHalves call fail, which silently
+// turns every split into a floor-case drop.
+//
+// Cutting the suffix has a second, load-bearing effect: the returned time.Time carries no
+// monotonic reading, so any timestamp derived from it formats cleanly. Deriving X from a
+// monotonic-carrying time instead would emit a stale, negative reading
+// (time.Now().Add(-time.Millisecond).String() ends in " m=-0.000980993"), which is
+// meaningless as a persisted value.
+func parseReportTimestamp(s string) (time.Time, bool) {
+	s, _, _ = strings.Cut(s, " m=")
+
+	if t, err := time.Parse(goTimeLayout, s); err == nil {
+		return t, true
+	}
+
+	// Zones whose offset is not a whole number of hours render a bare numeric abbreviation
+	// that the MST element cannot parse. Do not "simplify" this away.
+	if t, err := time.Parse(goTimeLayoutNumeric, s); err == nil {
+		return t, true
+	}
+
+	return time.Time{}, false
+}
+
+// isZeroTimeString mirrors storage's isZeroTime (containerprofile_processor.go:839-846), so a
+// zero previousReportTimestamp is recognised without depending on it parsing.
+func isZeroTimeString(s string) bool {
+	switch s {
+	case "", "0001-01-01 00:00:00 +0000 UTC", "0001-01-01T00:00:00Z":
+		return true
+	default:
+		return false
+	}
+}
+
+// countPartitionableElements returns the total number of elements across every list and
+// map field that splitProfile partitions.
+func countPartitionableElements(spec *v1beta1.ContainerProfileSpec) int {
+	return len(spec.Capabilities) +
+		len(spec.Execs) +
+		len(spec.Opens) +
+		len(spec.Syscalls) +
+		len(spec.Endpoints) +
+		len(spec.IdentifiedCallStacks) +
+		len(spec.Ingress) +
+		len(spec.Egress) +
+		len(spec.PolicyByRuleId)
+}
+
+// moveOneElement transfers a single element from the first non-empty partitionable field of
+// from into to, so that a split of a spec with at least two elements never yields an empty half.
+func moveOneElement(from, to *v1beta1.ContainerProfileSpec) {
+	switch {
+	case moveLast(&from.Capabilities, &to.Capabilities):
+	case moveLast(&from.Execs, &to.Execs):
+	case moveLast(&from.Opens, &to.Opens):
+	case moveLast(&from.Syscalls, &to.Syscalls):
+	case moveLast(&from.Endpoints, &to.Endpoints):
+	case moveLast(&from.IdentifiedCallStacks, &to.IdentifiedCallStacks):
+	case moveLast(&from.Ingress, &to.Ingress):
+	case moveLast(&from.Egress, &to.Egress):
+	default:
+		moveOnePolicy(&from.PolicyByRuleId, &to.PolicyByRuleId)
+	}
+}
+
+// moveLast pops the last element of *from into *to, reporting whether there was one to move.
+func moveLast[T any](from, to *[]T) bool {
+	if len(*from) == 0 {
+		return false
+	}
+
+	last := len(*from) - 1
+	*to = append(*to, (*from)[last])
+	*from = (*from)[:last]
+
+	return true
+}
+
+// moveOnePolicy transfers the lowest-keyed policy from *from into *to.
+func moveOnePolicy(from, to *map[string]v1beta1.RulePolicy) {
+	keys := sortedKeys(*from)
+	if len(keys) == 0 {
+		return
+	}
+
+	if *to == nil {
+		*to = map[string]v1beta1.RulePolicy{}
+	}
+	(*to)[keys[0]] = (*from)[keys[0]]
+	delete(*from, keys[0])
+}
+
+// serializedSize returns p's JSON-encoded byte length.
+//
+// This is an APPROXIMATION and is only ever used as a ratio between a parent and its halves.
+// It is NOT comparable to storage's Content-Length cap: node-agent's client forces protobuf
+// (pkg/storage/v1/storage.go:56-57), so the bytes actually weighed by QueueManager are
+// protobuf-encoded, not JSON. Never treat this number as ground truth against the cap.
+func serializedSize(p *v1beta1.ContainerProfile) int {
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		return 0
+	}
+
+	return len(encoded)
+}
+
+// freshOneTimeSlug replaces the trailing one-time UUID suffix of name with a newly
+// generated one, mirroring InstanceID.GetOneTimeSlug. The base name is recovered with
+// storage's own file.SplitProfileName - the same function the server uses to key the
+// aggregate - so agreement with the aggregation key is true by construction rather than by
+// a reimplemented heuristic.
+func freshOneTimeSlug(name string) string {
+	base, _ := file.SplitProfileName(name)
+
+	u := uuid.New()
+	suffix := "-" + hex.EncodeToString(u[:])
+
+	if len(base)+len(suffix) > names.MaxDNSSubdomainLength {
+		base = base[:names.MaxDNSSubdomainLength-len(suffix)]
+	}
+
+	return base + suffix
+}
+
+// halve returns the first ceil(len(s)/2) elements of s and the rest.
+func halve[T any](s []T) ([]T, []T) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	mid := (len(s) + 1) / 2
+
+	return s[:mid], s[mid:]
+}
+
+// halvePolicies partitions m by sorted key, so the partition is deterministic across runs.
+func halvePolicies(m map[string]v1beta1.RulePolicy) (map[string]v1beta1.RulePolicy, map[string]v1beta1.RulePolicy) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+
+	keys := sortedKeys(m)
+	firstKeys, secondKeys := halve(keys)
+
+	first := make(map[string]v1beta1.RulePolicy, len(firstKeys))
+	for _, k := range firstKeys {
+		first[k] = m[k]
+	}
+
+	second := make(map[string]v1beta1.RulePolicy, len(secondKeys))
+	for _, k := range secondKeys {
+		second[k] = m[k]
+	}
+
+	return first, second
+}
+
+func sortedKeys(m map[string]v1beta1.RulePolicy) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
+}
+
+// stitchChunk returns a stand-in for a chunk that is being dropped: the same annotations
+// (crucially the same previousReportTimestamp/reportTimestamp pair) and labels, a fresh
+// one-time slug, and a Spec with only the size-bearing collections cleared. Its only job is
+// to keep the report chain linear; it is a couple of KB and cannot itself be rejected with a 413.
+//
+// It is deliberately NOT an empty-Spec profile. Storage's AfterCreate hardcodes hasData=true,
+// so the stitch is merged like any other row, and mergeContainerProfileTS *assigns* rather
+// than appends SeccompProfile, ImageID and ImageTag (containerprofile_processor.go:863-866).
+// Rows merge oldest-last, so an empty stitch would zero those three on the aggregate.
+// Everything else is append- or map-merged, so clearing it contributes nothing - including
+// Architectures, which would otherwise be duplicated on every stitch.
+func stitchChunk(dropped *v1beta1.ContainerProfile) *v1beta1.ContainerProfile {
+	stitch := dropped.DeepCopy()
+	stitch.Name = freshOneTimeSlug(dropped.Name)
+	stitch.Spec = v1beta1.ContainerProfileSpec{
+		SeccompProfile: stitch.Spec.SeccompProfile,
+		ImageID:        stitch.Spec.ImageID,
+		ImageTag:       stitch.Spec.ImageTag,
+	}
+
+	return stitch
+}

--- a/pkg/containerprofilemanager/v1/queue/containerprofile_split_test.go
+++ b/pkg/containerprofilemanager/v1/queue/containerprofile_split_test.go
@@ -1,0 +1,657 @@
+package queue
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/k8s-interface/names"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/registry/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// tsRow is the reduced shape of storage's TimeSeriesContainers that
+// consolidateContinuousTimeSeries actually branches on.
+type tsRow struct {
+	PreviousReportTimestamp string
+	ReportTimestamp         string
+}
+
+// consolidateGolden is a line-by-line port of storage's consolidateContinuousTimeSeries
+// (kubescape/storage@v0.0.290/pkg/registry/file/containerprofile_processor.go:631-659),
+// reduced to the (previousReportTimestamp, reportTimestamp) pairs it actually branches on.
+// Tests assert against this rather than against our own understanding of the algorithm, so a
+// future storage change that invalidates the chaining shows up as a diff against a citable
+// source rather than as a silent production hang.
+func consolidateGolden(rows []tsRow) []tsRow {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// Storage mutates its slice in place; do the same over a copy so callers keep their rows.
+	rows = append([]tsRow(nil), rows...)
+
+	j := 0
+	var result []tsRow
+
+	for i := 0; i < len(rows)-1; i++ {
+		// rows are in reverse chronological order
+		if rows[j].PreviousReportTimestamp == rows[i+1].ReportTimestamp {
+			rows[j].PreviousReportTimestamp = rows[i+1].PreviousReportTimestamp
+		} else {
+			result = append(result, rows[j])
+			j = i + 1
+		}
+	}
+	result = append(result, rows[j])
+
+	return result
+}
+
+// assertChainIsLinear asserts that rows form exactly one path from origPrev to origRt: no two
+// rows share a previousReportTimestamp, no two share a reportTimestamp, and following the
+// links from origPrev visits every row exactly once and terminates at origRt.
+func assertChainIsLinear(t *testing.T, rows []tsRow, origPrev, origRt string) {
+	t.Helper()
+	require.NotEmpty(t, rows)
+
+	byPrev := make(map[string]tsRow, len(rows))
+	seenRt := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		_, dup := byPrev[r.PreviousReportTimestamp]
+		require.False(t, dup, "two rows share previousReportTimestamp %q - the chain is forked", r.PreviousReportTimestamp)
+		byPrev[r.PreviousReportTimestamp] = r
+
+		require.False(t, seenRt[r.ReportTimestamp], "two rows share reportTimestamp %q - the chain is forked", r.ReportTimestamp)
+		seenRt[r.ReportTimestamp] = true
+	}
+
+	cur := origPrev
+	visited := 0
+	for {
+		row, ok := byPrev[cur]
+		if !ok {
+			break
+		}
+		cur = row.ReportTimestamp
+		visited++
+	}
+
+	assert.Equal(t, len(rows), visited, "the chain must visit every row exactly once")
+	assert.Equal(t, origRt, cur, "the chain must terminate at the original reportTimestamp")
+}
+
+// richProfile builds a ContainerProfile with at least two elements in every partitionable
+// field, plus non-empty non-partitionable fields, so tests can assert both halving and
+// verbatim-copy behaviour against a single realistic fixture.
+func richProfile() *v1beta1.ContainerProfile {
+	p := testProfile()
+	p.Labels = map[string]string{"app": "test-app"}
+	p.Spec = v1beta1.ContainerProfileSpec{
+		Architectures: []string{"amd64"},
+		Capabilities:  []string{"cap-a", "cap-b"},
+		Execs: []v1beta1.ExecCalls{
+			{Path: "/bin/a"},
+			{Path: "/bin/b"},
+		},
+		Opens: []v1beta1.OpenCalls{
+			{Path: "/etc/a"},
+			{Path: "/etc/b"},
+		},
+		Syscalls:       []string{"read", "write"},
+		SeccompProfile: v1beta1.SingleSeccompProfile{Name: "seccomp-test"},
+		Endpoints: []v1beta1.HTTPEndpoint{
+			{Endpoint: "/a"},
+			{Endpoint: "/b"},
+		},
+		ImageID:  "sha256:abc",
+		ImageTag: "v1",
+		PolicyByRuleId: map[string]v1beta1.RulePolicy{
+			"rule-a": {AllowedProcesses: []string{"p1"}},
+			"rule-b": {AllowedProcesses: []string{"p2"}},
+		},
+		IdentifiedCallStacks: []v1beta1.IdentifiedCallStack{
+			{CallID: "cs-a"},
+			{CallID: "cs-b"},
+		},
+		LabelSelector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"k": "v"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "k", Operator: metav1.LabelSelectorOpExists},
+			},
+		},
+		Ingress: []v1beta1.NetworkNeighbor{{Identifier: "in-a"}, {Identifier: "in-b"}},
+		Egress:  []v1beta1.NetworkNeighbor{{Identifier: "eg-a"}, {Identifier: "eg-b"}},
+	}
+	return p
+}
+
+// elementSignatures returns one string per partitionable element, tagged by field, so tests
+// can assert the union/no-overlap invariant across splitProfile's halves.
+func elementSignatures(spec *v1beta1.ContainerProfileSpec) []string {
+	var out []string
+	for _, c := range spec.Capabilities {
+		out = append(out, "cap:"+c)
+	}
+	for _, e := range spec.Execs {
+		out = append(out, "exec:"+e.Path)
+	}
+	for _, o := range spec.Opens {
+		out = append(out, "open:"+o.Path)
+	}
+	for _, s := range spec.Syscalls {
+		out = append(out, "syscall:"+s)
+	}
+	for _, e := range spec.Endpoints {
+		out = append(out, "endpoint:"+e.Endpoint)
+	}
+	for _, c := range spec.IdentifiedCallStacks {
+		out = append(out, "callstack:"+string(c.CallID))
+	}
+	for _, n := range spec.Ingress {
+		out = append(out, "ingress:"+n.Identifier)
+	}
+	for _, n := range spec.Egress {
+		out = append(out, "egress:"+n.Identifier)
+	}
+	for k := range spec.PolicyByRuleId {
+		out = append(out, "policy:"+k)
+	}
+	return out
+}
+
+func TestSplitProfile_PartitionsWithoutLossOrDuplication(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(p *v1beta1.ContainerProfile)
+	}{
+		{"capabilities", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Capabilities = []string{"a", "b", "c", "d"}
+		}},
+		{"execs", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Execs = []v1beta1.ExecCalls{{Path: "/a"}, {Path: "/b"}, {Path: "/c"}}
+		}},
+		{"opens", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Opens = []v1beta1.OpenCalls{{Path: "/a"}, {Path: "/b"}, {Path: "/c"}}
+		}},
+		{"syscalls", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Syscalls = []string{"read", "write", "openat"}
+		}},
+		{"endpoints", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Endpoints = []v1beta1.HTTPEndpoint{{Endpoint: "/a"}, {Endpoint: "/b"}, {Endpoint: "/c"}}
+		}},
+		{"identifiedCallStacks", func(p *v1beta1.ContainerProfile) {
+			p.Spec.IdentifiedCallStacks = []v1beta1.IdentifiedCallStack{{CallID: "a"}, {CallID: "b"}, {CallID: "c"}}
+		}},
+		{"ingress", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Ingress = []v1beta1.NetworkNeighbor{{Identifier: "a"}, {Identifier: "b"}, {Identifier: "c"}}
+		}},
+		{"egress", func(p *v1beta1.ContainerProfile) {
+			p.Spec.Egress = []v1beta1.NetworkNeighbor{{Identifier: "a"}, {Identifier: "b"}, {Identifier: "c"}}
+		}},
+		{"policyByRuleId", func(p *v1beta1.ContainerProfile) {
+			p.Spec.PolicyByRuleId = map[string]v1beta1.RulePolicy{
+				"a": {AllowedProcesses: []string{"x"}},
+				"b": {AllowedProcesses: []string{"y"}},
+				"c": {AllowedProcesses: []string{"z"}},
+			}
+		}},
+		{"fully populated", func(p *v1beta1.ContainerProfile) {
+			*p = *richProfile()
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := testProfile()
+			tt.mutate(p)
+
+			original := elementSignatures(&p.Spec)
+			require.GreaterOrEqual(t, len(original), 2)
+
+			a, b, ok := splitProfile(p)
+			require.True(t, ok)
+
+			combined := append(elementSignatures(&a.Spec), elementSignatures(&b.Spec)...)
+			assert.ElementsMatch(t, original, combined)
+
+			seen := make(map[string]bool, len(combined))
+			for _, s := range combined {
+				assert.False(t, seen[s], "element %q duplicated across halves", s)
+				seen[s] = true
+			}
+		})
+	}
+}
+
+// TestSplitProfile_CopiesSharedFieldsVerbatim is inverted from an early draft, which asserted
+// the two timestamp annotations were equal across halves - that would have locked in the C1
+// chain fork. Every other shared field must be deep-equal; the two timestamp keys must NOT.
+func TestSplitProfile_CopiesSharedFieldsVerbatim(t *testing.T) {
+	p := richProfile()
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	for _, half := range []*v1beta1.ContainerProfile{a, b} {
+		assert.Equal(t, p.Labels, half.Labels)
+		assert.Equal(t, p.Spec.Architectures, half.Spec.Architectures)
+		assert.Equal(t, p.Spec.ImageID, half.Spec.ImageID)
+		assert.Equal(t, p.Spec.ImageTag, half.Spec.ImageTag)
+		assert.Equal(t, p.Spec.SeccompProfile, half.Spec.SeccompProfile)
+		assert.Equal(t, p.Spec.LabelSelector, half.Spec.LabelSelector)
+
+		for k, v := range p.Annotations {
+			if k == helpersv1.ReportTimestampMetadataKey || k == helpersv1.PreviousReportTimestampMetadataKey {
+				continue
+			}
+			assert.Equal(t, v, half.Annotations[k], "annotation %q must be copied verbatim", k)
+		}
+	}
+
+	assert.NotEqual(t, a.Annotations[helpersv1.ReportTimestampMetadataKey], b.Annotations[helpersv1.ReportTimestampMetadataKey],
+		"halves must not share a reportTimestamp - a shared pair forks storage's report chain (C1)")
+	assert.NotEqual(t, a.Annotations[helpersv1.PreviousReportTimestampMetadataKey], b.Annotations[helpersv1.PreviousReportTimestampMetadataKey],
+		"halves must not share a previousReportTimestamp")
+}
+
+func TestSplitProfile_FreshSlugPreservesBaseName(t *testing.T) {
+	p := testProfile()
+	p.Name = "cattle-cluster-agent-0123456789abcdef0123456789abcdef"
+	p.Spec.Capabilities = []string{"a", "b", "c"}
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	baseName, _ := file.SplitProfileName(p.Name)
+	aBase, aSuffix := file.SplitProfileName(a.Name)
+	bBase, bSuffix := file.SplitProfileName(b.Name)
+
+	assert.Equal(t, baseName, aBase)
+	assert.Equal(t, baseName, bBase)
+	assert.Len(t, aSuffix, 32)
+	assert.Len(t, bSuffix, 32)
+
+	assert.NotEqual(t, a.Name, b.Name)
+	assert.NotEqual(t, a.Name, p.Name)
+	assert.NotEqual(t, b.Name, p.Name)
+
+	assert.LessOrEqual(t, len(a.Name), names.MaxDNSSubdomainLength)
+	assert.LessOrEqual(t, len(b.Name), names.MaxDNSSubdomainLength)
+}
+
+func TestSplitProfile_FloorCase(t *testing.T) {
+	for _, n := range []int{0, 1} {
+		t.Run(fmt.Sprintf("%d elements", n), func(t *testing.T) {
+			p := testProfile()
+			if n == 1 {
+				p.Spec.Capabilities = []string{"only"}
+			}
+
+			_, _, ok := splitProfile(p)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestSplitProfile_NoEmptyHalf(t *testing.T) {
+	p := testProfile()
+	p.Spec.Capabilities = []string{"cap-1"}
+	p.Spec.Syscalls = []string{"read"}
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	assert.Greater(t, countPartitionableElements(&a.Spec), 0)
+	assert.Greater(t, countPartitionableElements(&b.Spec), 0)
+	assert.Equal(t, 2, countPartitionableElements(&a.Spec)+countPartitionableElements(&b.Spec))
+}
+
+// TestSplitProfile_Deterministic guards the sorted-key map partition against Go's randomised
+// map iteration order: two splits of the same input must produce identical field partitions.
+func TestSplitProfile_Deterministic(t *testing.T) {
+	p := richProfile()
+
+	a1, b1, ok := splitProfile(p.DeepCopy())
+	require.True(t, ok)
+	a2, b2, ok := splitProfile(p.DeepCopy())
+	require.True(t, ok)
+
+	assert.Equal(t, a1.Spec.PolicyByRuleId, a2.Spec.PolicyByRuleId)
+	assert.Equal(t, b1.Spec.PolicyByRuleId, b2.Spec.PolicyByRuleId)
+	assert.Equal(t, a1.Spec.Capabilities, a2.Spec.Capabilities)
+	assert.Equal(t, b1.Spec.Capabilities, b2.Spec.Capabilities)
+	assert.Equal(t, a1.Spec.Ingress, a2.Spec.Ingress)
+	assert.Equal(t, b1.Spec.Ingress, b2.Spec.Ingress)
+}
+
+func TestFreshOneTimeSlug_MalformedName(t *testing.T) {
+	t.Run("no hyphen suffix", func(t *testing.T) {
+		got := freshOneTimeSlug("noHyphenName")
+		base, suffix := file.SplitProfileName(got)
+		assert.Equal(t, "noHyphenName", base)
+		assert.Len(t, suffix, 32)
+	})
+
+	t.Run("at the DNS subdomain length limit", func(t *testing.T) {
+		longBase := strings.Repeat("a", names.MaxDNSSubdomainLength)
+		got := freshOneTimeSlug(longBase + "-deadbeef")
+
+		assert.LessOrEqual(t, len(got), names.MaxDNSSubdomainLength)
+		_, suffix := file.SplitProfileName(got)
+		assert.Len(t, suffix, 32)
+	})
+}
+
+// manyCapabilities returns n distinct, reasonably-sized capability strings, so a split has
+// enough payload to make genuine byte progress even when the timestamp annotations themselves
+// grow (e.g. a zero or whole-second timestamp being replaced by a manufactured one).
+func manyCapabilities(n int) []string {
+	caps := make([]string, n)
+	for i := range caps {
+		caps[i] = fmt.Sprintf("capability-%02d", i)
+	}
+	return caps
+}
+
+func rowOf(p *v1beta1.ContainerProfile) tsRow {
+	return tsRow{
+		PreviousReportTimestamp: p.Annotations[helpersv1.PreviousReportTimestampMetadataKey],
+		ReportTimestamp:         p.Annotations[helpersv1.ReportTimestampMetadataKey],
+	}
+}
+
+func sortRowsDesc(rows []tsRow) {
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ReportTimestamp > rows[j].ReportTimestamp })
+}
+
+func TestChainHalves_ConsolidatesToParentInterval(t *testing.T) {
+	p := testProfile()
+	p.Spec.Capabilities = []string{"a", "b", "c"}
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	rows := []tsRow{rowOf(a), rowOf(b)}
+	sortRowsDesc(rows)
+
+	result := consolidateGolden(rows)
+	require.Len(t, result, 1)
+	assert.Equal(t, p.Annotations[helpersv1.PreviousReportTimestampMetadataKey], result[0].PreviousReportTimestamp)
+	assert.Equal(t, p.Annotations[helpersv1.ReportTimestampMetadataKey], result[0].ReportTimestamp)
+}
+
+func TestChainHalves_ZeroPreviousTimestamp(t *testing.T) {
+	p := testProfile()
+	p.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = time.Time{}.String()
+	rt := time.Now()
+	p.Annotations[helpersv1.ReportTimestampMetadataKey] = rt.String()
+	// A zero previousReportTimestamp is a short string ("0001-01-01 00:00:00 +0000 UTC"),
+	// shorter than the manufactured X it gets replaced with, so a tiny payload would be
+	// dwarfed by that formatting growth alone; use enough elements for genuine progress.
+	p.Spec.Capabilities = manyCapabilities(10)
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	x, xok := parseReportTimestamp(a.Annotations[helpersv1.ReportTimestampMetadataKey])
+	require.True(t, xok)
+
+	assert.WithinDuration(t, rt, x, time.Second, "X must stay near T, never a year-1013 midpoint")
+
+	cutoff := time.Now().Add(-24 * time.Hour).String()
+	assert.Greater(t, x.String(), cutoff,
+		"X must not look expired under ListTimeSeriesExpired's raw string comparison (sqlite.go:352-356)")
+
+	rows := []tsRow{rowOf(a), rowOf(b)}
+	sortRowsDesc(rows)
+	result := consolidateGolden(rows)
+	require.Len(t, result, 1)
+	assert.True(t, isZeroTimeString(result[0].PreviousReportTimestamp))
+}
+
+func TestChainHalves_TimestampRoundTrip(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		prev time.Time
+		rt   time.Time
+	}{
+		{"whole second", now.Truncate(time.Second).Add(-time.Hour), now.Truncate(time.Second)},
+		{"sub-millisecond interval", now, now.Add(500 * time.Microsecond)},
+		{"time.Now()", time.Now().Add(-time.Hour), time.Now()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testProfile()
+			p.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = tc.prev.String()
+			p.Annotations[helpersv1.ReportTimestampMetadataKey] = tc.rt.String()
+			// Whole-second timestamps carry no monotonic suffix, so the manufactured X (which
+			// always has a fractional component) can be longer than the originals; use enough
+			// elements that halving still makes genuine byte progress.
+			p.Spec.Capabilities = manyCapabilities(10)
+
+			a, b, ok := splitProfile(p)
+			require.True(t, ok)
+
+			x, xok := parseReportTimestamp(a.Annotations[helpersv1.ReportTimestampMetadataKey])
+			require.True(t, xok)
+			assert.Equal(t, a.Annotations[helpersv1.ReportTimestampMetadataKey], x.String())
+
+			assert.True(t, tc.prev.Before(x))
+			assert.True(t, x.Before(tc.rt))
+
+			// Lexicographic, mirroring sqlite.go's ORDER BY reportTimestamp DESC string sort.
+			assert.Less(t, p.Annotations[helpersv1.PreviousReportTimestampMetadataKey], a.Annotations[helpersv1.ReportTimestampMetadataKey])
+			assert.Less(t, a.Annotations[helpersv1.ReportTimestampMetadataKey], p.Annotations[helpersv1.ReportTimestampMetadataKey])
+
+			_ = b
+		})
+	}
+}
+
+// TestParseReportTimestamp_MonotonicSuffix is the B1 regression guard: it asserts why the
+// " m=" cut exists, so a future reader cannot delete it as redundant.
+func TestParseReportTimestamp_MonotonicSuffix(t *testing.T) {
+	now := time.Now()
+	s := now.String()
+	require.Contains(t, s, " m=", "time.Now().String() must carry a monotonic reading for this test to be meaningful")
+
+	_, err := time.Parse(goTimeLayout, s)
+	require.Error(t, err, "a raw goTimeLayout parse must fail on the monotonic suffix - this is why parseReportTimestamp cuts it first")
+
+	parsed, ok := parseReportTimestamp(s)
+	require.True(t, ok)
+	assert.NotContains(t, parsed.String(), " m=")
+
+	x, xok := interposeTimestamp(time.Time{}, parsed, splitDelta)
+	require.True(t, xok)
+	assert.NotContains(t, x.String(), " m=", "a manufactured timestamp derived from a parsed time must never carry a monotonic reading")
+}
+
+// TestChainHalves_OnRealProductionAnnotations builds annotations exactly the way
+// saveContainerProfile does (monitoring.go:170-171, 184-185): real time.Now() values, not
+// time.Date fixtures. Do not "fix" this test by switching to time.Date - that would hide the
+// monotonic-suffix bug (B1) on every run, exactly as an earlier plan revision did.
+func TestChainHalves_OnRealProductionAnnotations(t *testing.T) {
+	prev := time.Now()
+	time.Sleep(time.Millisecond)
+	rt := time.Now()
+
+	p := testProfile()
+	p.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = prev.String()
+	p.Annotations[helpersv1.ReportTimestampMetadataKey] = rt.String()
+	p.Annotations[helpersv1.ReportSeriesIdMetadataKey] = "series-real"
+	p.Spec.Capabilities = []string{"a", "b", "c"}
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok, "splitting must succeed against real production-shaped timestamps")
+
+	assert.NotContains(t, a.Annotations[helpersv1.ReportTimestampMetadataKey], " m=")
+	assert.NotContains(t, b.Annotations[helpersv1.PreviousReportTimestampMetadataKey], " m=")
+}
+
+func TestParseReportTimestamp_NumericZoneAbbreviation(t *testing.T) {
+	zones := []string{
+		"Asia/Kathmandu", "Asia/Tehran", "Asia/Kabul", "Asia/Colombo", "Asia/Yangon",
+		"Australia/Eucla", "Australia/Lord_Howe", "Pacific/Chatham", "Pacific/Marquesas",
+		"Asia/Bangkok",  // whole-hour numeric zone control - parses under goTimeLayout directly
+		"Europe/Zurich", // letter-abbreviation zone control
+	}
+
+	for _, zoneName := range zones {
+		t.Run(zoneName, func(t *testing.T) {
+			loc, err := time.LoadLocation(zoneName)
+			if err != nil {
+				t.Skipf("zone database unavailable for %s: %v", zoneName, err)
+			}
+
+			rt := time.Now().In(loc)
+			prev := rt.Add(-time.Hour)
+
+			parsedRt, ok := parseReportTimestamp(rt.String())
+			require.True(t, ok, "must parse a %s timestamp", zoneName)
+
+			x, ok := interposeTimestamp(prev, parsedRt, splitDelta)
+			require.True(t, ok)
+
+			reparsedX, ok := parseReportTimestamp(x.String())
+			require.True(t, ok, "manufactured X must itself re-parse")
+			assert.Equal(t, x.String(), reparsedX.String())
+
+			assert.Less(t, x.String(), rt.String())
+		})
+	}
+}
+
+func TestChainHalves_RefusesInvalidInterval(t *testing.T) {
+	t.Run("unparseable reportTimestamp", func(t *testing.T) {
+		p := testProfile()
+		p.Annotations[helpersv1.ReportTimestampMetadataKey] = "not-a-real-timestamp"
+		p.Spec.Capabilities = []string{"a", "b", "c"}
+
+		_, _, ok := splitProfile(p)
+		assert.False(t, ok)
+	})
+
+	t.Run("reportTimestamp not after previousReportTimestamp", func(t *testing.T) {
+		p := testProfile()
+		now := time.Now()
+		p.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = now.String()
+		p.Annotations[helpersv1.ReportTimestampMetadataKey] = now.Add(-time.Hour).String()
+		p.Spec.Capabilities = []string{"a", "b", "c"}
+
+		_, _, ok := splitProfile(p)
+		assert.False(t, ok)
+	})
+
+	t.Run("interval too narrow to subdivide", func(t *testing.T) {
+		p := testProfile()
+		rt := time.Now()
+		prev := rt.Add(-time.Nanosecond)
+		p.Annotations[helpersv1.PreviousReportTimestampMetadataKey] = prev.String()
+		p.Annotations[helpersv1.ReportTimestampMetadataKey] = rt.String()
+		p.Spec.Capabilities = []string{"a", "b", "c"}
+
+		_, _, ok := splitProfile(p)
+		assert.False(t, ok)
+	})
+}
+
+// TestSplitProfile_RecursiveChainStaysLinear pins the "interior nodes are only inserted, never
+// removed" invariant from the plan's §5.2a: splitting one half of an already-split pair must
+// still consolidate back to the original (P, T] interval.
+func TestSplitProfile_RecursiveChainStaysLinear(t *testing.T) {
+	p := testProfile()
+	p.Spec.Capabilities = []string{"a", "b", "c", "d", "e"}
+
+	a, b, ok := splitProfile(p)
+	require.True(t, ok)
+
+	b1, b2, ok := splitProfile(b)
+	require.True(t, ok)
+
+	rows := []tsRow{rowOf(a), rowOf(b1), rowOf(b2)}
+	sortRowsDesc(rows)
+
+	assertChainIsLinear(t, rows,
+		p.Annotations[helpersv1.PreviousReportTimestampMetadataKey],
+		p.Annotations[helpersv1.ReportTimestampMetadataKey])
+
+	result := consolidateGolden(rows)
+	require.Len(t, result, 1)
+	assert.Equal(t, p.Annotations[helpersv1.PreviousReportTimestampMetadataKey], result[0].PreviousReportTimestamp)
+	assert.Equal(t, p.Annotations[helpersv1.ReportTimestampMetadataKey], result[0].ReportTimestamp)
+}
+
+func TestSplitProfile_NoProgressGuard(t *testing.T) {
+	t.Run("no progress when the fresh name outweighs a tiny payload", func(t *testing.T) {
+		p := testProfile()
+		// A one-character name means freshOneTimeSlug's 32-hex suffix adds far more bytes to
+		// each half than halving these two single-character capabilities ever removes.
+		p.Name = "p"
+		p.Spec.Capabilities = []string{"a", "b"}
+
+		_, _, ok := splitProfile(p)
+		assert.False(t, ok, "halves whose regenerated name outweighs the halved payload must be refused")
+	})
+
+	t.Run("revision-3 regression: must still split one round from success", func(t *testing.T) {
+		p := testProfile()
+		// K ~ 2.2MB baseline, P ~ 0.5MB partitionable payload - the shape the old 0.9
+		// threshold false-dropped, per the plan's worked example (K > 4P but halves still
+		// land under a realistic cap).
+		p.Spec.SeccompProfile = v1beta1.SingleSeccompProfile{Name: strings.Repeat("k", 2_200_000)}
+		caps := make([]string, 500)
+		for i := range caps {
+			caps[i] = fmt.Sprintf("capability-%d-%s", i, strings.Repeat("p", 1000))
+		}
+		p.Spec.Capabilities = caps
+
+		_, _, ok := splitProfile(p)
+		assert.True(t, ok, "a chunk one round from fitting under the cap must still split")
+	})
+}
+
+// TestStitchChunk_PreservesAssignmentMergedScalars is the M-a regression guard. Storage's
+// mergeContainerProfileTS assigns (not appends) SeccompProfile, ImageID and ImageTag
+// (containerprofile_processor.go:863-866), and rows merge oldest-last, so an empty-Spec
+// stitch would zero those three on the aggregate.
+func TestStitchChunk_PreservesAssignmentMergedScalars(t *testing.T) {
+	p := richProfile()
+
+	stitch := stitchChunk(p)
+
+	assert.Equal(t, p.Spec.SeccompProfile, stitch.Spec.SeccompProfile)
+	assert.Equal(t, p.Spec.ImageID, stitch.Spec.ImageID)
+	assert.Equal(t, p.Spec.ImageTag, stitch.Spec.ImageTag)
+
+	assert.Empty(t, stitch.Spec.Capabilities)
+	assert.Empty(t, stitch.Spec.Execs)
+	assert.Empty(t, stitch.Spec.Opens)
+	assert.Empty(t, stitch.Spec.Syscalls)
+	assert.Empty(t, stitch.Spec.Endpoints)
+	assert.Empty(t, stitch.Spec.IdentifiedCallStacks)
+	assert.Empty(t, stitch.Spec.Ingress)
+	assert.Empty(t, stitch.Spec.Egress)
+	assert.Empty(t, stitch.Spec.PolicyByRuleId)
+	assert.Empty(t, stitch.Spec.Architectures)
+	assert.Empty(t, stitch.Spec.LabelSelector.MatchLabels)
+	assert.Empty(t, stitch.Spec.LabelSelector.MatchExpressions)
+
+	assert.Equal(t, p.Annotations[helpersv1.ReportTimestampMetadataKey], stitch.Annotations[helpersv1.ReportTimestampMetadataKey])
+	assert.Equal(t, p.Annotations[helpersv1.PreviousReportTimestampMetadataKey], stitch.Annotations[helpersv1.PreviousReportTimestampMetadataKey])
+	assert.Equal(t, p.Annotations[helpersv1.ReportSeriesIdMetadataKey], stitch.Annotations[helpersv1.ReportSeriesIdMetadataKey])
+
+	assert.NotEqual(t, p.Name, stitch.Name)
+	base, _ := file.SplitProfileName(p.Name)
+	stitchBase, _ := file.SplitProfileName(stitch.Name)
+	assert.Equal(t, base, stitchBase)
+}

--- a/pkg/metricsmanager/metrics_manager_interface.go
+++ b/pkg/metricsmanager/metrics_manager_interface.go
@@ -26,12 +26,17 @@ type MetricsManager interface {
 	ReportContainerProfileCacheHit(hit bool)
 	ReportContainerProfileReconcilerDuration(phase string, duration time.Duration)
 	ReportContainerProfileReconcilerEviction(reason string)
+	// ReportContainerProfileSplit counts chunks halved after a transport-level size rejection.
+	ReportContainerProfileSplit()
+	// ReportContainerProfileChunkDropped counts chunks discarded because they could not be
+	// split further, labeled by the queue's closed set of drop reasons.
+	ReportContainerProfileChunkDropped(reason string)
 
 	// Profile-projection metrics — always-on.
-	IncMissingProfileDataRequired(ruleID string)      // rule has profileDependency>0 but no profileDataRequired
-	IncProjectionUndeclaredLiteral(helper string)     // literal evaluated against a projected field not in spec
-	SetProjectionStaleEntries(count float64)          // cache entries whose SpecHash != currentSpecHash
-	SetProjectionUndeclaredRules(count float64)       // rules loaded with no profileDataRequired
+	IncMissingProfileDataRequired(ruleID string)  // rule has profileDependency>0 but no profileDataRequired
+	IncProjectionUndeclaredLiteral(helper string) // literal evaluated against a projected field not in spec
+	SetProjectionStaleEntries(count float64)      // cache entries whose SpecHash != currentSpecHash
+	SetProjectionUndeclaredRules(count float64)   // rules loaded with no profileDataRequired
 
 	// Profile-projection metrics — detailed (gated by profileProjection.detailedMetricsEnabled).
 	IncProjectionSpecCompile()

--- a/pkg/metricsmanager/metrics_manager_mock.go
+++ b/pkg/metricsmanager/metrics_manager_mock.go
@@ -67,31 +67,33 @@ func (m *MetricsMock) ReportContainerStart() {}
 
 func (m *MetricsMock) ReportContainerStop() {}
 
-func (m *MetricsMock) ReportDedupEvent(eventType utils.EventType, duplicate bool)          {}
+func (m *MetricsMock) ReportDedupEvent(eventType utils.EventType, duplicate bool)         {}
 func (m *MetricsMock) ReportContainerProfileLegacyLoad(_, _ string)                       {}
 func (m *MetricsMock) SetContainerProfileCacheEntries(_ string, _ float64)                {}
 func (m *MetricsMock) ReportContainerProfileCacheHit(_ bool)                              {}
 func (m *MetricsMock) ReportContainerProfileReconcilerDuration(_ string, _ time.Duration) {}
 func (m *MetricsMock) ReportContainerProfileReconcilerEviction(_ string)                  {}
-func (m *MetricsMock) IncMissingProfileDataRequired(_ string)            {}
-func (m *MetricsMock) IncProjectionUndeclaredLiteral(_ string)           {}
-func (m *MetricsMock) SetProjectionStaleEntries(_ float64)               {}
-func (m *MetricsMock) SetProjectionUndeclaredRules(_ float64)            {}
-func (m *MetricsMock) IncProjectionSpecCompile()                         {}
-func (m *MetricsMock) IncProjectionSpecHashChange()                      {}
-func (m *MetricsMock) SetProjectionSpecPatterns(_, _ string, _ float64)  {}
-func (m *MetricsMock) SetProjectionSpecAllField(_ string, _ bool)        {}
-func (m *MetricsMock) ObserveProjectionApplyDuration(_ time.Duration)    {}
-func (m *MetricsMock) IncProjectionReconcileTriggered(_ string)          {}
-func (m *MetricsMock) IncHelperCall(_ string)                            {}
-func (m *MetricsMock) SetProjectionUndeclaredRulesDetail(_ []string)     {}
-func (m *MetricsMock) ObserveProfileRawSize(_ float64)                   {}
-func (m *MetricsMock) ObserveProfileProjectedSize(_ float64)             {}
-func (m *MetricsMock) ObserveProfileEntriesRaw(_ string, _ float64)     {}
-func (m *MetricsMock) ObserveProfileEntriesRetained(_ string, _ float64) {}
-func (m *MetricsMock) ObserveProfileRetentionRatio(_ string, _ float64)  {}
-func (m *MetricsMock) ReportSBOMScan(_ string)                           {}
-func (m *MetricsMock) ObserveSBOMScanDuration(_ string, _ time.Duration) {}
-func (m *MetricsMock) ReportSBOMScannerRestart()                         {}
-func (m *MetricsMock) SetSBOMScannerReady(_ bool)                        {}
-func (m *MetricsMock) ReportAlertSuppressed(_, _ string)                 {}
+func (m *MetricsMock) ReportContainerProfileSplit()                                       {}
+func (m *MetricsMock) ReportContainerProfileChunkDropped(_ string)                        {}
+func (m *MetricsMock) IncMissingProfileDataRequired(_ string)                             {}
+func (m *MetricsMock) IncProjectionUndeclaredLiteral(_ string)                            {}
+func (m *MetricsMock) SetProjectionStaleEntries(_ float64)                                {}
+func (m *MetricsMock) SetProjectionUndeclaredRules(_ float64)                             {}
+func (m *MetricsMock) IncProjectionSpecCompile()                                          {}
+func (m *MetricsMock) IncProjectionSpecHashChange()                                       {}
+func (m *MetricsMock) SetProjectionSpecPatterns(_, _ string, _ float64)                   {}
+func (m *MetricsMock) SetProjectionSpecAllField(_ string, _ bool)                         {}
+func (m *MetricsMock) ObserveProjectionApplyDuration(_ time.Duration)                     {}
+func (m *MetricsMock) IncProjectionReconcileTriggered(_ string)                           {}
+func (m *MetricsMock) IncHelperCall(_ string)                                             {}
+func (m *MetricsMock) SetProjectionUndeclaredRulesDetail(_ []string)                      {}
+func (m *MetricsMock) ObserveProfileRawSize(_ float64)                                    {}
+func (m *MetricsMock) ObserveProfileProjectedSize(_ float64)                              {}
+func (m *MetricsMock) ObserveProfileEntriesRaw(_ string, _ float64)                       {}
+func (m *MetricsMock) ObserveProfileEntriesRetained(_ string, _ float64)                  {}
+func (m *MetricsMock) ObserveProfileRetentionRatio(_ string, _ float64)                   {}
+func (m *MetricsMock) ReportSBOMScan(_ string)                                            {}
+func (m *MetricsMock) ObserveSBOMScanDuration(_ string, _ time.Duration)                  {}
+func (m *MetricsMock) ReportSBOMScannerRestart()                                          {}
+func (m *MetricsMock) SetSBOMScannerReady(_ bool)                                         {}
+func (m *MetricsMock) ReportAlertSuppressed(_, _ string)                                  {}

--- a/pkg/metricsmanager/metrics_manager_noop.go
+++ b/pkg/metricsmanager/metrics_manager_noop.go
@@ -11,42 +11,45 @@ var _ MetricsManager = (*MetricsNoop)(nil)
 
 type MetricsNoop struct{}
 
-func NewMetricsNoop() *MetricsNoop                                                          { return &MetricsNoop{} }
-func (m *MetricsNoop) Start()                                                               {}
-func (m *MetricsNoop) Destroy()                                                             {}
-func (m *MetricsNoop) ReportEvent(_ utils.EventType)                                        {}
-func (m *MetricsNoop) ReportFailedEvent()                                                   {}
-func (m *MetricsNoop) ReportRuleProcessed(_ string)                                         {}
-func (m *MetricsNoop) ReportRulePrefiltered(_ string)                                       {}
-func (m *MetricsNoop) ReportRuleAlert(_ string)                                             {}
-func (m *MetricsNoop) ReportRuleEvaluationTime(_ context.Context, _ string, _ utils.EventType, _ time.Duration) {}
-func (m *MetricsNoop) ReportContainerStart()                                                {}
-func (m *MetricsNoop) ReportContainerStop()                                                 {}
-func (m *MetricsNoop) ReportDedupEvent(_ utils.EventType, _ bool)                           {}
-func (m *MetricsNoop) ReportContainerProfileLegacyLoad(_, _ string)                        {}
-func (m *MetricsNoop) SetContainerProfileCacheEntries(_ string, _ float64)                 {}
-func (m *MetricsNoop) ReportContainerProfileCacheHit(_ bool)                               {}
-func (m *MetricsNoop) ReportContainerProfileReconcilerDuration(_ string, _ time.Duration)  {}
-func (m *MetricsNoop) ReportContainerProfileReconcilerEviction(_ string)                   {}
-func (m *MetricsNoop) IncMissingProfileDataRequired(_ string)            {}
-func (m *MetricsNoop) IncProjectionUndeclaredLiteral(_ string)           {}
-func (m *MetricsNoop) SetProjectionStaleEntries(_ float64)               {}
-func (m *MetricsNoop) SetProjectionUndeclaredRules(_ float64)            {}
-func (m *MetricsNoop) IncProjectionSpecCompile()                         {}
-func (m *MetricsNoop) IncProjectionSpecHashChange()                      {}
-func (m *MetricsNoop) SetProjectionSpecPatterns(_, _ string, _ float64)  {}
-func (m *MetricsNoop) SetProjectionSpecAllField(_ string, _ bool)        {}
-func (m *MetricsNoop) ObserveProjectionApplyDuration(_ time.Duration)    {}
-func (m *MetricsNoop) IncProjectionReconcileTriggered(_ string)          {}
-func (m *MetricsNoop) IncHelperCall(_ string)                            {}
-func (m *MetricsNoop) SetProjectionUndeclaredRulesDetail(_ []string)     {}
-func (m *MetricsNoop) ObserveProfileRawSize(_ float64)                   {}
-func (m *MetricsNoop) ObserveProfileProjectedSize(_ float64)             {}
-func (m *MetricsNoop) ObserveProfileEntriesRaw(_ string, _ float64)     {}
-func (m *MetricsNoop) ObserveProfileEntriesRetained(_ string, _ float64) {}
-func (m *MetricsNoop) ObserveProfileRetentionRatio(_ string, _ float64)  {}
-func (m *MetricsNoop) ReportSBOMScan(_ string)                           {}
-func (m *MetricsNoop) ObserveSBOMScanDuration(_ string, _ time.Duration) {}
-func (m *MetricsNoop) ReportSBOMScannerRestart()                         {}
-func (m *MetricsNoop) SetSBOMScannerReady(_ bool)                        {}
-func (m *MetricsNoop) ReportAlertSuppressed(_, _ string)                 {}
+func NewMetricsNoop() *MetricsNoop                    { return &MetricsNoop{} }
+func (m *MetricsNoop) Start()                         {}
+func (m *MetricsNoop) Destroy()                       {}
+func (m *MetricsNoop) ReportEvent(_ utils.EventType)  {}
+func (m *MetricsNoop) ReportFailedEvent()             {}
+func (m *MetricsNoop) ReportRuleProcessed(_ string)   {}
+func (m *MetricsNoop) ReportRulePrefiltered(_ string) {}
+func (m *MetricsNoop) ReportRuleAlert(_ string)       {}
+func (m *MetricsNoop) ReportRuleEvaluationTime(_ context.Context, _ string, _ utils.EventType, _ time.Duration) {
+}
+func (m *MetricsNoop) ReportContainerStart()                                              {}
+func (m *MetricsNoop) ReportContainerStop()                                               {}
+func (m *MetricsNoop) ReportDedupEvent(_ utils.EventType, _ bool)                         {}
+func (m *MetricsNoop) ReportContainerProfileLegacyLoad(_, _ string)                       {}
+func (m *MetricsNoop) SetContainerProfileCacheEntries(_ string, _ float64)                {}
+func (m *MetricsNoop) ReportContainerProfileCacheHit(_ bool)                              {}
+func (m *MetricsNoop) ReportContainerProfileReconcilerDuration(_ string, _ time.Duration) {}
+func (m *MetricsNoop) ReportContainerProfileReconcilerEviction(_ string)                  {}
+func (m *MetricsNoop) ReportContainerProfileSplit()                                       {}
+func (m *MetricsNoop) ReportContainerProfileChunkDropped(_ string)                        {}
+func (m *MetricsNoop) IncMissingProfileDataRequired(_ string)                             {}
+func (m *MetricsNoop) IncProjectionUndeclaredLiteral(_ string)                            {}
+func (m *MetricsNoop) SetProjectionStaleEntries(_ float64)                                {}
+func (m *MetricsNoop) SetProjectionUndeclaredRules(_ float64)                             {}
+func (m *MetricsNoop) IncProjectionSpecCompile()                                          {}
+func (m *MetricsNoop) IncProjectionSpecHashChange()                                       {}
+func (m *MetricsNoop) SetProjectionSpecPatterns(_, _ string, _ float64)                   {}
+func (m *MetricsNoop) SetProjectionSpecAllField(_ string, _ bool)                         {}
+func (m *MetricsNoop) ObserveProjectionApplyDuration(_ time.Duration)                     {}
+func (m *MetricsNoop) IncProjectionReconcileTriggered(_ string)                           {}
+func (m *MetricsNoop) IncHelperCall(_ string)                                             {}
+func (m *MetricsNoop) SetProjectionUndeclaredRulesDetail(_ []string)                      {}
+func (m *MetricsNoop) ObserveProfileRawSize(_ float64)                                    {}
+func (m *MetricsNoop) ObserveProfileProjectedSize(_ float64)                              {}
+func (m *MetricsNoop) ObserveProfileEntriesRaw(_ string, _ float64)                       {}
+func (m *MetricsNoop) ObserveProfileEntriesRetained(_ string, _ float64)                  {}
+func (m *MetricsNoop) ObserveProfileRetentionRatio(_ string, _ float64)                   {}
+func (m *MetricsNoop) ReportSBOMScan(_ string)                                            {}
+func (m *MetricsNoop) ObserveSBOMScanDuration(_ string, _ time.Duration)                  {}
+func (m *MetricsNoop) ReportSBOMScannerRestart()                                          {}
+func (m *MetricsNoop) SetSBOMScannerReady(_ bool)                                         {}
+func (m *MetricsNoop) ReportAlertSuppressed(_, _ string)                                  {}

--- a/pkg/metricsmanager/otel/otel_metrics_manager.go
+++ b/pkg/metricsmanager/otel/otel_metrics_manager.go
@@ -40,6 +40,8 @@ type OTELMetricsManager struct {
 	profileCacheHitTotal     metric.Int64Counter
 	reconcilerDuration       metric.Float64Histogram
 	reconcilerEvictionsTotal metric.Int64Counter
+	profileSplitTotal        metric.Int64Counter
+	profileChunkDroppedTotal metric.Int64Counter
 
 	// Rule projection — always-on
 	projMissingDeclTotal   metric.Int64Counter
@@ -169,6 +171,10 @@ func NewOTELMetricsManager(ownContainerID string) *OTELMetricsManager {
 		"ContainerProfile reconciler phase duration", "s", defBuckets)
 	m.reconcilerEvictionsTotal = mustCounter("node_agent.profile.reconciler.evictions.total",
 		"ContainerProfile cache evictions by reason")
+	m.profileSplitTotal = mustCounter("node_agent.profile.split.total",
+		"ContainerProfile chunks halved after a transport-level size rejection")
+	m.profileChunkDroppedTotal = mustCounter("node_agent.profile.chunk.dropped.total",
+		"ContainerProfile chunks dropped because they could not be split further, by reason")
 
 	m.projMissingDeclTotal = mustCounter("node_agent.rule.projection.missing_decl.total",
 		"Rules with profileDependency>0 but no profileDataRequired declaration")
@@ -356,6 +362,16 @@ func (m *OTELMetricsManager) ReportContainerProfileReconcilerDuration(phase stri
 
 func (m *OTELMetricsManager) ReportContainerProfileReconcilerEviction(reason string) {
 	m.reconcilerEvictionsTotal.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("reason", reason),
+	))
+}
+
+func (m *OTELMetricsManager) ReportContainerProfileSplit() {
+	m.profileSplitTotal.Add(context.Background(), 1)
+}
+
+func (m *OTELMetricsManager) ReportContainerProfileChunkDropped(reason string) {
+	m.profileChunkDroppedTotal.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("reason", reason),
 	))
 }

--- a/pkg/metricsmanager/prometheus/prometheus.go
+++ b/pkg/metricsmanager/prometheus/prometheus.go
@@ -25,27 +25,27 @@ const (
 var _ metricsmanager.MetricsManager = (*PrometheusMetric)(nil)
 
 type PrometheusMetric struct {
-	ebpfExecCounter       prometheus.Counter
-	ebpfOpenCounter       prometheus.Counter
-	ebpfNetworkCounter    prometheus.Counter
-	ebpfDNSCounter        prometheus.Counter
-	ebpfSyscallCounter    prometheus.Counter
-	ebpfCapabilityCounter prometheus.Counter
-	ebpfRandomXCounter    prometheus.Counter
-	ebpfFailedCounter     prometheus.Counter
-	ebpfSymlinkCounter    prometheus.Counter
-	ebpfHardlinkCounter   prometheus.Counter
-	ebpfSSHCounter        prometheus.Counter
-	ebpfHTTPCounter       prometheus.Counter
-	ebpfPtraceCounter     prometheus.Counter
-	ebpfIoUringCounter    prometheus.Counter
-	ebpfKmodCounter       prometheus.Counter
-	ebpfUnshareCounter    prometheus.Counter
-	ebpfBpfCounter        prometheus.Counter
+	ebpfExecCounter        prometheus.Counter
+	ebpfOpenCounter        prometheus.Counter
+	ebpfNetworkCounter     prometheus.Counter
+	ebpfDNSCounter         prometheus.Counter
+	ebpfSyscallCounter     prometheus.Counter
+	ebpfCapabilityCounter  prometheus.Counter
+	ebpfRandomXCounter     prometheus.Counter
+	ebpfFailedCounter      prometheus.Counter
+	ebpfSymlinkCounter     prometheus.Counter
+	ebpfHardlinkCounter    prometheus.Counter
+	ebpfSSHCounter         prometheus.Counter
+	ebpfHTTPCounter        prometheus.Counter
+	ebpfPtraceCounter      prometheus.Counter
+	ebpfIoUringCounter     prometheus.Counter
+	ebpfKmodCounter        prometheus.Counter
+	ebpfUnshareCounter     prometheus.Counter
+	ebpfBpfCounter         prometheus.Counter
 	ruleCounter            *prometheus.CounterVec
 	rulePrefilteredCounter *prometheus.CounterVec
 	alertCounter           *prometheus.CounterVec
-	ruleEvaluationTime    *prometheus.HistogramVec
+	ruleEvaluationTime     *prometheus.HistogramVec
 
 	// Program ID metrics
 	programRuntimeGauge       *prometheus.GaugeVec
@@ -65,14 +65,16 @@ type PrometheusMetric struct {
 	dedupEventCounter *prometheus.CounterVec
 
 	// ContainerProfile cache metrics
-	cpCacheLegacyLoadsCounter      *prometheus.CounterVec
-	cpCacheEntriesGauge            *prometheus.GaugeVec
-	cpCacheHitCounter              *prometheus.CounterVec
-	cpReconcilerDurationHistogram  *prometheus.HistogramVec
-	cpReconcilerEvictionsCounter   *prometheus.CounterVec
+	cpCacheLegacyLoadsCounter     *prometheus.CounterVec
+	cpCacheEntriesGauge           *prometheus.GaugeVec
+	cpCacheHitCounter             *prometheus.CounterVec
+	cpReconcilerDurationHistogram *prometheus.HistogramVec
+	cpReconcilerEvictionsCounter  *prometheus.CounterVec
+	cpSplitCounter                prometheus.Counter
+	cpChunkDroppedCounter         *prometheus.CounterVec
 
 	// Profile projection metrics — always-on
-	cpProjectionMissingDeclCounter      *prometheus.CounterVec
+	cpProjectionMissingDeclCounter       *prometheus.CounterVec
 	cpProjectionUndeclaredLiteralCounter *prometheus.CounterVec
 	cpProjectionStaleEntriesGauge        prometheus.Gauge
 	cpProjectionUndeclaredRulesGauge     prometheus.Gauge
@@ -104,10 +106,10 @@ type PrometheusMetric struct {
 	alertSuppressedCounter *prometheus.CounterVec
 
 	// Cache to avoid allocating Labels maps on every call
-	ruleCounterCache          map[string]prometheus.Counter
+	ruleCounterCache            map[string]prometheus.Counter
 	rulePrefilteredCounterCache map[string]prometheus.Counter
-	alertCounterCache         map[string]prometheus.Counter
-	counterCacheMutex sync.RWMutex
+	alertCounterCache           map[string]prometheus.Counter
+	counterCacheMutex           sync.RWMutex
 }
 
 func NewPrometheusMetric() *PrometheusMetric {
@@ -277,6 +279,14 @@ func NewPrometheusMetric() *PrometheusMetric {
 			Name: "node_agent_containerprofile_reconciler_evictions_total",
 			Help: "Total number of ContainerProfile cache evictions by reason.",
 		}, []string{"reason"}),
+		cpSplitCounter: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "node_agent_containerprofile_split_total",
+			Help: "Total number of ContainerProfile chunks halved after a transport-level size rejection.",
+		}),
+		cpChunkDroppedCounter: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "node_agent_containerprofile_chunk_dropped_total",
+			Help: "Total number of ContainerProfile chunks dropped because they could not be split further, by reason.",
+		}, []string{"reason"}),
 
 		// Profile projection metrics — always-on
 		cpProjectionMissingDeclCounter: promauto.NewCounterVec(prometheus.CounterOpts{
@@ -427,6 +437,8 @@ func (p *PrometheusMetric) Destroy() {
 	prometheus.Unregister(p.cpCacheHitCounter)
 	prometheus.Unregister(p.cpReconcilerDurationHistogram)
 	prometheus.Unregister(p.cpReconcilerEvictionsCounter)
+	prometheus.Unregister(p.cpSplitCounter)
+	prometheus.Unregister(p.cpChunkDroppedCounter)
 	prometheus.Unregister(p.cpProjectionMissingDeclCounter)
 	prometheus.Unregister(p.cpProjectionUndeclaredLiteralCounter)
 	prometheus.Unregister(p.cpProjectionStaleEntriesGauge)
@@ -644,6 +656,14 @@ func (p *PrometheusMetric) ReportContainerProfileCacheHit(hit bool) {
 
 func (p *PrometheusMetric) ReportContainerProfileReconcilerDuration(phase string, duration time.Duration) {
 	p.cpReconcilerDurationHistogram.WithLabelValues(phase).Observe(duration.Seconds())
+}
+
+func (p *PrometheusMetric) ReportContainerProfileSplit() {
+	p.cpSplitCounter.Inc()
+}
+
+func (p *PrometheusMetric) ReportContainerProfileChunkDropped(reason string) {
+	p.cpChunkDroppedCounter.WithLabelValues(reason).Inc()
 }
 
 func (p *PrometheusMetric) ReportContainerProfileReconcilerEviction(reason string) {


### PR DESCRIPTION
Fixes #865

## Problem

customer of Rancher/RKE2 saw storage log this on repeat for `cattle-system` workloads:

```
QueueManager - request entity too large  contentLength=3231797  maxObjectSize=2500000
```

storage's `QueueManager` rejects a create whose `Content-Length` exceeds `kindQueues.containerprofiles.maxObjectSize` before it reaches the registry, replying `413` with a **plain-text** body — so there is no `Status` object and no sentinel.

## What changed since the last revision of this PR

@matthyx's review (https://github.com/kubescape/node-agent/pull/866#pullrequestreview-4794269159) verified the original fix's diagnosis and bounded-retry mechanism, but flagged one blocking concern: mapping a bare 413 onto `ObjectTooLargeError` conflates two different signals. `ObjectTooLargeError` is storage's own **aggregate** findings-count check — an authoritative "this container's profile is genuinely full" verdict that's fair to end learning on. A bare 413 is a **transport** rejection of one delta based on byte size alone, and treating it the same way throws away all future learning for a container that merely produced one oversized chunk.

This revision implements the reviewer's suggested fix: **on a bare 413, split the rejected chunk in half and resend both halves**, recursing until each piece is accepted, instead of ending learning.

## Change

**`classifyFailure()`** gains a third reaction, `failureSplit`, alongside the existing `failureRetryable`/`failureTerminal`. The two genuine storage sentinels (`ObjectTooLargeError`, `ObjectCompletedError`, matched via `errors.Is` + substring) are checked **first** and remain terminal exactly as before — only a bare 413 detected purely by HTTP status code (`apierrors.IsRequestEntityTooLargeError`) now triggers `failureSplit` instead of being treated as terminal.

**Splitting (`containerprofile_split.go`, new).** `splitProfile` partitions the rejected chunk's list/map fields (`Capabilities`, `Execs`, `Opens`, `Syscalls`, `Endpoints`, `IdentifiedCallStacks`, `Ingress`, `Egress`, `PolicyByRuleId`) roughly in half, with a non-empty guarantee so recursion always makes progress, and gives each half a fresh one-time slug over the same base name (recovered via storage's own `file.SplitProfileName`, so agreement with the server's aggregation key is true by construction — a `-partN` suffix scheme was considered and rejected, since `SplitProfileName` cuts on the last hyphen and would scatter a differently-suffixed half into a phantom aggregate). A byte-progress guard refuses to keep splitting a chunk that isn't shrinking.

**Preserving the report chain — the trickiest part.** Storage reconstructs a container's lifecycle by walking a strictly linear `previousReportTimestamp → reportTimestamp` chain (`consolidateContinuousTimeSeries`). Naively giving both halves the parent's identical timestamp pair permanently forks that chain and leaves the profile in `Learning` forever — worse than today's behavior. Instead, `chainHalves` interposes a fresh timestamp `X` so one half spans `(P, X]` and the other `(X, T]`, keeping the chain linear (including for the *next* real report, and correctly under recursive re-splitting). This required care around: a monotonic-clock suffix on production timestamps (`time.Now().String()`) that needs stripping before parsing; a numeric (non-letter) timezone-abbreviation fallback for several IANA zones; and never taking a naive midpoint against a first-report's zero `previousReportTimestamp` (which would otherwise produce an implausible timestamp that storage's expiry check matches unconditionally, re-ending learning through a different route).

**Bounding the recursion.** `MaxSplitDepth` (default 4) plus the byte-progress guard cap how many times a single chunk can be halved. A chunk that can't be split further (a single oversized element, or depth exhausted) is dropped with a `Warning` — and replaced by a **stitch chunk**: a metadata-and-scalars-only stand-in that preserves the dropped chunk's `(previousReportTimestamp, reportTimestamp)` link so the chain doesn't fork, without carrying any of the oversized data. A stitch is never itself re-stitched. Neither drop path calls `ErrorCallback.OnQueueError` — that's the callback that ends learning, and avoiding it on every 413 path is the entire point of this change.

**Observability.** Two new counters (`ReportContainerProfileSplit`, `ReportContainerProfileChunkDropped(reason)`) across all `MetricsManager` implementations, since after this change there's no remaining status signal on the 413 path at all — these counters are the only way to see the underlying estimator issue (#870) firing in the field.

The bounded-retry mechanism from the previous revision (`MaxAttempts`, default 360) is unchanged and still governs genuinely retryable failures.

## Tests

`containerprofile_split_test.go` (new) and `containerprofile_queue_errors_test.go` (extended) — partition correctness (no loss/duplication across halves), shared-field verbatim-copy vs. the two report-timestamp fields (deliberately *not* equal across halves), naming/base-name preservation, the floor case and non-empty rebalance, determinism, the timestamp-chain interposition and its zero-time/monotonic-suffix/numeric-timezone edge cases (including a golden port of storage's own consolidation algorithm so drift against the real thing is caught), recursive re-splitting staying chain-linear, the byte-progress guard, and end-to-end queue tests for split-and-resend, the unsplittable floor case (with stitch-chunk emission), `MaxSplitDepth` bounding, and `SplitDepth`/stitch persistence across a queue restart.

Verified:
```
go build ./...                                                                          ok
go vet ./pkg/containerprofilemanager/... ./pkg/metricsmanager/...                        ok
go test ./pkg/containerprofilemanager/... ./pkg/metricsmanager/... -race -count=3        ok
gofmt -l (all changed files)                                                             clean
```

Also fixed a pre-existing data race in the test-only `MockProfileCreator` (unsynchronized fields read across goroutines), found while getting the package's `-race` gate green.

## Not in this PR

- **#870** — node-agent's own pre-send size estimator (`config.MaxTsProfileSize`) mixes byte-size and element-count units, which is the root cause of reaching a 413 at all. Fixing it should make splitting a rare safety net rather than something regularly exercised.
- **#871** — a `MaxAttempts` exhaustion drop or LRU eviction can already break a container's report chain today, independent of this PR, permanently preventing that container's profile from completing. Found as a side effect of verifying this PR's own chain-preservation logic; appears to have never been reported.
- **kubescape/storage#352** (cross-repo) — `consolidateContinuousTimeSeries` should collapse rows sharing an identical `(previousReportTimestamp, reportTimestamp)` pair. This is the reason node-agent has to manufacture an intermediate timestamp at all; once it lands (and once a minimum storage version can be assumed), the `chainHalves` interposition logic in this PR becomes unnecessary and can be deleted.
- storage's swallowing of `ObjectTooLargeError` into an HTTP 201 with the data discarded server-side (`clearSpec`) is unrelated to the 413 path this PR addresses, but was a lower-priority thing worth someone eventually surfacing as a client-visible signal.
- Previously tracked: kubescape/storage#350 (the size caps themselves are inconsistent) and kubescape/helm-charts#885.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container-profile learning now splits profiles rejected for excessive size and retries manageable chunks.
  * Added safeguards for retry limits, split-depth limits, unsplittable chunks, and queue shutdown.
  * Added stitch chunks to preserve continuity when portions are dropped.
  * Added monitoring metrics for profile splits and dropped chunks.

* **Documentation**
  * Added guidance on size rejection handling, retries, timestamp processing, observability, and limitations.

* **Tests**
  * Added comprehensive coverage for splitting, retries, persistence, stitching, queue limits, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->