### PR TITLE
feat(cel): expose the exec controlling terminal to rules (hasTty, tty, ttyMajor, ttyMinor)

### DIFF
--- a/docs/features/exec-tty-field.md
+++ b/docs/features/exec-tty-field.md
@@ -7,7 +7,7 @@ Four CEL fields on exec events describe the process's controlling terminal:
 | `event.hasTty` | bool | **Use this one.** True when the process has a controlling terminal. |
 | `event.ttyMajor` | uint | Terminal driver major: `136` = pseudo terminal (`kubectl exec`, `docker exec`, ssh), `4` = virtual console, `0` = none. |
 | `event.ttyMinor` | uint | Terminal device minor. |
-| `event.tty` | int | Raw driver-local index. **Does not identify a terminal** — the index is only unique per driver, so `/dev/pts/0` and `/dev/tty0` are both `0`. Prefer `ttyMajor`. |
+| `event.tty` | int | Raw driver-local index. **Does not uniquely identify a device** — the index is only unique per driver, so `/dev/pts/0` and `/dev/tty0` are both `0`. A nonzero value does mean a terminal is present; only `0` is ambiguous, meaning either `/dev/pts/0` or no terminal at all. Prefer `ttyMajor`. |
 
 ## Not every agent measures this
 

--- a/docs/features/exec-tty-field.md
+++ b/docs/features/exec-tty-field.md
@@ -38,13 +38,26 @@ interactive shells. Such a rule must carry an `agentVersionRequirement`:
 ```yaml
 - name: "Non-interactive download tool"
   expressions:
-    rule_expression:
-      - event_type: exec
+    ruleExpression:
+      - eventType: exec
         expression: |
-          has(event.hasTty) && !event.hasTty &&
+          !event.hasTty &&
           event.exepath in ["/usr/bin/curl", "/usr/bin/wget"]
   agentVersionRequirement: ">=<version that ships the device number>"
 ```
+
+## Comparing the numeric fields
+
+`ttyMajor` and `ttyMinor` are unsigned; this CEL environment has no
+cross-type numeric comparison, so comparing against a bare integer literal
+fails to compile (and thus silently disables the rule) rather than failing
+at runtime. Compare them with an explicit unsigned literal:
+
+```cel
+has(event.ttyMajor) && event.ttyMajor == uint(136)
+```
+
+`event.tty` is signed, so it takes a bare integer instead: `event.tty == 3`.
 
 See `projects/2026-07-27-exec-tty-cel-field/spec.md` in shared-designs-and-docs
 for the full design and the phase-2 checklist.

--- a/docs/features/exec-tty-field.md
+++ b/docs/features/exec-tty-field.md
@@ -59,5 +59,53 @@ has(event.ttyMajor) && event.ttyMajor == uint(136)
 
 `event.tty` is signed, so it takes a bare integer instead: `event.tty == 3`.
 
+## Cluster validation
+
+`tests/component_test.go:Test_35_ExecTTYFieldTest` proves the fields work
+end-to-end against real eBPF, using four test-only rules in
+`tests/resources/exec-tty-rules.yaml`. Measured on kind with
+`trace_exec:v0.48.1`:
+
+```
+R9901 (hasTty)   c-none=0  c-pts0=0  c-conc=1
+R9902 (control)  total=3
+R9903/R9904      0 / 3
+```
+
+Three properties the test pins down, each for a reason:
+
+- **The control rule matters.** An unresolvable CEL field does not raise an
+  error — it fails to compile and silently disables the whole expression. "No
+  alert" is therefore ambiguous between "the field was false" and "the rule
+  never ran". R9902 shares the trigger without the TTY predicate, so it
+  separates the two. Verified by mutation: pointing R9901 at a nonexistent
+  field drops it to 0 while R9902 stays at 3.
+- **R9903/R9904 are mutually exclusive.** Exactly one must fire. Both silent
+  would mean `ttyMajor` is unregistered rather than absent. This is what makes
+  `has()` presence testing trustworthy, and it doubles as the phase-2
+  acceptance test — the two swap when the gadget starts emitting the device
+  number.
+- **`c-pts0` expecting zero alerts is deliberate.** A single exec into a fresh
+  container lands on `/dev/pts/0`, which phase 1 cannot distinguish from "no
+  terminal". Confirmed directly against the gadget: a process with no terminal
+  and a process on `pts/0` both report `tty=0`. Do not "fix" that expectation.
+
+Two environment facts the test depends on, both verified rather than assumed:
+
+- Containers in a pod have separate mount namespaces and therefore separate
+  `/dev/pts` instances, so each of the three containers starts from a pristine
+  pts index. With a session held in one container, an exec into a sibling still
+  lands on `/dev/pts/0`.
+- The API server allocates a pty on `PodExecOptions.TTY` alone, regardless of
+  `Stdin` — so ordinary component-test execs already carry a terminal, and
+  `ExecIntoPodNoTTY` is what a test needs for a terminal-free process.
+  `kubectl exec -t` is not a way to check this: kubectl silently drops the TTY
+  flag when `-i` is absent and misleadingly reports "not a tty".
+
+Because pts indices are not reclaimed instantly, the concurrent trigger waits
+for the holder to *report* its own tty path rather than launching it and
+sleeping. A probe fired before the holder's pty exists lands on `pts/0` and
+reads as "no terminal" — indistinguishable from a broken feature.
+
 See `projects/2026-07-27-exec-tty-cel-field/spec.md` in shared-designs-and-docs
 for the full design and the phase-2 checklist.

--- a/docs/features/exec-tty-field.md
+++ b/docs/features/exec-tty-field.md
@@ -1,0 +1,50 @@
+# Exec controlling-terminal (TTY) fields
+
+Four CEL fields on exec events describe the process's controlling terminal:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `event.hasTty` | bool | **Use this one.** True when the process has a controlling terminal. |
+| `event.ttyMajor` | uint | Terminal driver major: `136` = pseudo terminal (`kubectl exec`, `docker exec`, ssh), `4` = virtual console, `0` = none. |
+| `event.ttyMinor` | uint | Terminal device minor. |
+| `event.tty` | int | Raw driver-local index. **Does not identify a terminal** — the index is only unique per driver, so `/dev/pts/0` and `/dev/tty0` are both `0`. Prefer `ttyMajor`. |
+
+## Not every agent measures this
+
+`ttyMajor`/`ttyMinor` require a gadget version that emits the terminal device
+number. On older agents those fields are absent, and `has()` reports it:
+
+```cel
+has(event.ttyMajor)   // false when this agent cannot measure the device number
+```
+
+`has(event.hasTty)` is true on any agent with a working exec tracer.
+
+## Two authoring rules
+
+**Positive predicates need no guard and no version gate.** Safe on every agent
+version; on older agents they under-fire rather than mis-fire:
+
+```cel
+event.hasTty && event.comm in ["bash", "sh", "zsh"]
+```
+
+**Negative predicates require a version gate.** On agents without the device
+number, `hasTty` is derived from the ambiguous index, where `0` is read as "no
+terminal" — which is wrong for `/dev/pts/0`, the usual first `kubectl exec`
+into a pod. A rule asserting "not interactive" would fire on genuinely
+interactive shells. Such a rule must carry an `agentVersionRequirement`:
+
+```yaml
+- name: "Non-interactive download tool"
+  expressions:
+    rule_expression:
+      - event_type: exec
+        expression: |
+          has(event.hasTty) && !event.hasTty &&
+          event.exepath in ["/usr/bin/curl", "/usr/bin/wget"]
+  agentVersionRequirement: ">=<version that ships the device number>"
+```
+
+See `projects/2026-07-27-exec-tty-cel-field/spec.md` in shared-designs-and-docs
+for the full design and the phase-2 checklist.

