### PR TITLE
docs(utils): document why fieldCaches is keyed by EventType (release trigger)

### DIFF
--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -29,6 +29,16 @@ const (
 )
 
 var (
+	// fieldCaches maps an EventType to a *sync.Map of fieldName ->
+	// datasource.FieldAccessor, and backs getFieldAccessor.
+	//
+	// Note the key: accessors are cached per *event type*, so two datasources
+	// sharing an event type share one cache and can be handed each other's
+	// accessors. A FieldAccessor decodes at a fixed offset in the layout of the
+	// datasource that produced it, so that is safe only while one tracer is
+	// registered per event type -- which is what RegisterTracer's map assignment
+	// enforces today. Reads that must not depend on that invariant should use
+	// localFieldAccessor; see accessorCaches below.
 	fieldCaches = sync.Map{}
 
 	// accessorCaches maps a datasource.DataSource to a *sync.Map of


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Cuts a release so that #868 (exec controlling-terminal CEL fields) becomes consumable from a tagged version. #868 was merged without the `release` label, so `create-release-and-retag` was skipped and the newest tag, `v0.3.158`, predates the merge — no released version contains the TTY fields. This PR carries the `release` label to produce one.

The code change is incidental and comment-only. A pure `.md` change could not serve as the trigger, because `pr-merged.yaml` lists `**.md` and `.github/workflows/*` under `paths-ignore`, so the release workflow would not run at all.

## Why this comment

`fieldCaches` had no comment at all, while the `accessorCaches` added next to it in #868 carries a long one explaining why it is keyed by datasource instead. That left the more surprising of the two undocumented.

The comment records the invariant the `EventType` key depends on: a `FieldAccessor` decodes at a fixed offset in the layout of the datasource that produced it, so sharing one cache across an event type is safe only while a single tracer is registered per event type — which is what `RegisterTracer`'s map assignment enforces today. It points readers at `localFieldAccessor` for reads that must not rely on that.

## Ticket

None — release plumbing.

## Test plan

Comment-only, no behavioural change. `go build ./pkg/utils/` and `gofmt` clean. CI covers the rest.

## Follow-up

Once this releases, `private-node-agent` gets bumped from `node-agent v0.3.146` to the new tag.

AI-skills: notify-me,superpowers:brainstorming,superpowers:writing-plans,superpowers:subagent-driven-development,superpowers:using-git-worktrees | cmds: /compact,/rate-limit-options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded technical documentation for event field caching behavior and its expected usage.
  * Clarified how cached field accessors relate to tracer registration.
  * Added guidance for accessing fields when cache assumptions do not apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->