### PR TITLE
addon fix for the old issue to /proc full paths not being recorded

### DIFF
--- a/pkg/utils/normalize_path_test.go
+++ b/pkg/utils/normalize_path_test.go
@@ -51,6 +51,30 @@ func TestNormalizePath(t *testing.T) {
 			expected: "/proc/46/task",
 		},
 		{
+			// #721 regression: runc:[2:INIT] user-namespace-setup paths outside
+			// the old (task|fd) allowlist previously leaked /proc-less.
+			name:     "headless proc path (setgroups)",
+			input:    "/17/setgroups",
+			expected: "/proc/17/setgroups",
+		},
+		{
+			name:     "headless proc path (gid_map)",
+			input:    "/1/gid_map",
+			expected: "/proc/1/gid_map",
+		},
+		{
+			name:     "headless proc path (uid_map)",
+			input:    "/1/uid_map",
+			expected: "/proc/1/uid_map",
+		},
+		{
+			// A non-proc path whose leading segment is non-numeric must be
+			// untouched even though a later segment looks proc-like.
+			name:     "non-proc path with data dir",
+			input:    "/data/appendonlydir/x",
+			expected: "/data/appendonlydir/x",
+		},
+		{
 			name:     "relative path (not dot)",
 			input:    "usr/bin/ls",
 			expected: "/usr/bin/ls",

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -6,16 +6,17 @@ import (
 	"strings"
 )
 
-// headlessProcRegex matches any path whose leading segment is a bare PID — the
-// residue of a /proc/<pid>/... path stripped of its /proc root. A top-level
-// numeric segment is never a real filesystem path node-agent should record, so
-// the entire class is normalized back under /proc.
+// headlessProcRegex matches a headless /proc/<pid>/<file> path — a /proc/<pid>/...
+// path stripped of its /proc root — which NormalizePath re-roots under /proc.
 //
-// The allowlist was previously narrowed to `(task|fd)`, which let sibling
-// headless paths written by runc:[2:INIT] during user-namespace setup —
-// /<pid>/setgroups, /<pid>/gid_map, /<pid>/uid_map, /<pid>/status, /<pid>/cgroup,
-// ... — leak /proc-less into learned ContainerProfiles (a regression of #721).
-var headlessProcRegex = regexp.MustCompile(`^/\d+(/|$)`)
+// The allowlist enumerates the /proc/<pid> entries opened by runc:[2:INIT]
+// during container/user-namespace setup. It was previously only (task|fd),
+// which let the sibling entries (setgroups, gid_map, uid_map, status, cgroup,
+// ...) leak /proc-less into learned ContainerProfiles — a regression of #721.
+// It stays an explicit allowlist rather than a bare `^/\d+` catch-all so a
+// genuine top-level numeric directory is never misread as a PID; extend it if
+// another /proc/<pid> entry is observed leaking.
+var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd|setgroups|gid_map|uid_map|status|stat|cgroup|mountinfo|maps|environ|comm|cmdline|ns)(/|$)`)
 
 // NormalizePath normalizes a path by:
 // 1. Prepending "/proc" to "headless" proc paths (e.g. /46/task/46/fd -> /proc/46/task/46/fd)

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -6,7 +6,16 @@ import (
 	"strings"
 )
 
-var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd)(/|$)`)
+// headlessProcRegex matches any path whose leading segment is a bare PID — the
+// residue of a /proc/<pid>/... path stripped of its /proc root. A top-level
+// numeric segment is never a real filesystem path node-agent should record, so
+// the entire class is normalized back under /proc.
+//
+// The allowlist was previously narrowed to `(task|fd)`, which let sibling
+// headless paths written by runc:[2:INIT] during user-namespace setup —
+// /<pid>/setgroups, /<pid>/gid_map, /<pid>/uid_map, /<pid>/status, /<pid>/cgroup,
+// ... — leak /proc-less into learned ContainerProfiles (a regression of #721).
+var headlessProcRegex = regexp.MustCompile(`^/\d+(/|$)`)
 
 // NormalizePath normalizes a path by:
 // 1. Prepending "/proc" to "headless" proc paths (e.g. /46/task/46/fd -> /proc/46/task/46/fd)


### PR DESCRIPTION

We re seeing again :

 - "/17/setgroups" → "/proc/17/setgroups"
  - "/1/gid_map" → "/proc/1/gid_map", "/1/uid_map" → "/proc/1/uid_map"
  
  This is a band-aid type patch for the resurface of  https://github.com/kubescape/node-agent/issues/721 

In my tests on dragonfly and argocd, it worked, but that list is not exhaustive, so will look if we have a real regression as soon as I have some time
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of additional process metadata and mapping paths under `/proc`, including namespace, user/group mapping, status, and cgroup paths.
  * Preserved correct behavior for non-process paths that contain numeric path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->