--- a/pkg/rulemanager/cel/cel_tty_test.go
+++ b/pkg/rulemanager/cel/cel_tty_test.go
@@ -3,6 +3,8 @@ package cel
 import (
 	"testing"
 
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
 	"github.com/kubescape/node-agent/pkg/config"
 	"github.com/kubescape/node-agent/pkg/ebpf/events"
 	"github.com/kubescape/node-agent/pkg/objectcache"
@@ -25,13 +27,83 @@ func newTestCEL(t *testing.T) *CEL {
 // a legitimate false and the test would pass for the wrong reason.
 func evalTTY(t *testing.T, e *utils.StructEvent, expr string) bool {
 	t.Helper()
+	return evalTTYEvent(t, e, e.EventType, expr)
+}
+
+// evalTTYEvent is the generalised form of evalTTY: it accepts any utils.K8sEvent
+// implementer (StructEvent or DatasourceEvent) so the same CEL expressions can
+// be exercised against both the test-only presence path and the production
+// DatasourceEvent.FieldPresent path.
+//
+// It keeps the same load-bearing discipline as evalTTY: it asserts
+// c.registerExpression(expr) succeeds BEFORE evaluating, because EvaluateRule
+// reports a compile failure as (false, nil) — without the compile assertion a
+// typo or type error looks exactly like a legitimate false.
+func evalTTYEvent(t *testing.T, e utils.K8sEvent, eventType utils.EventType, expr string) bool {
+	t.Helper()
 	c := newTestCEL(t)
 	require.NoError(t, c.registerExpression(expr), "expression must compile")
 
 	ok, err := c.EvaluateRule(&events.EnrichedEvent{Event: e},
-		[]typesv1.RuleExpression{{EventType: utils.ExecveEventType, Expression: expr}})
+		[]typesv1.RuleExpression{{EventType: eventType, Expression: expr}})
 	require.NoError(t, err)
 	return ok
+}
+
+// newDatasourceExecEvent builds a synthetic "exec" datasource containing only
+// the tty-related fields listed in fields, plus a filler "comm" field so the
+// datasource is not degenerate. It mirrors the newExecEvent helper in
+// pkg/utils/datasource_event_tty_test.go, which lives in package utils and is
+// not importable from package cel.
+type ttyDSFields struct {
+	tty      *int32
+	ttyMajor *uint32
+	ttyMinor *uint32
+}
+
+func newDatasourceExecEvent(t *testing.T, eventType utils.EventType, f ttyDSFields) *utils.DatasourceEvent {
+	t.Helper()
+
+	ds, err := datasource.New(datasource.TypeSingle, "exec")
+	require.NoError(t, err)
+
+	commAcc, err := ds.AddField("comm", api.Kind_String)
+	require.NoError(t, err)
+
+	var ttyAcc, majorAcc, minorAcc datasource.FieldAccessor
+	if f.tty != nil {
+		ttyAcc, err = ds.AddField("tty", api.Kind_Int32)
+		require.NoError(t, err)
+	}
+	if f.ttyMajor != nil {
+		majorAcc, err = ds.AddField("tty_major", api.Kind_Uint32)
+		require.NoError(t, err)
+	}
+	if f.ttyMinor != nil {
+		minorAcc, err = ds.AddField("tty_minor", api.Kind_Uint32)
+		require.NoError(t, err)
+	}
+
+	data, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+	t.Cleanup(func() { ds.Release(data) })
+
+	require.NoError(t, commAcc.PutString(data, "bash"))
+	if f.tty != nil {
+		require.NoError(t, ttyAcc.PutInt32(data, *f.tty))
+	}
+	if f.ttyMajor != nil {
+		require.NoError(t, majorAcc.PutUint32(data, *f.ttyMajor))
+	}
+	if f.ttyMinor != nil {
+		require.NoError(t, minorAcc.PutUint32(data, *f.ttyMinor))
+	}
+
+	return &utils.DatasourceEvent{
+		Data:       data,
+		Datasource: ds,
+		EventType:  eventType,
+	}
 }
 
 func TestCELTTYFieldsPhase1(t *testing.T) {
@@ -75,3 +147,57 @@ func TestCELForwardCompatibility(t *testing.T) {
 
 func ptrInt32(v int32) *int32    { return &v }
 func ptrUint32(v uint32) *uint32 { return &v }
+
+// --- DatasourceEvent coverage -----------------------------------------------
+//
+// The tests above all build *utils.StructEvent, so presenceOf() is only ever
+// exercised against StructEvent.FieldPresent's simple switch — never against
+// DatasourceEvent.FieldPresent, which is what runs in production. The tests
+// below evaluate the same CEL expressions against a *utils.DatasourceEvent
+// built over a synthetic datasource, so a regression in the datasource
+// presence path would be caught here.
+
+// TestCELTTYFieldsPhase1_DatasourceEvent mirrors TestCELTTYFieldsPhase1 but
+// against a DatasourceEvent backed by a datasource that only emits "tty".
+func TestCELTTYFieldsPhase1_DatasourceEvent(t *testing.T) {
+	withTTY := newDatasourceExecEvent(t, utils.ExecveEventType, ttyDSFields{tty: ptrInt32(3)})
+	require.True(t, evalTTYEvent(t, withTTY, utils.ExecveEventType, `has(event.hasTty) && event.hasTty`))
+	require.True(t, evalTTYEvent(t, withTTY, utils.ExecveEventType, `event.tty == 3`))
+	// The device number is not measured by this datasource shape.
+	require.False(t, evalTTYEvent(t, withTTY, utils.ExecveEventType, `has(event.ttyMajor)`))
+}
+
+// TestCELTTYFieldsPhase2_DatasourceEvent mirrors TestCELTTYFieldsPhase2 but
+// against a DatasourceEvent backed by a datasource that emits tty, tty_major,
+// and tty_minor — the pts/0 shape (index 0, major 136, minor 0).
+func TestCELTTYFieldsPhase2_DatasourceEvent(t *testing.T) {
+	pts0 := newDatasourceExecEvent(t, utils.ExecveEventType, ttyDSFields{
+		tty:      ptrInt32(0),
+		ttyMajor: ptrUint32(136),
+		ttyMinor: ptrUint32(0),
+	})
+	require.True(t, evalTTYEvent(t, pts0, utils.ExecveEventType, `has(event.ttyMajor) && event.ttyMajor == uint(136)`))
+	require.True(t, evalTTYEvent(t, pts0, utils.ExecveEventType, `event.hasTty`), "pts/0 has a terminal")
+}
+
+// TestCELHasTTY_NonExecEvent_DatasourceEvent asserts that has(event.hasTty) is
+// false on a non-exec event whose datasource carries no tty field at all. The
+// design intends this to be naturally false because presenceOf("tty") finds
+// nothing to report — not because of any special-casing on event type.
+func TestCELHasTTY_NonExecEvent_DatasourceEvent(t *testing.T) {
+	noTTYFields := newDatasourceExecEvent(t, utils.OpenEventType, ttyDSFields{})
+	require.False(t, evalTTYEvent(t, noTTYFields, utils.OpenEventType, `has(event.hasTty)`))
+}
+
+// TestCELTTYFieldsDatasourceEvent_WrongExpressionRejected proves the compile
+// assertion in evalTTYEvent has teeth: a comparison against a bare integer
+// literal for a uint-typed field must fail to compile (CEL here has no
+// cross-type numeric comparison), so a typo cannot masquerade as a legitimate
+// false. This is exercised directly against registerExpression rather than
+// evalTTYEvent, since evalTTYEvent's require.NoError would itself fail the
+// test if invoked with this expression — which is precisely the point.
+func TestCELTTYFieldsDatasourceEvent_WrongExpressionRejected(t *testing.T) {
+	c := newTestCEL(t)
+	err := c.registerExpression(`event.ttyMajor == 136`)
+	require.Error(t, err, "comparing a uint field against a bare int literal must fail to compile")
+}

--- a/pkg/rulemanager/cel/cel_tty_test.go
+++ b/pkg/rulemanager/cel/cel_tty_test.go
@@ -1,0 +1,77 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/ebpf/events"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	typesv1 "github.com/kubescape/node-agent/pkg/rulemanager/types/v1"
+	"github.com/kubescape/node-agent/pkg/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCEL(t *testing.T) *CEL {
+	t.Helper()
+	c, err := NewCEL(objectcache.NewObjectCacheMock(), config.Config{})
+	require.NoError(t, err)
+	return c
+}
+
+// evalTTY evaluates expr against a single exec event and returns the result.
+//
+// It asserts compilability first: EvaluateRule reports a compile failure as
+// (false, nil), so without this a typo or an unregistered field would look like
+// a legitimate false and the test would pass for the wrong reason.
+func evalTTY(t *testing.T, e *utils.StructEvent, expr string) bool {
+	t.Helper()
+	c := newTestCEL(t)
+	require.NoError(t, c.registerExpression(expr), "expression must compile")
+
+	ok, err := c.EvaluateRule(&events.EnrichedEvent{Event: e},
+		[]typesv1.RuleExpression{{EventType: utils.ExecveEventType, Expression: expr}})
+	require.NoError(t, err)
+	return ok
+}
+
+func TestCELTTYFieldsPhase1(t *testing.T) {
+	withTTY := &utils.StructEvent{EventType: utils.ExecveEventType, Comm: "bash", TTY: ptrInt32(3)}
+	require.True(t, evalTTY(t, withTTY, `has(event.hasTty) && event.hasTty`))
+	require.True(t, evalTTY(t, withTTY, `event.tty == 3`))
+	// The device number is not measured on this event.
+	require.False(t, evalTTY(t, withTTY, `has(event.ttyMajor)`))
+
+	noTTY := &utils.StructEvent{EventType: utils.ExecveEventType, Comm: "curl", TTY: ptrInt32(0)}
+	require.True(t, evalTTY(t, noTTY, `has(event.hasTty) && !event.hasTty`))
+}
+
+func TestCELTTYFieldsPhase2(t *testing.T) {
+	pts0 := &utils.StructEvent{
+		EventType: utils.ExecveEventType,
+		Comm:      "bash",
+		TTY:       ptrInt32(0),
+		TTYMajor:  ptrUint32(136),
+		TTYMinor:  ptrUint32(0),
+	}
+	require.True(t, evalTTY(t, pts0, `has(event.ttyMajor) && event.ttyMajor == 136u`))
+	require.True(t, evalTTY(t, pts0, `event.hasTty`), "pts/0 has a terminal")
+}
+
+// TestCELForwardCompatibility is the load-bearing test for the whole design: an
+// expression written for the future gadget must COMPILE on today's agent and
+// evaluate false, rather than fail to compile and silently disable the rule.
+func TestCELForwardCompatibility(t *testing.T) {
+	expr := `has(event.ttyMajor) && event.ttyMajor == 136u && event.comm == "bash"`
+
+	// The load-bearing assertion: it compiles even though no event carries the field.
+	c := newTestCEL(t)
+	require.NoError(t, c.registerExpression(expr),
+		"a phase-2 expression must compile on a phase-1 agent, or the rule is silently disabled")
+
+	// And it is inert rather than wrong.
+	phase1 := &utils.StructEvent{EventType: utils.ExecveEventType, Comm: "bash", TTY: ptrInt32(3)}
+	require.False(t, evalTTY(t, phase1, expr))
+}
+
+func ptrInt32(v int32) *int32    { return &v }
+func ptrUint32(v uint32) *uint32 { return &v }

--- a/pkg/rulemanager/types/v1/doc_exec_tty_test.go
+++ b/pkg/rulemanager/types/v1/doc_exec_tty_test.go
@@ -1,0 +1,86 @@
+package types
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestExecTTYDocRuleYAMLIsParseable keeps docs/features/exec-tty-field.md
+// honest. That doc's example rule YAML was fixed by human review from
+// snake_case keys (rule_expression, event_type) to the camelCase keys node-agent
+// actually parses (ruleExpression, eventType); with the wrong keys the rule
+// loads without error but its expression list silently unmarshals to empty, so
+// the rule never fires. Nothing guarded that regression, so this test extracts
+// every fenced ```yaml block from the doc and asserts each one unmarshals into
+// the real Rule type with a non-empty rule-expression list whose entry carries
+// a non-empty event type — exactly what the snake_case bug would have failed.
+func TestExecTTYDocRuleYAMLIsParseable(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("could not determine test file location via runtime.Caller")
+	}
+
+	// pkg/rulemanager/types/v1 -> repo root is four levels up.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	docPath := filepath.Join(repoRoot, "docs", "features", "exec-tty-field.md")
+
+	content, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Skipf("doc file not found at %s (repo layout may have changed): %v", docPath, err)
+	}
+
+	blocks := extractYAMLBlocks(string(content))
+	if len(blocks) == 0 {
+		t.Skip("no yaml code blocks found in docs/features/exec-tty-field.md")
+	}
+
+	for i, block := range blocks {
+		block := block
+		t.Run("block", func(t *testing.T) {
+			// The example in the doc is a YAML sequence fragment (a single
+			// list item), matching the shape of RulesSpec.Rules ([]Rule), not
+			// a whole Rules document. Unmarshal into []Rule directly.
+			var rules []Rule
+			if err := yaml.Unmarshal([]byte(block), &rules); err != nil {
+				t.Fatalf("yaml block %d did not parse as []Rule: %v\n---\n%s", i, err, block)
+			}
+
+			if len(rules) == 0 {
+				t.Fatalf("yaml block %d parsed but yielded zero rules:\n%s", i, block)
+			}
+
+			for _, r := range rules {
+				if len(r.Expressions.RuleExpression) == 0 {
+					t.Fatalf("rule %q parsed with an empty RuleExpression list — this is exactly"+
+						" the symptom of the snake_case key bug (rule_expression/event_type instead"+
+						" of ruleExpression/eventType), where the YAML parses without error but the"+
+						" expressions are silently dropped:\n%s", r.Name, block)
+				}
+				for _, re := range r.Expressions.RuleExpression {
+					if re.EventType == "" {
+						t.Fatalf("rule %q has a RuleExpression with an empty EventType — same"+
+							" snake_case symptom (event_type vs eventType):\n%s", r.Name, block)
+					}
+				}
+			}
+		})
+	}
+}
+
+var yamlFenceRe = regexp.MustCompile("(?s)```ya?ml\\n(.*?)```")
+
+// extractYAMLBlocks returns the content of every fenced ```yaml (or ```yml)
+// code block in md.
+func extractYAMLBlocks(md string) []string {
+	matches := yamlFenceRe.FindAllStringSubmatch(md, -1)
+	blocks := make([]string, 0, len(matches))
+	for _, m := range matches {
+		blocks = append(blocks, m[1])
+	}
+	return blocks
+}

--- a/pkg/rulemanager/types/v1/doc_exec_tty_test.go
+++ b/pkg/rulemanager/types/v1/doc_exec_tty_test.go
@@ -22,7 +22,7 @@ import (
 func TestExecTTYDocRuleYAMLIsParseable(t *testing.T) {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
-		t.Skip("could not determine test file location via runtime.Caller")
+		t.Fatal("could not determine test file location via runtime.Caller")
 	}
 
 	// pkg/rulemanager/types/v1 -> repo root is four levels up.
@@ -31,12 +31,12 @@ func TestExecTTYDocRuleYAMLIsParseable(t *testing.T) {
 
 	content, err := os.ReadFile(docPath)
 	if err != nil {
-		t.Skipf("doc file not found at %s (repo layout may have changed): %v", docPath, err)
+		t.Fatalf("read documented rule example at %s: %v", docPath, err)
 	}
 
 	blocks := extractYAMLBlocks(string(content))
 	if len(blocks) == 0 {
-		t.Skip("no yaml code blocks found in docs/features/exec-tty-field.md")
+		t.Fatal("no yaml code blocks found in docs/features/exec-tty-field.md")
 	}
 
 	for i, block := range blocks {

--- a/pkg/utils/cel.go
+++ b/pkg/utils/cel.go
@@ -75,6 +75,11 @@ func presenceOf(dsField string) ref.FieldTester {
 	})
 }
 
+// CelFields is the field registry exposed to rule expressions as `event.<name>`.
+//
+// A field whose IsSet tester is presenceOf(...) can be absent at runtime when
+// the running gadget does not emit it; rules should guard those with has().
+// See docs/features/exec-tty-field.md for the tty fields specifically.
 var CelFields = map[string]*celtypes.FieldType{
 	"args": {
 		Type:  celtypes.ListType,

--- a/pkg/utils/cel.go
+++ b/pkg/utils/cel.go
@@ -61,6 +61,20 @@ var urlIsSet = ref.FieldTester(func(target any) bool {
 	return req != nil && req.URL != nil
 })
 
+// presenceOf builds a field tester backed by the datasource field name dsField,
+// so CEL has(event.x) reports whether the running gadget actually emits the
+// underlying signal. Without this, an absent field is indistinguishable from a
+// zero value and rules cannot tell "no terminal" from "not measured".
+func presenceOf(dsField string) ref.FieldTester {
+	return ref.FieldTester(func(target any) bool {
+		x := target.(*xcel.Object[CelEvent])
+		if x.Raw == nil {
+			return false
+		}
+		return x.Raw.FieldPresent(dsField)
+	})
+}
+
 var CelFields = map[string]*celtypes.FieldType{
 	"args": {
 		Type:  celtypes.ListType,
@@ -214,6 +228,17 @@ var CelFields = map[string]*celtypes.FieldType{
 				return nil, errCelObjectNil
 			}
 			return celtypes.Int(x.Raw.GetFlagsRaw()), nil
+		}),
+	},
+	"hasTty": {
+		Type:  celtypes.BoolType,
+		IsSet: presenceOf("tty"),
+		GetFrom: ref.FieldGetter(func(target any) (any, error) {
+			x := target.(*xcel.Object[CelEvent])
+			if x.Raw == nil {
+				return nil, errCelObjectNil
+			}
+			return celtypes.Bool(x.Raw.GetHasTTY()), nil
 		}),
 	},
 	"module": {
@@ -390,6 +415,39 @@ var CelFields = map[string]*celtypes.FieldType{
 				return nil, errCelObjectNil
 			}
 			return celtypes.String(x.Raw.GetSyscall()), nil
+		}),
+	},
+	"tty": {
+		Type:  celtypes.IntType,
+		IsSet: presenceOf("tty"),
+		GetFrom: ref.FieldGetter(func(target any) (any, error) {
+			x := target.(*xcel.Object[CelEvent])
+			if x.Raw == nil {
+				return nil, errCelObjectNil
+			}
+			return celtypes.Int(x.Raw.GetTTY()), nil
+		}),
+	},
+	"ttyMajor": {
+		Type:  celtypes.UintType,
+		IsSet: presenceOf("tty_major"),
+		GetFrom: ref.FieldGetter(func(target any) (any, error) {
+			x := target.(*xcel.Object[CelEvent])
+			if x.Raw == nil {
+				return nil, errCelObjectNil
+			}
+			return celtypes.Uint(x.Raw.GetTTYMajor()), nil
+		}),
+	},
+	"ttyMinor": {
+		Type:  celtypes.UintType,
+		IsSet: presenceOf("tty_minor"),
+		GetFrom: ref.FieldGetter(func(target any) (any, error) {
+			x := target.(*xcel.Object[CelEvent])
+			if x.Raw == nil {
+				return nil, errCelObjectNil
+			}
+			return celtypes.Uint(x.Raw.GetTTYMinor()), nil
 		}),
 	},
 	"upperlayer": {

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -35,11 +35,16 @@ var (
 	// fieldName -> bool, recording whether that datasource exposes the field.
 	//
 	// Keyed by datasource instance rather than by EventType (as fieldCaches is)
-	// for two reasons: a FieldAccessor is only valid against the datasource that
-	// produced it, and misses must be cached here. dataSource.GetField falls back
-	// to a case-insensitive scan over every field when the name is absent, and
-	// fields that are absent by design (tty_major on an older gadget) are looked
-	// up on every single event.
+	// because a FieldAccessor is only valid against the datasource that produced
+	// it, so an EventType-keyed cache would serve accessors across datasources
+	// sharing an event type.
+	//
+	// Misses are cached too. Fields that are absent by design (tty_major on an
+	// older gadget) are looked up on every single event, and caching spares each
+	// one an RLock and a map lookup. It also keeps the cost flat if the IG
+	// replace directive in go.mod is ever retargeted at a version whose GetField
+	// falls back to a case-insensitive scan over all fields on a miss, as
+	// upstream's does.
 	//
 	// Bounded by the number of tracers (~19), all long-lived.
 	presenceCaches = sync.Map{}

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -509,6 +509,18 @@ func (e *DatasourceEvent) GetGid() *uint32 {
 	}
 }
 
+func (e *DatasourceEvent) GetHasTTY() bool {
+	if e.FieldPresent("tty_major") {
+		major, _ := e.getFieldAccessor("tty_major").Uint32(e.Data)
+		return major != 0
+	}
+	if e.FieldPresent("tty") {
+		idx, _ := e.getFieldAccessor("tty").Int32(e.Data)
+		return idx != 0
+	}
+	return false
+}
+
 func (e *DatasourceEvent) GetHostNetwork() bool {
 	hostNetwork, _ := e.getFieldAccessor("k8s.hostnetwork").Bool(e.Data)
 	return hostNetwork
@@ -767,6 +779,40 @@ func (e *DatasourceEvent) GetSyscall() string {
 func (e *DatasourceEvent) GetSyscalls() []byte {
 	syscallsBuffer, _ := e.getFieldAccessor("syscalls").Bytes(e.Data)
 	return syscallsBuffer
+}
+
+// GetTTY returns the index of the controlling terminal within its own driver.
+// It does not identify a terminal: the index is only unique per driver, and 0
+// is reported both for /dev/pts/0 and for a process with no terminal. Prefer
+// GetTTYMajor/GetTTYMinor.
+func (e *DatasourceEvent) GetTTY() int32 {
+	if !e.FieldPresent("tty") {
+		return 0
+	}
+	tty, _ := e.getFieldAccessor("tty").Int32(e.Data)
+	return tty
+}
+
+// GetTTYMajor returns the major number of the controlling terminal's device,
+// or 0 when the process has no controlling terminal or the running gadget does
+// not emit it. Use FieldPresent("tty_major") to tell those apart.
+func (e *DatasourceEvent) GetTTYMajor() uint32 {
+	if !e.FieldPresent("tty_major") {
+		return 0
+	}
+	major, _ := e.getFieldAccessor("tty_major").Uint32(e.Data)
+	return major
+}
+
+// GetTTYMinor returns the minor number of the controlling terminal's device,
+// or 0 when the process has no controlling terminal or the running gadget does
+// not emit it.
+func (e *DatasourceEvent) GetTTYMinor() uint32 {
+	if !e.FieldPresent("tty_minor") {
+		return 0
+	}
+	minor, _ := e.getFieldAccessor("tty_minor").Uint32(e.Data)
+	return minor
 }
 
 func (e *DatasourceEvent) getTid() uint64 {

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -31,13 +31,20 @@ const (
 var (
 	fieldCaches = sync.Map{}
 
-	// presenceCaches maps a datasource.DataSource to a *sync.Map of
-	// fieldName -> bool, recording whether that datasource exposes the field.
+	// accessorCaches maps a datasource.DataSource to a *sync.Map of
+	// fieldName -> datasource.FieldAccessor, storing nil for fields the
+	// datasource does not expose.
 	//
 	// Keyed by datasource instance rather than by EventType (as fieldCaches is)
 	// because a FieldAccessor is only valid against the datasource that produced
-	// it, so an EventType-keyed cache would serve accessors across datasources
-	// sharing an event type.
+	// it: it decodes at a fixed offset in that datasource's layout. An
+	// EventType-keyed cache serves accessors across datasources sharing an event
+	// type, so reading through one would decode another datasource's data at the
+	// wrong offset -- returning garbage, or panicking inside Inspektor Gadget's
+	// fieldAccessor.Get. Checking presence first is not sufficient protection,
+	// because it only rules out the case where this datasource lacks the field;
+	// when two datasources both expose it, presence passes and the cached
+	// accessor still belongs to the other one.
 	//
 	// Misses are cached too. Fields that are absent by design (tty_major on an
 	// older gadget) are looked up on every single event, and caching spares each
@@ -47,7 +54,7 @@ var (
 	// upstream's does.
 	//
 	// Bounded by the number of tracers (~19), all long-lived.
-	presenceCaches = sync.Map{}
+	accessorCaches = sync.Map{}
 )
 
 type DatasourceEvent struct {
@@ -216,27 +223,38 @@ func (e *DatasourceEvent) getFieldAccessor(fieldName string) datasource.FieldAcc
 // distinguished from "the signal's value is zero". It never logs: an absent
 // field is an expected, per-event condition.
 func (e *DatasourceEvent) FieldPresent(name string) bool {
+	return e.localFieldAccessor(name) != nil
+}
+
+// localFieldAccessor returns the accessor for name on *this event's* datasource,
+// or nil when that datasource does not expose the field. Unlike
+// getFieldAccessor it never returns an accessor belonging to a different
+// datasource, and it never logs -- an absent field is an expected, per-event
+// condition. See accessorCaches for why the distinction matters.
+func (e *DatasourceEvent) localFieldAccessor(name string) datasource.FieldAccessor {
 	if e == nil || e.Datasource == nil {
-		return false
+		return nil
 	}
 
-	cacheVal, ok := presenceCaches.Load(e.Datasource)
+	cacheVal, ok := accessorCaches.Load(e.Datasource)
 	if !ok {
-		cacheVal, _ = presenceCaches.LoadOrStore(e.Datasource, &sync.Map{})
+		cacheVal, _ = accessorCaches.LoadOrStore(e.Datasource, &sync.Map{})
 	}
 
 	m, ok := cacheVal.(*sync.Map)
 	if !ok {
-		return false
+		return nil
 	}
 
-	if present, ok := m.Load(name); ok {
-		return present.(bool)
+	if cached, ok := m.Load(name); ok {
+		accessor, _ := cached.(datasource.FieldAccessor)
+		return accessor
 	}
 
-	present := e.Datasource.GetField(name) != nil
-	m.Store(name, present)
-	return present
+	// GetField returns nil for an absent field; storing that nil caches the miss.
+	field := e.Datasource.GetField(name)
+	m.Store(name, field)
+	return field
 }
 
 func (e *DatasourceEvent) GetAddresses() []string {
@@ -509,19 +527,23 @@ func (e *DatasourceEvent) GetGid() *uint32 {
 	}
 }
 
-// GetHasTTY reports whether the process has a controlling terminal. It checks
-// FieldPresent first: besides avoiding a log-spam warning for a field the
-// running gadget doesn't emit, this also guards against fieldCaches (keyed by
-// EventType, not by datasource) serving back a FieldAccessor cached by a
-// different datasource that does have the field, which would otherwise panic
-// inside Inspektor Gadget's fieldAccessor.Get.
+// GetHasTTY reports whether the process has a controlling terminal.
+//
+// It prefers the device number, which is unambiguous, and falls back to the
+// raw per-driver index, where 0 means both /dev/pts/0 and "no terminal" -- so on
+// a gadget that emits only the index this under-reports rather than
+// over-reports. The preference order is what lets the field become accurate with
+// no code change once the gadget emits tty_major.
+//
+// Reads go through localFieldAccessor, not getFieldAccessor, so an accessor from
+// another datasource sharing this EventType can never decode this event's data.
 func (e *DatasourceEvent) GetHasTTY() bool {
-	if e.FieldPresent("tty_major") {
-		major, _ := e.getFieldAccessor("tty_major").Uint32(e.Data)
+	if accessor := e.localFieldAccessor("tty_major"); accessor != nil {
+		major, _ := accessor.Uint32(e.Data)
 		return major != 0
 	}
-	if e.FieldPresent("tty") {
-		idx, _ := e.getFieldAccessor("tty").Int32(e.Data)
+	if accessor := e.localFieldAccessor("tty"); accessor != nil {
+		idx, _ := accessor.Int32(e.Data)
 		return idx != 0
 	}
 	return false
@@ -788,14 +810,16 @@ func (e *DatasourceEvent) GetSyscalls() []byte {
 }
 
 // GetTTY returns the index of the controlling terminal within its own driver.
-// It does not identify a terminal: the index is only unique per driver, and 0
-// is reported both for /dev/pts/0 and for a process with no terminal. Prefer
-// GetTTYMajor/GetTTYMinor.
+// It does not uniquely identify a device: the index is only unique per driver,
+// so /dev/pts/0 and /dev/tty0 are both 0. A nonzero value does mean a terminal
+// is present; only 0 is ambiguous, meaning either /dev/pts/0 or no terminal at
+// all. Prefer GetTTYMajor/GetTTYMinor.
 func (e *DatasourceEvent) GetTTY() int32 {
-	if !e.FieldPresent("tty") {
+	accessor := e.localFieldAccessor("tty")
+	if accessor == nil {
 		return 0
 	}
-	tty, _ := e.getFieldAccessor("tty").Int32(e.Data)
+	tty, _ := accessor.Int32(e.Data)
 	return tty
 }
 
@@ -803,10 +827,11 @@ func (e *DatasourceEvent) GetTTY() int32 {
 // or 0 when the process has no controlling terminal or the running gadget does
 // not emit it. Use FieldPresent("tty_major") to tell those apart.
 func (e *DatasourceEvent) GetTTYMajor() uint32 {
-	if !e.FieldPresent("tty_major") {
+	accessor := e.localFieldAccessor("tty_major")
+	if accessor == nil {
 		return 0
 	}
-	major, _ := e.getFieldAccessor("tty_major").Uint32(e.Data)
+	major, _ := accessor.Uint32(e.Data)
 	return major
 }
 
@@ -814,10 +839,11 @@ func (e *DatasourceEvent) GetTTYMajor() uint32 {
 // or 0 when the process has no controlling terminal or the running gadget does
 // not emit it.
 func (e *DatasourceEvent) GetTTYMinor() uint32 {
-	if !e.FieldPresent("tty_minor") {
+	accessor := e.localFieldAccessor("tty_minor")
+	if accessor == nil {
 		return 0
 	}
-	minor, _ := e.getFieldAccessor("tty_minor").Uint32(e.Data)
+	minor, _ := accessor.Uint32(e.Data)
 	return minor
 }
 

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -509,6 +509,12 @@ func (e *DatasourceEvent) GetGid() *uint32 {
 	}
 }
 
+// GetHasTTY reports whether the process has a controlling terminal. It checks
+// FieldPresent first: besides avoiding a log-spam warning for a field the
+// running gadget doesn't emit, this also guards against fieldCaches (keyed by
+// EventType, not by datasource) serving back a FieldAccessor cached by a
+// different datasource that does have the field, which would otherwise panic
+// inside Inspektor Gadget's fieldAccessor.Get.
 func (e *DatasourceEvent) GetHasTTY() bool {
 	if e.FieldPresent("tty_major") {
 		major, _ := e.getFieldAccessor("tty_major").Uint32(e.Data)

--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -30,6 +30,19 @@ const (
 
 var (
 	fieldCaches = sync.Map{}
+
+	// presenceCaches maps a datasource.DataSource to a *sync.Map of
+	// fieldName -> bool, recording whether that datasource exposes the field.
+	//
+	// Keyed by datasource instance rather than by EventType (as fieldCaches is)
+	// for two reasons: a FieldAccessor is only valid against the datasource that
+	// produced it, and misses must be cached here. dataSource.GetField falls back
+	// to a case-insensitive scan over every field when the name is absent, and
+	// fields that are absent by design (tty_major on an older gadget) are looked
+	// up on every single event.
+	//
+	// Bounded by the number of tracers (~19), all long-lived.
+	presenceCaches = sync.Map{}
 )
 
 type DatasourceEvent struct {
@@ -189,6 +202,36 @@ func (e *DatasourceEvent) getFieldAccessor(fieldName string) datasource.FieldAcc
 	}
 
 	return res
+}
+
+// FieldPresent reports whether the underlying datasource exposes the named
+// field. name is a datasource field name (snake_case), not a CEL field name.
+//
+// This is how "the gadget running on this agent does not emit this signal" is
+// distinguished from "the signal's value is zero". It never logs: an absent
+// field is an expected, per-event condition.
+func (e *DatasourceEvent) FieldPresent(name string) bool {
+	if e == nil || e.Datasource == nil {
+		return false
+	}
+
+	cacheVal, ok := presenceCaches.Load(e.Datasource)
+	if !ok {
+		cacheVal, _ = presenceCaches.LoadOrStore(e.Datasource, &sync.Map{})
+	}
+
+	m, ok := cacheVal.(*sync.Map)
+	if !ok {
+		return false
+	}
+
+	if present, ok := m.Load(name); ok {
+		return present.(bool)
+	}
+
+	present := e.Datasource.GetField(name) != nil
+	m.Store(name, present)
+	return present
 }
 
 func (e *DatasourceEvent) GetAddresses() []string {

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -222,12 +222,13 @@ func TestTTYGettersDoNotLog(t *testing.T) {
 
 	// The pretty logger honours SetWriter; the zap logger does not, and plain
 	// (non-Ctx) warnings bypass the OTEL bridge entirely.
+	prevName := logger.L().LoggerName()
 	logger.InitLogger("pretty")
 	prev := logger.L().GetWriter()
 	logger.L().SetWriter(f)
 	defer func() {
 		logger.L().SetWriter(prev)
-		logger.InitLogger("none")
+		logger.InitLogger(prevName)
 	}()
 
 	// Phase-1 shape: tty_major and tty_minor are absent.

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"os"
 	"testing"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/kubescape/go-logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -189,4 +191,72 @@ func TestStructEventTTYGetters(t *testing.T) {
 	unset := &StructEvent{EventType: ExecveEventType}
 	require.Equal(t, int32(0), unset.GetTTY())
 	require.False(t, unset.GetHasTTY())
+}
+
+// logSize returns the number of bytes written to the capture file so far.
+func logSize(t *testing.T, f *os.File) int64 {
+	t.Helper()
+	st, err := os.Stat(f.Name())
+	require.NoError(t, err)
+	return st.Size()
+}
+
+// resetLog truncates the capture file back to empty.
+func resetLog(t *testing.T, f *os.File) {
+	t.Helper()
+	require.NoError(t, f.Truncate(0))
+	_, err := f.Seek(0, 0)
+	require.NoError(t, err)
+}
+
+// TestTTYGettersDoNotLog asserts that reading tty fields the running gadget does
+// not emit produces no log output. tty_major is absent on every exec event until
+// the gadget ships it, so a single Warning on that path becomes thousands of
+// lines per second on a busy node.
+//
+// Does not call t.Parallel(): it mutates the global logger.
+func TestTTYGettersDoNotLog(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "log")
+	require.NoError(t, err)
+	defer f.Close()
+
+	// The pretty logger honours SetWriter; the zap logger does not, and plain
+	// (non-Ctx) warnings bypass the OTEL bridge entirely.
+	logger.InitLogger("pretty")
+	prev := logger.L().GetWriter()
+	logger.L().SetWriter(f)
+	defer func() {
+		logger.L().SetWriter(prev)
+		logger.InitLogger("none")
+	}()
+
+	// Phase-1 shape: tty_major and tty_minor are absent.
+	e := newExecEvent(t, ttyFields{tty: i32(0)})
+
+	// Control 1: capture must be live, or everything below passes vacuously.
+	logger.L().Warning("capture control")
+	require.NotZero(t, logSize(t, f), "log capture is not working, so this test would prove nothing")
+	resetLog(t, f)
+
+	// The property under test.
+	for i := 0; i < 100; i++ {
+		e.GetHasTTY()
+		e.GetTTY()
+		e.GetTTYMajor()
+		e.GetTTYMinor()
+		e.FieldPresent("tty_major")
+	}
+	require.Zero(t, logSize(t, f), "tty getters must not log for absent fields")
+
+	// Control 2: an unguarded lookup of an absent field DOES log, proving the
+	// assertion above would fail if a getter dropped its FieldPresent guard.
+	//
+	// Deliberately NOT "tty_major": getFieldAccessor caches found fields in the
+	// package-global fieldCaches, keyed by EventType rather than by datasource.
+	// Earlier tests in this package construct a phase-2 datasource that HAS
+	// tty_major, which caches an accessor under ExecveEventType and silences the
+	// warning for every later lookup of that name. A name nothing else looks up
+	// is immune to that, and misses are never cached, so it logs every time.
+	_ = e.getFieldAccessor("zz_absent_log_control")
+	require.NotZero(t, logSize(t, f), "unguarded getFieldAccessor should log; if it does not, the assertion above has no teeth")
 }

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -154,6 +154,15 @@ func TestDatasourceEventTTYGetters(t *testing.T) {
 		require.True(t, e.GetHasTTY())
 	})
 
+	t.Run("phase2 major zero wins over nonzero index", func(t *testing.T) {
+		// Discriminates preference-order from OR semantics: tty_major is
+		// authoritative when present, so major 0 means no controlling terminal
+		// even though the stale index is nonzero. An OR implementation would
+		// wrongly return true here.
+		e := newExecEvent(t, ttyFields{tty: i32(5), ttyMajor: u32(0), ttyMinor: u32(0)})
+		require.False(t, e.GetHasTTY(), "tty_major present and 0 must win over a nonzero tty index")
+	})
+
 	t.Run("no tty fields at all", func(t *testing.T) {
 		e := newExecEvent(t, ttyFields{})
 		require.Equal(t, int32(0), e.GetTTY())
@@ -173,6 +182,9 @@ func TestStructEventTTYGetters(t *testing.T) {
 	phase2 := &StructEvent{EventType: ExecveEventType, TTY: i32(0), TTYMajor: u32(136), TTYMinor: u32(0)}
 	require.Equal(t, uint32(136), phase2.GetTTYMajor())
 	require.True(t, phase2.GetHasTTY())
+
+	majorZeroWins := &StructEvent{EventType: ExecveEventType, TTY: i32(5), TTYMajor: u32(0), TTYMinor: u32(0)}
+	require.False(t, majorZeroWins.GetHasTTY(), "TTYMajor present and 0 must win over a nonzero TTY index")
 
 	unset := &StructEvent{EventType: ExecveEventType}
 	require.Equal(t, int32(0), unset.GetTTY())

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-service/api"
+	"github.com/stretchr/testify/require"
+)
+
+// ttyFields describes which tty-related fields a synthetic datasource exposes.
+type ttyFields struct {
+	tty      *int32
+	ttyMajor *uint32
+	ttyMinor *uint32
+}
+
+// newExecEvent builds a synthetic "exec" datasource containing only the tty
+// fields that are non-nil in f, plus a filler "comm" field so the datasource is
+// not degenerate. It returns a DatasourceEvent ready for the getters under test.
+//
+// The filler is decorative: the CEL "comm" field actually reads the datasource
+// field "proc.comm", so GetComm() on this event returns "". Do not assert on it.
+//
+// Each call creates a fresh DataSource, which matters: the presence cache is
+// keyed by datasource instance, so cases cannot poison each other.
+func newExecEvent(t *testing.T, f ttyFields) *DatasourceEvent {
+	t.Helper()
+
+	ds, err := datasource.New(datasource.TypeSingle, "exec")
+	require.NoError(t, err)
+
+	commAcc, err := ds.AddField("comm", api.Kind_String)
+	require.NoError(t, err)
+
+	var ttyAcc, majorAcc, minorAcc datasource.FieldAccessor
+	if f.tty != nil {
+		ttyAcc, err = ds.AddField("tty", api.Kind_Int32)
+		require.NoError(t, err)
+	}
+	if f.ttyMajor != nil {
+		majorAcc, err = ds.AddField("tty_major", api.Kind_Uint32)
+		require.NoError(t, err)
+	}
+	if f.ttyMinor != nil {
+		minorAcc, err = ds.AddField("tty_minor", api.Kind_Uint32)
+		require.NoError(t, err)
+	}
+
+	data, err := ds.NewPacketSingle()
+	require.NoError(t, err)
+	t.Cleanup(func() { ds.Release(data) })
+
+	require.NoError(t, commAcc.PutString(data, "bash"))
+	if f.tty != nil {
+		require.NoError(t, ttyAcc.PutInt32(data, *f.tty))
+	}
+	if f.ttyMajor != nil {
+		require.NoError(t, majorAcc.PutUint32(data, *f.ttyMajor))
+	}
+	if f.ttyMinor != nil {
+		require.NoError(t, minorAcc.PutUint32(data, *f.ttyMinor))
+	}
+
+	return &DatasourceEvent{
+		Data:       data,
+		Datasource: ds,
+		EventType:  ExecveEventType,
+	}
+}
+
+func i32(v int32) *int32   { return &v }
+func u32(v uint32) *uint32 { return &v }
+
+func TestDatasourceEventFieldPresent(t *testing.T) {
+	// Phase-1 gadget shape: only "tty" is emitted.
+	phase1 := newExecEvent(t, ttyFields{tty: i32(0)})
+	require.True(t, phase1.FieldPresent("tty"))
+	require.False(t, phase1.FieldPresent("tty_major"))
+	require.False(t, phase1.FieldPresent("tty_minor"))
+
+	// Repeat lookups must be stable (exercises the cached-miss path).
+	require.False(t, phase1.FieldPresent("tty_major"))
+
+	// Phase-2 gadget shape: all three emitted.
+	phase2 := newExecEvent(t, ttyFields{tty: i32(0), ttyMajor: u32(136), ttyMinor: u32(0)})
+	require.True(t, phase2.FieldPresent("tty"))
+	require.True(t, phase2.FieldPresent("tty_major"))
+	require.True(t, phase2.FieldPresent("tty_minor"))
+
+	// A datasource with no tty fields at all.
+	none := newExecEvent(t, ttyFields{})
+	require.False(t, none.FieldPresent("tty"))
+	require.False(t, none.FieldPresent("tty_major"))
+
+	// Defensive: a nil datasource must not panic.
+	empty := &DatasourceEvent{EventType: ExecveEventType}
+	require.False(t, empty.FieldPresent("tty"))
+}
+
+func TestStructEventFieldPresent(t *testing.T) {
+	set := &StructEvent{EventType: ExecveEventType, TTY: i32(3), TTYMajor: u32(136), TTYMinor: u32(3)}
+	require.True(t, set.FieldPresent("tty"))
+	require.True(t, set.FieldPresent("tty_major"))
+	require.True(t, set.FieldPresent("tty_minor"))
+
+	unset := &StructEvent{EventType: ExecveEventType}
+	require.False(t, unset.FieldPresent("tty"))
+	require.False(t, unset.FieldPresent("tty_major"))
+	require.False(t, unset.FieldPresent("tty_minor"))
+
+	// Names without a wired presence tester report false.
+	require.False(t, set.FieldPresent("comm"))
+}

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -116,3 +116,65 @@ func TestStructEventFieldPresent(t *testing.T) {
 	// Names without a wired presence tester report false.
 	require.False(t, set.FieldPresent("comm"))
 }
+
+func TestDatasourceEventTTYGetters(t *testing.T) {
+	t.Run("phase1 with a terminal", func(t *testing.T) {
+		// Gadget emits only the driver-local index. Index 3 proves a terminal.
+		e := newExecEvent(t, ttyFields{tty: i32(3)})
+		require.Equal(t, int32(3), e.GetTTY())
+		require.True(t, e.GetHasTTY())
+		// Device number is unavailable on this gadget.
+		require.Equal(t, uint32(0), e.GetTTYMajor())
+		require.Equal(t, uint32(0), e.GetTTYMinor())
+	})
+
+	t.Run("phase1 index zero reads as no terminal", func(t *testing.T) {
+		// Knowingly wrong for pts/0; accepted phase-1 semantics.
+		e := newExecEvent(t, ttyFields{tty: i32(0)})
+		require.Equal(t, int32(0), e.GetTTY())
+		require.False(t, e.GetHasTTY())
+	})
+
+	t.Run("phase2 pts0 is recognised", func(t *testing.T) {
+		// The case phase 1 gets wrong: major 136 minor 0 is /dev/pts/0.
+		e := newExecEvent(t, ttyFields{tty: i32(0), ttyMajor: u32(136), ttyMinor: u32(0)})
+		require.Equal(t, uint32(136), e.GetTTYMajor())
+		require.Equal(t, uint32(0), e.GetTTYMinor())
+		require.True(t, e.GetHasTTY(), "major 136 is a pty, so a terminal exists")
+	})
+
+	t.Run("phase2 no terminal", func(t *testing.T) {
+		e := newExecEvent(t, ttyFields{tty: i32(0), ttyMajor: u32(0), ttyMinor: u32(0)})
+		require.False(t, e.GetHasTTY())
+	})
+
+	t.Run("phase2 major wins over index", func(t *testing.T) {
+		// Proves the fallback order: tty_major is authoritative when present.
+		e := newExecEvent(t, ttyFields{tty: i32(0), ttyMajor: u32(4), ttyMinor: u32(1)})
+		require.True(t, e.GetHasTTY())
+	})
+
+	t.Run("no tty fields at all", func(t *testing.T) {
+		e := newExecEvent(t, ttyFields{})
+		require.Equal(t, int32(0), e.GetTTY())
+		require.Equal(t, uint32(0), e.GetTTYMajor())
+		require.False(t, e.GetHasTTY())
+	})
+}
+
+func TestStructEventTTYGetters(t *testing.T) {
+	phase1 := &StructEvent{EventType: ExecveEventType, TTY: i32(3)}
+	require.Equal(t, int32(3), phase1.GetTTY())
+	require.True(t, phase1.GetHasTTY())
+
+	phase1Zero := &StructEvent{EventType: ExecveEventType, TTY: i32(0)}
+	require.False(t, phase1Zero.GetHasTTY())
+
+	phase2 := &StructEvent{EventType: ExecveEventType, TTY: i32(0), TTYMajor: u32(136), TTYMinor: u32(0)}
+	require.Equal(t, uint32(136), phase2.GetTTYMajor())
+	require.True(t, phase2.GetHasTTY())
+
+	unset := &StructEvent{EventType: ExecveEventType}
+	require.Equal(t, int32(0), unset.GetTTY())
+	require.False(t, unset.GetHasTTY())
+}

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -96,6 +96,10 @@ func TestDatasourceEventFieldPresent(t *testing.T) {
 	// Defensive: a nil datasource must not panic.
 	empty := &DatasourceEvent{EventType: ExecveEventType}
 	require.False(t, empty.FieldPresent("tty"))
+
+	// Defensive: a nil receiver must not panic either.
+	var nilEvent *DatasourceEvent
+	require.False(t, nilEvent.FieldPresent("tty"))
 }
 
 func TestStructEventFieldPresent(t *testing.T) {

--- a/pkg/utils/datasource_event_tty_test.go
+++ b/pkg/utils/datasource_event_tty_test.go
@@ -261,3 +261,69 @@ func TestTTYGettersDoNotLog(t *testing.T) {
 	_ = e.getFieldAccessor("zz_absent_log_control")
 	require.NotZero(t, logSize(t, f), "unguarded getFieldAccessor should log; if it does not, the assertion above has no teeth")
 }
+
+// TestTTYGettersUseTheirOwnDatasource is a regression test for accessor reuse
+// across datasources.
+//
+// fieldCaches is keyed by EventType, not by datasource, so two datasources that
+// share an event type share one accessor cache. A FieldAccessor decodes at a
+// fixed offset in the layout of the datasource that produced it, so reading one
+// datasource's data through another's accessor yields the wrong value or panics
+// inside Inspektor Gadget's fieldAccessor.Get.
+//
+// Checking presence first does not prevent this: presence only rules out the
+// case where this datasource lacks the field. When both expose it -- as here --
+// presence passes and the stale accessor is still the other datasource's. The
+// TTY getters therefore resolve accessors per datasource.
+//
+// The two datasources below deliberately place "tty" at different offsets, and
+// the wide one is read first so it is the entry that lands in the shared cache.
+func TestTTYGettersUseTheirOwnDatasource(t *testing.T) {
+	newAt := func(t *testing.T, name string, pads int, tty int32) *DatasourceEvent {
+		t.Helper()
+
+		ds, err := datasource.New(datasource.TypeSingle, name)
+		require.NoError(t, err)
+
+		commAcc, err := ds.AddField("comm", api.Kind_String)
+		require.NoError(t, err)
+		padAccs := make([]datasource.FieldAccessor, pads)
+		for i := 0; i < pads; i++ {
+			padAccs[i], err = ds.AddField("pad"+string(rune('a'+i)), api.Kind_Uint64)
+			require.NoError(t, err)
+		}
+		ttyAcc, err := ds.AddField("tty", api.Kind_Int32)
+		require.NoError(t, err)
+
+		data, err := ds.NewPacketSingle()
+		require.NoError(t, err)
+		t.Cleanup(func() { ds.Release(data) })
+
+		require.NoError(t, commAcc.PutString(data, "bash"))
+		for _, acc := range padAccs {
+			require.NoError(t, acc.PutUint64(data, 0xDEADBEEF))
+		}
+		require.NoError(t, ttyAcc.PutInt32(data, tty))
+
+		// Same EventType for both, which is what makes them share fieldCaches.
+		return &DatasourceEvent{Data: data, Datasource: ds, EventType: ExecveEventType}
+	}
+
+	wide := newAt(t, "exec-wide", 3, 7)
+	narrow := newAt(t, "exec-narrow", 0, 3)
+
+	// Read the wide one first so its accessor is the cached one for "tty".
+	require.Equal(t, int32(7), wide.GetTTY())
+	require.True(t, wide.GetHasTTY())
+
+	// The narrow datasource must read its own value, not the wide one's.
+	require.Equal(t, int32(3), narrow.GetTTY(),
+		"narrow datasource must decode its own tty, not through the wide datasource's cached accessor")
+	require.True(t, narrow.GetHasTTY())
+
+	// And a third, narrow datasource whose tty is genuinely 0 must not inherit
+	// the cached nonzero reading.
+	zero := newAt(t, "exec-zero", 0, 0)
+	require.Equal(t, int32(0), zero.GetTTY())
+	require.False(t, zero.GetHasTTY(), "tty == 0 must read as no terminal regardless of other datasources")
+}

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -37,6 +37,7 @@ type EnrichEvent interface {
 	GetContainerImageDigest() string
 	GetError() int64
 	GetExtra() interface{}
+	FieldPresent(name string) bool
 	GetGid() *uint32
 	GetHostNetwork() bool
 	GetMountNsID() uint64

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -97,8 +97,12 @@ type ExecEvent interface {
 	GetArgs() []string
 	GetCwd() string
 	GetExePath() string
+	GetHasTTY() bool
 	GetParentExePath() string
 	GetPupperLayer() bool
+	GetTTY() int32
+	GetTTYMajor() uint32
+	GetTTYMinor() uint32
 	GetUpperLayer() bool
 }
 

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -104,6 +104,26 @@ var _ SshEvent = (*StructEvent)(nil)
 var _ SyscallEvent = (*StructEvent)(nil)
 var _ UnshareEvent = (*StructEvent)(nil)
 
+// FieldPresent reports whether this event carries the named field, using
+// datasource field names (snake_case) to match the DatasourceEvent
+// implementation. A nil pointer means "not measured".
+//
+// Only names with a wired CEL presence tester are meaningful here; everything
+// else reports false. If a presence tester is ever added for another field,
+// this switch must be extended in the same change.
+func (e *StructEvent) FieldPresent(name string) bool {
+	switch name {
+	case "tty":
+		return e.TTY != nil
+	case "tty_major":
+		return e.TTYMajor != nil
+	case "tty_minor":
+		return e.TTYMinor != nil
+	default:
+		return false
+	}
+}
+
 func (e *StructEvent) GetAddresses() []string {
 	return e.Addresses
 }
@@ -425,26 +445,6 @@ func (e *StructEvent) GetTimestamp() types.Time {
 
 func (e *StructEvent) GetType() HTTPDataType {
 	return e.Type
-}
-
-// FieldPresent reports whether this event carries the named field, using
-// datasource field names (snake_case) to match the DatasourceEvent
-// implementation. A nil pointer means "not measured".
-//
-// Only names with a wired CEL presence tester are meaningful here; everything
-// else reports false. If a presence tester is ever added for another field,
-// this switch must be extended in the same change.
-func (e *StructEvent) FieldPresent(name string) bool {
-	switch name {
-	case "tty":
-		return e.TTY != nil
-	case "tty_major":
-		return e.TTYMajor != nil
-	case "tty_minor":
-		return e.TTYMinor != nil
-	default:
-		return false
-	}
 }
 
 func (e *StructEvent) GetUid() *uint32 {

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -285,6 +285,18 @@ func (e *StructEvent) GetGid() *uint32 {
 	return &e.Gid
 }
 
+// GetHasTTY reports whether the process has a controlling terminal, preferring
+// the device major and falling back to the driver-local index.
+func (e *StructEvent) GetHasTTY() bool {
+	if e.TTYMajor != nil {
+		return *e.TTYMajor != 0
+	}
+	if e.TTY != nil {
+		return *e.TTY != 0
+	}
+	return false
+}
+
 func (e *StructEvent) GetHostNetwork() bool {
 	return e.HostNetwork
 }
@@ -428,6 +440,27 @@ func (e *StructEvent) GetSyscall() string {
 
 func (e *StructEvent) GetSyscalls() []byte {
 	return e.Syscalls
+}
+
+func (e *StructEvent) GetTTY() int32 {
+	if e.TTY == nil {
+		return 0
+	}
+	return *e.TTY
+}
+
+func (e *StructEvent) GetTTYMajor() uint32 {
+	if e.TTYMajor == nil {
+		return 0
+	}
+	return *e.TTYMajor
+}
+
+func (e *StructEvent) GetTTYMinor() uint32 {
+	if e.TTYMinor == nil {
+		return 0
+	}
+	return *e.TTYMinor
 }
 
 func (e *StructEvent) GetTid() uint64 {

--- a/pkg/utils/struct_event.go
+++ b/pkg/utils/struct_event.go
@@ -78,6 +78,9 @@ type StructEvent struct {
 	Syscalls             []byte                  `json:"syscalls,omitempty" yaml:"syscalls,omitempty"`
 	Tid                  uint64                  `json:"tid,omitempty" yaml:"tid,omitempty"`
 	Timestamp            int64                   `json:"timestamp,omitempty" yaml:"timestamp,omitempty"`
+	TTY                  *int32                  `json:"tty,omitempty" yaml:"tty,omitempty"`
+	TTYMajor             *uint32                 `json:"ttyMajor,omitempty" yaml:"ttyMajor,omitempty"`
+	TTYMinor             *uint32                 `json:"ttyMinor,omitempty" yaml:"ttyMinor,omitempty"`
 	Type                 HTTPDataType            `json:"type,omitempty" yaml:"type,omitempty"`
 	Uid                  uint32                  `json:"uid,omitempty" yaml:"uid,omitempty"`
 	UpperLayer           bool                    `json:"upperLayer,omitempty" yaml:"upperLayer,omitempty"`
@@ -422,6 +425,26 @@ func (e *StructEvent) GetTimestamp() types.Time {
 
 func (e *StructEvent) GetType() HTTPDataType {
 	return e.Type
+}
+
+// FieldPresent reports whether this event carries the named field, using
+// datasource field names (snake_case) to match the DatasourceEvent
+// implementation. A nil pointer means "not measured".
+//
+// Only names with a wired CEL presence tester are meaningful here; everything
+// else reports false. If a presence tester is ever added for another field,
+// this switch must be extended in the same change.
+func (e *StructEvent) FieldPresent(name string) bool {
+	switch name {
+	case "tty":
+		return e.TTY != nil
+	case "tty_major":
+		return e.TTYMajor != nil
+	case "tty_minor":
+		return e.TTYMinor != nil
+	default:
+		return false
+	}
 }
 
 func (e *StructEvent) GetUid() *uint32 {

--- a/tests/component_test.go
+++ b/tests/component_test.go
@@ -3384,7 +3384,9 @@ func Test_34_NetworkNeighborsCIDRCollapse(t *testing.T) {
 
 	k8sClient := k8sinterface.NewKubernetesApi()
 	dyn := dynamic.NewForConfigOrDie(k8sClient.K8SConfig)
-	t.Cleanup(func() { _ = dyn.Resource(ccCollapseGVR).Delete(context.Background(), "default", metav1.DeleteOptions{}) })
+	t.Cleanup(func() {
+		_ = dyn.Resource(ccCollapseGVR).Delete(context.Background(), "default", metav1.DeleteOptions{})
+	})
 
 	// -------- Phase 1: /16 floor — exactness on real cloud ranges --------
 	applyCollapseFloor(t, dyn, 16)
@@ -3446,4 +3448,150 @@ func Test_34_NetworkNeighborsCIDRCollapse(t *testing.T) {
 
 	t.Logf("collapse validated on real cloud ranges: S3=%v spread=%v scattered=%v split=%v",
 		withPrefixes(s3CIDRs, "52.216.1."), withPrefixes(spreadCIDRs, "52.216."), got, withPrefixes(splitCIDRs, "52.216.2."))
+}
+
+// Test_35_ExecTTYFieldTest validates, against real eBPF on a real cluster, that
+// a CEL rule can actually use the exec TTY fields (event.hasTty, event.tty,
+// event.ttyMajor/ttyMinor). Everything before this test was exercised only
+// against synthetic datasources, so this is the first end-to-end proof.
+//
+// Why four rules instead of one: an unresolvable CEL field does not raise an
+// error, it fails to compile and silently disables the whole expression
+// (pkg/rulemanager/cel returns (false, nil) on compile failure). "No alert" is
+// therefore ambiguous between "the field was false" and "the rule never ran".
+// R9902 is a control on the same trigger with no TTY predicate, and R9903/R9904
+// are a mutually exclusive pair on has(event.ttyMajor). See
+// resources/exec-tty-rules.yaml.
+//
+// Why three containers: containers in a pod have separate mount namespaces and
+// therefore separate /dev/pts instances, so each trigger gets a pristine pts
+// index. That matters because pts indices are not reclaimed instantly -- with a
+// shared devpts a "single" exec can land on index >= 1 and make the phase-1
+// expectation below flap.
+func Test_35_ExecTTYFieldTest(t *testing.T) {
+	start := time.Now()
+	defer tearDownTest(t, start)
+
+	rulesPath := path.Join(utils.CurrentDir(), "resources/exec-tty-rules.yaml")
+	bindingPath := path.Join(utils.CurrentDir(), "resources/exec-tty-rulebinding.yaml")
+	require.Equal(t, 0, testutils.RunCommand("kubectl", "apply", "--validate=false", "-f", rulesPath), "apply TTY test rules")
+	defer testutils.RunCommand("kubectl", "delete", "--ignore-not-found", "-f", rulesPath)
+	require.Equal(t, 0, testutils.RunCommand("kubectl", "apply", "--validate=false", "-f", bindingPath), "apply TTY test rule binding")
+	defer testutils.RunCommand("kubectl", "delete", "--ignore-not-found", "-f", bindingPath)
+	// let the rules watcher and rule-binding watcher pick the new rules up
+	time.Sleep(20 * time.Second)
+
+	ns := testutils.NewRandomNamespace()
+	wl, err := testutils.NewTestWorkload(ns.Name, path.Join(utils.CurrentDir(), "resources/exec-tty-deployment.yaml"))
+	require.NoError(t, err, "Error creating workload")
+	require.NoError(t, wl.WaitForReady(80))
+	time.Sleep(15 * time.Second)
+
+	probe := []string{"/bin/uname"}
+
+	// Trigger A -- genuinely no controlling terminal.
+	_, _, err = wl.ExecIntoPodNoTTY(probe, "c-none")
+	require.NoError(t, err, "no-tty probe")
+
+	// Trigger B -- one TTY exec into a pristine devpts, so /dev/pts/0.
+	_, _, err = wl.ExecIntoPod(probe, "c-pts0")
+	require.NoError(t, err, "single-tty probe")
+
+	// Trigger C -- hold a pty open, then probe while it is held so the probe
+	// gets a nonzero pts index.
+	go func() {
+		// Writes its own tty path so the test can wait for real readiness, then
+		// keeps the pty allocated.
+		_, _, _ = wl.ExecIntoPod([]string{"sh", "-c", "tty > /tmp/holder-tty; sleep 120"}, "c-conc")
+	}()
+	defer func() {
+		_, _, _ = wl.ExecIntoPodNoTTY([]string{"pkill", "-f", "sleep 120"}, "c-conc")
+	}()
+
+	// Waiting for the holder to *report* its pty is the point: merely launching
+	// it and sleeping is racy. Observed on kind -- a probe fired before the
+	// holder's pty existed landed on pts/0 and read as "no terminal", which
+	// looks exactly like the feature being broken.
+	var holderTTY string
+	require.Eventually(t, func() bool {
+		out, _, err := wl.ExecIntoPodNoTTY([]string{"cat", "/tmp/holder-tty"}, "c-conc")
+		if err != nil {
+			return false
+		}
+		holderTTY = strings.TrimSpace(strings.ReplaceAll(out, "\r", ""))
+		return strings.HasPrefix(holderTTY, "/dev/pts/")
+	}, 90*time.Second, 3*time.Second, "holder must allocate its pty before the concurrent probe runs")
+	t.Logf("holder holds %s", holderTTY)
+
+	// Confirm the environment really does hand out a nonzero index here. If this
+	// fails the assertions below would be testing nothing.
+	out, _, err := wl.ExecIntoPod([]string{"tty"}, "c-conc")
+	require.NoError(t, err, "tty check in c-conc")
+	probeTTY := strings.TrimSpace(strings.ReplaceAll(out, "\r", ""))
+	t.Logf("concurrent probe sees %s", probeTTY)
+	require.True(t, strings.HasPrefix(probeTTY, "/dev/pts/"), "concurrent exec must get a terminal, got %q", probeTTY)
+	require.NotEqual(t, "/dev/pts/0", probeTTY,
+		"concurrent exec landed on pts/0; phase 1 cannot distinguish that from no terminal, so trigger C would prove nothing")
+
+	_, _, err = wl.ExecIntoPod(probe, "c-conc")
+	require.NoError(t, err, "concurrent-tty probe")
+
+	count := func(alerts []testutils.Alert, ruleID, container string) int {
+		n := 0
+		for _, a := range alerts {
+			if a.Labels["rule_id"] == ruleID && a.Labels["container_name"] == container {
+				n++
+			}
+		}
+		return n
+	}
+	total := func(alerts []testutils.Alert, ruleID string) int {
+		n := 0
+		for _, a := range alerts {
+			if a.Labels["rule_id"] == ruleID {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Wait on the *control* rule reaching all three containers. R9901 and R9902
+	// evaluate the same exec event, so once R9902 has arrived for a container the
+	// verdict on R9901 for that same event is already decided -- which is what
+	// makes the negative assertions below sound rather than merely un-elapsed.
+	var alerts []testutils.Alert
+	require.Eventually(t, func() bool {
+		alerts, err = testutils.GetAlerts(ns.Name)
+		if err != nil {
+			return false
+		}
+		return count(alerts, "R9902", "c-none") > 0 &&
+			count(alerts, "R9902", "c-pts0") > 0 &&
+			count(alerts, "R9902", "c-conc") > 0
+	}, 180*time.Second, 5*time.Second,
+		"control rule R9902 must fire for all three probe execs -- if it does not, the trigger or the rule pipeline is broken, not the TTY field")
+
+	t.Logf("alert counts: R9901 none=%d pts0=%d conc=%d | R9902 total=%d | R9903=%d R9904=%d",
+		count(alerts, "R9901", "c-none"), count(alerts, "R9901", "c-pts0"), count(alerts, "R9901", "c-conc"),
+		total(alerts, "R9902"), total(alerts, "R9903"), total(alerts, "R9904"))
+
+	// The feature: hasTty discriminates.
+	assert.Greater(t, count(alerts, "R9901", "c-conc"), 0,
+		"R9901 must fire for the exec that held a nonzero pts index -- this is the actual TTY-field proof")
+	assert.Equal(t, 0, count(alerts, "R9901", "c-none"),
+		"R9901 must not fire for an exec with no controlling terminal")
+	// Deliberate: phase 1 reads the ambiguous per-driver index, where 0 means
+	// both /dev/pts/0 and "no terminal". A single exec into a fresh container is
+	// pts/0 and so is invisible to hasTty. This is a known, documented
+	// limitation, not a bug -- do not "fix" this expectation. It flips when
+	// phase 2 lands (gadget emits tty_major/tty_minor).
+	assert.Equal(t, 0, count(alerts, "R9901", "c-pts0"),
+		"phase 1: an exec on pts/0 is indistinguishable from no terminal, so R9901 must stay silent here")
+
+	// has() presence testing is honest, and ttyMajor is registered rather than
+	// silently unresolvable. Exactly one of these two must fire.
+	assert.Equal(t, 0, total(alerts, "R9903"),
+		"R9903 must not fire: the pinned gadget does not emit tty_major, so has(event.ttyMajor) is false")
+	assert.Greater(t, total(alerts, "R9904"), 0,
+		"R9904 must fire: !has(event.ttyMajor) proves ttyMajor is a registered field that is honestly absent, not a compile failure")
 }

--- a/tests/resources/exec-tty-deployment.yaml
+++ b/tests/resources/exec-tty-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: exec-tty-app
+  name: exec-tty-deployment
+spec:
+  selector:
+    matchLabels:
+      app: exec-tty-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: exec-tty-app
+    spec:
+      containers:
+      # One container per TTY trigger. Containers in a pod get separate mount
+      # namespaces and therefore separate /dev/pts instances, so each starts
+      # from a pristine pts index with no cross-contamination. Verified on kind:
+      # with a session held in one container, an exec into a sibling container
+      # still lands on /dev/pts/0.
+      - name: c-none
+        image: alpine:3.20
+        command: ["sleep", "infinity"]
+      - name: c-pts0
+        image: alpine:3.20
+        command: ["sleep", "infinity"]
+      - name: c-conc
+        image: alpine:3.20
+        command: ["sleep", "infinity"]

--- a/tests/resources/exec-tty-rulebinding.yaml
+++ b/tests/resources/exec-tty-rulebinding.yaml
@@ -1,0 +1,22 @@
+# Binds the test-only TTY rules. The shipped default binding
+# (chart/templates/node-agent/default-rule-binding.yaml) lists rules by explicit
+# ruleName, so newly added rule IDs are inert until something binds them.
+apiVersion: kubescape.io/v1
+kind: RuntimeRuleAlertBinding
+metadata:
+  name: exec-tty-test-binding
+spec:
+  namespaceSelector:
+    matchExpressions:
+      - key: "kubernetes.io/metadata.name"
+        operator: "NotIn"
+        values:
+          - "kube-system"
+          - "kube-public"
+          - "kube-node-lease"
+  podSelector:
+  rules:
+    - ruleName: "TEST TTY exec detected"
+    - ruleName: "TEST exec control"
+    - ruleName: "TEST ttyMajor present"
+    - ruleName: "TEST ttyMajor absent"

--- a/tests/resources/exec-tty-rules.yaml
+++ b/tests/resources/exec-tty-rules.yaml
@@ -1,0 +1,107 @@
+# Test-only rules validating that the exec TTY CEL fields are usable from a real
+# rule against real eBPF. Applied by Test_35_ExecTTYFieldTest and deleted on
+# cleanup. IDs are in a deliberately test-only 99xx range so they cannot collide
+# with the shipped R1xxx/R2xxx ranges.
+#
+# The four rules exist as two pairs, because "no alert" is ambiguous on its own:
+# an unresolvable CEL field does not error, it fails to compile and silently
+# disables the whole expression, which looks exactly like "the field was false".
+#
+#   R9901 / R9902  isolate hasTty from the plumbing. R9902 fires on every probe
+#                  exec, so if R9902 is silent the trigger or the rule pipeline
+#                  is broken, not the TTY field.
+#   R9903 / R9904  pin down has() presence testing. Exactly one must fire.
+#                  Both silent would mean ttyMajor is unregistered (compile
+#                  failure); both firing is impossible. Today ttyMajor is not
+#                  emitted by the pinned gadget, so R9904 fires and R9903 does
+#                  not. When phase 2 lands (gadget emits tty_major/tty_minor)
+#                  these two swap, making this file the phase-2 acceptance test.
+#
+# All rules use profileDependency 2 (NotRequired) so the test never waits for
+# application-profile completion, and uniqueId includes the pid so per-rule
+# cooldown/dedup cannot swallow a later probe.
+apiVersion: kubescape.io/v1
+kind: Rules
+metadata:
+  name: exec-tty-test-rules
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  rules:
+    - name: "TEST TTY exec detected"
+      enabled: true
+      id: "R9901"
+      description: "Test rule: exec carrying a controlling terminal, via event.hasTty"
+      expressions:
+        message: "'TTY exec: ' + event.comm + ' tty=' + string(event.tty)"
+        uniqueId: "'R9901_' + event.comm + '_' + string(event.pid)"
+        ruleExpression:
+          - eventType: "exec"
+            expression: "event.comm == 'uname' && event.hasTty"
+      profileDependency: 2
+      severity: 1
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0002"
+      mitreTechnique: "T1059"
+      tags:
+        - "test"
+        - "exec"
+    - name: "TEST exec control"
+      enabled: true
+      id: "R9902"
+      description: "Test control rule: same trigger, no TTY predicate. Must fire for every probe exec."
+      expressions:
+        message: "'control exec: ' + event.comm + ' tty=' + string(event.tty)"
+        uniqueId: "'R9902_' + event.comm + '_' + string(event.pid)"
+        ruleExpression:
+          - eventType: "exec"
+            expression: "event.comm == 'uname'"
+      profileDependency: 2
+      severity: 1
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0002"
+      mitreTechnique: "T1059"
+      tags:
+        - "test"
+        - "exec"
+    - name: "TEST ttyMajor present"
+      enabled: true
+      id: "R9903"
+      description: "Test rule: fires only where the gadget emits the tty device number. Must NOT fire before phase 2."
+      expressions:
+        message: "'ttyMajor present: ' + string(event.ttyMajor)"
+        uniqueId: "'R9903_' + event.comm + '_' + string(event.pid)"
+        ruleExpression:
+          - eventType: "exec"
+            expression: "event.comm == 'uname' && has(event.ttyMajor)"
+      profileDependency: 2
+      severity: 1
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0002"
+      mitreTechnique: "T1059"
+      tags:
+        - "test"
+        - "exec"
+    - name: "TEST ttyMajor absent"
+      enabled: true
+      id: "R9904"
+      description: "Test rule: fires while the gadget does not emit the tty device number. Proves ttyMajor is registered but honestly absent."
+      expressions:
+        message: "'ttyMajor absent for ' + event.comm"
+        uniqueId: "'R9904_' + event.comm + '_' + string(event.pid)"
+        ruleExpression:
+          - eventType: "exec"
+            expression: "event.comm == 'uname' && !has(event.ttyMajor)"
+      profileDependency: 2
+      severity: 1
+      supportPolicy: false
+      isTriggerAlert: true
+      mitreTactic: "TA0002"
+      mitreTechnique: "T1059"
+      tags:
+        - "test"
+        - "exec"

--- a/tests/testutils/k8s.go
+++ b/tests/testutils/k8s.go
@@ -93,6 +93,17 @@ func (w *TestWorkload) ExecIntoPod(command []string, container string) (string, 
 
 	return ExecIntoPod(pod.Name, w.Namespace, command, container)
 }
+
+// ExecIntoPodNoTTY execs without a controlling terminal. See ExecIntoPodNoTTY.
+func (w *TestWorkload) ExecIntoPodNoTTY(command []string, container string) (string, string, error) {
+	pods, err := w.GetPods()
+	if err != nil {
+		return "", "", err
+	}
+	pod := pods[0]
+
+	return ExecIntoPodNoTTY(pod.Name, w.Namespace, command, container)
+}
 func NewTestWorkloadFromK8sIdentifiers(namespace, kind, name string) (*TestWorkload, error) {
 	k8sClient := k8sinterface.NewKubernetesApi()
 	gvr, err := k8sinterface.GetGroupVersionResource(kind)
@@ -120,7 +131,25 @@ func NewTestWorkloadFromK8sIdentifiers(namespace, kind, name string) (*TestWorkl
 	}, nil
 }
 
+// ExecIntoPodNoTTY is ExecIntoPod without a controlling terminal.
+//
+// Every other exec helper here sets TTY: true, and the API server allocates a
+// pty on that flag alone regardless of Stdin — so all ordinary component-test
+// execs run *with* a terminal. Note that `kubectl exec -t` is not a way to
+// check this: kubectl silently drops the TTY flag when -i is absent, so it
+// never sends TTY=true/Stdin=false at all and reports "not a tty" misleadingly.
+// Verified against a live API server: TTY=true/Stdin=false -> /dev/pts/0.
+//
+// Use this when a test needs a process with genuinely no controlling terminal.
+func ExecIntoPodNoTTY(podName, podNamespace string, command []string, container string) (string, string, error) {
+	return execIntoPod(podName, podNamespace, command, container, false)
+}
+
 func ExecIntoPod(podName, podNamespace string, command []string, container string) (string, string, error) {
+	return execIntoPod(podName, podNamespace, command, container, true)
+}
+
+func execIntoPod(podName, podNamespace string, command []string, container string, tty bool) (string, string, error) {
 	k8sClient := k8sinterface.NewKubernetesApi()
 
 	buf := &bytes.Buffer{}
@@ -131,7 +160,7 @@ func ExecIntoPod(podName, podNamespace string, command []string, container strin
 		Stdin:   false,
 		Stdout:  true,
 		Stderr:  true,
-		TTY:     true,
+		TTY:     tty,
 	}
 
 	if container != "" {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Exposes the exec event's controlling terminal to CEL rules as four new `event` fields, so rules can express "this ran from an interactive shell". The signal is deliberately phased: the currently pinned gadget emits an ambiguous terminal index, so positive predicates are safe today while negative ones need a version gate, and all four fields are registered now so rules written today survive the phase-2 gadget bump unchanged.

## What

Exposes the exec event's controlling terminal to CEL rules, so rules can express "this ran from an interactive shell". Four fields on the `event` variable:

| Field | Type | Notes |
|---|---|---|
| `event.hasTty` | bool | What rules should normally use |
| `event.ttyMajor` / `event.ttyMinor` | uint | Terminal device number. Not emitted by the currently pinned gadget, so `has()` is false today |
| `event.tty` | int | Raw driver-local index. Does not identify a terminal on its own |

Adds `docs/features/exec-tty-field.md` for rule authors, and `Test_35_ExecTTYFieldTest`, which validates the fields end-to-end against real eBPF.

## Why the two-phase shape

The gadget currently emits only `tty`, the per-driver index. That value is ambiguous: measured against `trace_exec:v0.48.1`, a process with **no** terminal and a process on `/dev/pts/0` **both report `tty = 0`**.

```
comm     tty
echo       0     <- no terminal at all
date       0     <- has a terminal (/dev/pts/0)
```

So today's signal can only under-report, never over-report. That shapes the rule-authoring contract:

- **Positive predicates (`event.hasTty`) are safe.** They miss `pts/0` execs but never misfire.
- **Negative predicates (`!event.hasTty`) are wrong today** and must carry an `agentVersionRequirement` gate, because they would fire on genuinely interactive shells sitting on `pts/0`.

`inspektor-gadget#5714` adds `tty_major`/`tty_minor`, which disambiguates. All four fields are registered now rather than later, because a rule referencing an unknown CEL field does not error: it fails to compile and **silently disables the whole expression**. Registering them up front means rules written today keep working, and `GetHasTTY` already prefers the device number when present, so phase 2 is a gadget-pin bump with no code change.

`has()` is backed by a real presence test rather than a zero-check, so `has(event.ttyMajor)` is honestly false on agents whose gadget does not emit it.

## Validation

Beyond unit tests, `Test_35_ExecTTYFieldTest` runs four test-only rules through the real rule pipeline on a cluster. Measured on kind:

```
holder holds /dev/pts/0
concurrent probe sees /dev/pts/1
alert counts: R9901 none=0 pts0=0 conc=1 | R9902 total=3 | R9903=0 R9904=3
```

Four rules rather than one, because **"no alert" is ambiguous on its own** — silent-disable and "the predicate was false" are indistinguishable. So:

- `R9902` is a control on the same trigger without the TTY predicate. It separates "TTY field broken" from "pipeline broken".
- `R9903`/`R9904` are a mutually exclusive pair on `has(event.ttyMajor)`. Exactly one must fire; both silent would mean the field is unregistered rather than absent. This pair doubles as the phase-2 acceptance test, since the two swap when the gadget starts emitting the device number.

**Mutation-checked:** pointing `R9901` at a nonexistent field drops it to 0 while `R9902` holds at 3, confirming the test detects the exact failure mode it was built for.

`Test_01_BasicAlertTest` was run as a regression check on the `ExecIntoPod` refactor.

## Notes for reviewers

Two details worth knowing, both verified rather than assumed:

- **`c-pts0` asserting zero alerts is deliberate**, not a bug. A single exec into a fresh container lands on `pts/0`, which phase 1 cannot distinguish from "no terminal". Please don't "fix" that expectation — it flips when phase 2 lands.
- **The test uses three containers in one pod**, because containers have separate mount namespaces and therefore separate `/dev/pts` instances. pts indices are not reclaimed instantly, so with a shared devpts a "single" exec could land on index >= 1 and make the phase-1 expectation flap.

`ExecIntoPodNoTTY` is added because the existing helpers all set `TTY: true`, and the API server allocates a pty on that flag alone regardless of `Stdin` — so ordinary component-test execs already carry a terminal. Note that `kubectl exec -t` cannot be used to verify this: kubectl silently drops the TTY flag when `-i` is absent and misleadingly reports "not a tty".

`ttyMajor`/`ttyMinor` are unsigned and this CEL environment has no cross-type numeric comparison, so `event.ttyMajor == 136` fails to compile (and thus silently disables the rule). Use `uint(136)`. This is called out in the docs.

AI-skills: notify-me,superpowers:brainstorming,superpowers:writing-plans,superpowers:subagent-driven-development,superpowers:using-git-worktrees | cmds: /compact,/rate-limit-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CEL support for exec controlling-terminal detection, including `hasTty`, `tty`, `ttyMajor`, and `ttyMinor`.
  * Added proper presence semantics so rules can reliably distinguish “field not emitted” from “zero value” (using `has(...)` where applicable).

* **Bug Fixes**
  * Improved TTY field handling to avoid ambiguous interpretations across agent/gadget compatibility phases.

* **Documentation**
  * Documented TTY field meanings, compatibility behavior, and CEL authoring guidance with examples.

* **Tests**
  * Added unit, parsing/validation, and end-to-end coverage, including exec scenarios with and without TTY.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->