### PR TITLE
fix(processtree): correct the exit-cleanup lifecycle under shutdown and pid reuse (SUB-7847, SUB-7846)

### DIFF
--- a/docs/features/process-id-reuse-hardening.md
+++ b/docs/features/process-id-reuse-hardening.md
@@ -1,0 +1,283 @@
+# Process-id reuse hardening
+
+The kernel recycles process ids. The process tree keeps an exited process's node
+for up to `exitCleanup::cleanupDelay` after it dies, so for that window a pid can
+be held by a **live** process while the tree still holds the **dead** one's node
+under the same pid. Nothing in the tree used to notice.
+
+Two things went wrong as a result, and both were confirmed by reproduction rather
+than inferred:
+
+1. **The new process reported the dead one's identity.** `handleForkEvent` fills
+   only *empty* fields, and a stale node is not empty, so a recycled pid kept the
+   predecessor's `Comm`, `Cmdline`, `Path`, `Cwd`, `Uid` and `Gid`. **A runtime
+   alert of any type could name the wrong command.**
+2. **The dead process's delayed exit deleted the live process's node.**
+   `exitByPid` matches on pid alone, so when cleanup finally fired it removed
+   whatever node held that pid by then — reparenting a running process's children
+   around it and taking its start time with it.
+
+Neither self-corrects for the cases that matter: an alert emitted inside the
+window has already been exported with the wrong command, and the node deletion
+leaves children reparented around a process that is alive. What *does* self-correct
+is the *field* staleness on a pid that goes on to exec or be rescanned, which is
+why the likelihood of the first is rated medium rather than high.
+
+See [process-start-time.md](./process-start-time.md) for the identity value this
+work builds on, and
+[process-tree-exit-manager-lifecycle.md](./process-tree-exit-manager-lifecycle.md)
+for the deferred-deletion model that opens the window.
+
+## Three layers
+
+Each is independent, and each falls through to today's behaviour when its input is
+unknown. None of them may ever *keep* a node it cannot prove is newer: retaining
+stale state is the harmful direction, re-deleting a node is not.
+
+| Layer | Signal | Needs a clock? |
+|---|---|---|
+| A fork or exec retires a pending-exit predecessor | The event itself | No |
+| A delayed exit skips a node newer than the exit's arrival | `CLOCK_BOOTTIME` comparison | Yes |
+| The procfs scan rebuilds a node whose start time changed | Start-time inequality | No |
+
+### 1. A fork or exec retires the predecessor
+
+A fork or exec for a pid **proves a new live incarnation holds it** — a zombie can
+do neither. So a pending exit on that pid must belong to a dead predecessor, and
+`retireRecycledPredecessor` tears that predecessor down before the handler touches
+the node. No clock is involved, which is why this layer is independent of the
+start-time work entirely.
+
+The guard runs **before** the node lookup, not only where a stale node was found.
+A pending exit can outlive its node — the exit may arrive for a pid the tree never
+created a node for, or another path may already have removed it — and the recycled
+fork then builds a fresh node that the stale entry would delete at the next
+cleanup. `TestPidReuse_ForkAfterExit_ConsumesPendingExitWithNoNode` fails if the
+guard is gated on an existing node.
+
+> **The proof is a kernel-ordering argument, and the pipeline does not preserve
+> kernel order.** Fork, exec and exit come from three separate tracers, each with
+> its own goroutine, feeding one queue that is drained in batches and sorted only
+> within a batch. An exit enqueued after its batch drained is processed after a
+> fork that really preceded it, and this layer reads that as a recycle: it retires
+> a node that was about to be legitimately deleted, and consumes a real pending
+> exit.
+>
+> The result is a dead node left in the tree, not a live one deleted, and it
+> self-heals — `sendExitEvents` re-synthesises an exit for any tree pid absent from
+> `/proc` every `ProcfsPidScanInterval` (5 s), so the window is bounded wherever
+> that reaper runs. Tightening it needs no new clock: the fork/exec event timestamp
+> and `pendingExit.StartTimeNs` are both wall-clock event stamps, so declining to
+> retire when the fork/exec is the *earlier* of the two is a same-domain
+> comparison. Not done here, deliberately — it trades a bounded, self-healing
+> staleness for a new ordering dependency.
+
+#### Retiring means the full teardown, not dropping the pending entry
+
+This is the part that looks safe to simplify and is not.
+
+```go
+// WRONG — passes the obvious tests, corrupts the tree more quietly
+delete(pt.pendingExits, pid)
+```
+
+That does stop the delayed deletion, and it does let the new process's fields be
+written. But the dead process's **children are still linked to the pid**, so the
+new process silently inherits them. The tree then claims an unrelated live process
+is the parent of another process's children, and every alert built from that
+branch carries the lie. It is harder to notice than the bug it replaces.
+
+`retireRecycledPredecessor` therefore performs the full teardown, which reparents
+the children away first. `TestPidReuse_ForkAfterExit_DoesNotInheritDeadChildren`
+fails if this is ever simplified back — it asserts both that the recycled pid has
+no children and that the orphan survives, reparented, rather than being deleted
+with its parent.
+
+### 2. A delayed exit never deletes a provably-newer node
+
+For a recycle discovered *without* a fork or exec — the scan found the new process
+first — the guard is purely temporal: a node whose recorded creation time is
+**later than the moment the exit event arrived** cannot be the process that exit
+was for.
+
+Both sides are boot-relative nanoseconds. The side map holds `/proc` starttime
+ticks × 10⁷; the arrival is stamped with `CLOCK_BOOTTIME` when the pending exit is
+recorded. **No wall clock is involved on either side, and none may be introduced**
+— `pendingExit.Timestamp` and `pendingExit.StartTimeNs` are wall-clock values with
+unrelated jobs (cleanup ageing and sort ordering respectively), and comparing
+either against the side map would be meaningless rather than merely imprecise.
+`pendingExit.StartTimeNs` in particular is **not a process start time** at all; it
+is the exit event's timestamp.
+
+Two populations are deliberately **not** covered:
+
+- **Nodes with no recorded start time.** There is nothing to compare, so the guard
+  falls through to today's deletion rather than guessing. Layer 1 covers these
+  whenever the recycle is seen via fork or exec, needing no clock.
+- **Reordered events.** If the exit arrives *after* the recycled process was
+  already scanned, the arrival is the later value and the guard deletes — today's
+  behaviour — and the next procfs scan recreates the node. That recovery runs
+  through the **node-absent** path, not layer 3: the teardown deletes the side-map
+  entry along with the node, so the prior start time layer 3 compares against is
+  gone and its check declines.
+
+> **A newer recorded start time does not prove the node's *contents* were
+> rebuilt.** Layer 3 only fires when the side map already held a non-zero value, so
+> when the predecessor had none — a fork-created node whose on-demand read failed,
+> or a node auto-created as a parent — the scan **merges** the successor's fields
+> into the dead node, keeping its `ChildrenMap`, and writes the successor's start
+> time. Layer 2 then sees a value newer than the arrival and keeps that merged
+> node, so the successor inherits the predecessor's children: the same shape as the
+> trap below, reached by a different route.
+>
+> It self-corrects within one full scan interval (30 s) when each child's own procfs
+> event fixes its PPID — except where `UpdatePPID`'s Kubernetes container-subtree
+> branch declines the update. Closing it properly means letting layer 3 fire on a
+> zero prior value, which cannot distinguish "recycled" from "first ever reading"
+> and would tear down healthy nodes on first sight. Left open knowingly.
+
+`TestPidReuse_DelayedExit_NormalExitStillDeletes` pins the mirror case: an
+ordinary, non-recycled exit must still remove its own node. Without it, writing
+the comparison the wrong way round would leak every exited process's node forever
+and no other test would notice.
+
+### 3. The procfs scan rebuilds a recycled node
+
+Two procfs readings of the same process yield the *identical* starttime ticks, so a
+different non-zero value is proof of recycling — exact inequality, no tolerance,
+and none should be added.
+
+On detection the stale node is torn down and rebuilt from the event. Merging is
+never correct here: the handler's overwrite-only-if-non-empty logic preserves any
+field the new process does not report, so the dead process's `Cwd` would survive
+into a node otherwise describing the new one.
+
+The rebuild re-applies the Kubernetes host-process policy that the first-sighting
+path enforces. Without that, a host procfs event could materialise a node the same
+event would be refused on first sight.
+
+**The teardown reparents every child, and not all of them necessarily belonged to
+the dead process.** This layer can fire up to a scan interval after the recycle, by
+which time the successor may already have forked, so a live child can be detached
+and reparented to init. Versus today that is a trade rather than a pure win —
+today's behaviour retains dead children instead — and it self-corrects on the
+child's next scan. Layer 1 does not have this problem, because it fires on the
+first fork or exec, before the successor has children.
+
+`TestPidReuse_ProcfsSameStartTime_MergesAsToday` is the control — an equal start
+time means the same process, so the refresh must keep today's merge semantics and
+keep the node's children.
+
+#### Why a pending exit is not the signal on this path
+
+`handleProcfsEvent` must **never** treat a pending exit as recycle proof. `/proc`
+lists zombies, so a procfs event can legitimately belong to the same incarnation
+that already exited — the pending exit would be correct, not stale, and tearing
+the node down would be wrong.
+
+The same asymmetry applies to "the node already exists", which is a much weaker
+signal than it looks: another path may simply have created the node first. Every
+guard here is gated on a **pending exit** or on a **changed start time**, never on
+mere existence — an earlier version of the start-time guard wiped a correct value
+on that weaker basis.
+
+## The gap no layer covers: a fork processed before the exit it follows
+
+The two reorder cases described above are per-layer. There is a third, symmetric to
+the first, that **all three layers decline** — so both original bugs survive it.
+
+Kernel order is `P1 exits` → pid recycled → `P2 forks`, but the **fork event is
+processed before the exit event**:
+
+| Layer | Why it declines |
+|---|---|
+| 1 | There is no pending exit yet when the fork is handled, so there is nothing to retire. |
+| start-time fallback | The `else if … exited` branch in `handleForkEvent` is gated on the same pending exit. |
+| 2 | The fork's on-demand read has already recorded P2's real creation time, which **precedes** the late exit's arrival, so `startNs > ArrivalBootNs` is false. |
+| 3 | The side map now holds P2's start, so the next procfs reading matches it and no rebuild triggers. |
+
+Confirmed against the implementation: after the fork the node still reports P1's
+`Comm` and `Cmdline`, and the late exit then deletes P2's live node.
+
+Severity is low and this is deliberately **not** fixed. The reorder window is about
+one drain batch of the event queue, and a pid recycling inside it is essentially
+impossible — the 32,768-entry pid space would have to wrap in milliseconds. Closing
+it would mean making the guards depend on event ordering they cannot verify, which
+trades a near-impossible case for a new class of ordering bug.
+
+It is recorded here because the other two reorder blind spots are, and because
+finding it later without this note would read as a regression rather than a known
+edge.
+
+## The shared teardown
+
+`removeProcessNode` holds the teardown — reparent children, unlink from parent,
+delete the node and its identity entry — so the exit path and the procfs rebuild
+cannot drift apart. It is deliberately independent of `pendingExits`, because the
+rebuild needs the same teardown for a pid that has no pending exit at all.
+
+It returns `false` when the node could not be removed, which today means
+reparenting failed. Both callers then leave their own bookkeeping untouched, so
+the operation degrades to today's retry-on-the-next-tick behaviour rather than
+inventing a partial teardown. In that state the fork handler still falls back to
+the narrower start-time guard, and the node keeps its stale fields — today's
+behaviour, reached deliberately.
+
+## Cost
+
+Under `pt.mutex`, the additions are a `pendingExits` map lookup on the fork and exec
+paths and one integer comparison on the procfs path. The teardown only runs in the
+recycle case. **No `/proc` read is added.**
+
+**The one syscall this work introduces is taken outside the lock.** Layer 2 needs
+`CLOCK_BOOTTIME` at the moment an exit is recorded, and `unix.ClockGettime` is a
+raw syscall — `x/sys` does not route it through the vDSO the way the runtime does
+for `time.Now`. Exits are about as frequent as forks, so `handleExitEvent` reads the
+clock **before** acquiring `pt.mutex` and passes the value into `addPendingExit`,
+exactly as the fork path does with its start-time read. Anything that moves that
+read back under the lock is a regression.
+
+That pattern is the thing to preserve. A start-time read costs **~7.5 µs** and every
+fork already performs one, which is why it happens outside `pt.mutex` — at 3,000
+forks/s it would otherwise add ~22 ms/s of hold time to a lock every alert type
+depends on, and this package has a prior mutex-stall fix in its history. Read the
+cost section of [process-start-time.md](./process-start-time.md) before adding work
+here.
+
+## Observable changes
+
+The first three are recycle-scenario only:
+
+- A fork or exec on a pid with a pending exit reparents the dead process's
+  children **immediately** rather than after the cleanup delay.
+- A delayed exit no longer deletes a node whose recorded creation postdates the
+  exit's arrival.
+- A procfs start-time change rebuilds the node instead of merging two
+  incarnations. Because the rebuild reparents every child, a child the successor
+  forked before the scan noticed it is detached to init — see layer 3 above.
+- `forceCleanupOldest` no longer makes a second, redundant pass over the same
+  pending exits. That pass was silent while a repeat call always found the node
+  already gone; now that a guard can legitimately keep a node and consume its
+  pending entry, the second pass would log a warning for every node kept.
+
+Same-incarnation behaviour is unchanged. This matters more than usual because
+`GetContainerProcessTree` serves the rule manager and every exporter, so this code
+path sits behind **every** alert type, not just the consumer the start time was
+added for.
+
+## Testing
+
+macOS cannot build this package: `inspektor-gadget/pkg/utils/host` excludes darwin
+and everything under `pkg/processtree` imports it transitively. All runs in the
+Linux container:
+
+```bash
+docker run --rm -v "$PWD":/src -v "$(go env GOMODCACHE)":/go/pkg/mod -w /src \
+  -e GOFLAGS=-mod=mod golang:1.25 go test -race ./pkg/processtree/...
+```
+
+Every reproduction and guard test lives in
+`pkg/processtree/creator/pid_reuse_test.go`. Note that the pull-request pipeline
+does not run the race detector — `CGO_ENABLED: 0` is hardcoded in
+`.github/workflows/pr-created.yaml`, gating the race step off (SUB-7848) — so race
+evidence for changes here has to come from the command above.

--- a/docs/features/process-start-time.md
+++ b/docs/features/process-start-time.md
@@ -127,26 +127,27 @@ alone does not prove reuse — some other path may simply have created it first 
 and wiping on that weaker signal would discard a good scan-recorded value
 whenever the on-demand read then fails.
 
-> **This guard covers the identity map only.** It is **not** process-id-reuse
-> hardening, and its benefit is temporary.
+> **This guard covers the identity map only**, and on its own it was not
+> process-id-reuse hardening.
 >
-> The dead process's entry in `pendingExits` survives the fork. When the delayed
-> cleanup fires — up to `cleanupDelay` after the *original* exit — it runs
-> `exitByPid` on that pid and deletes what is by then the **live** successor's
-> node, along with the start time just read for it. The pid reverts to reading
-> as unknown.
+> By itself it left the dead process's `pendingExits` entry in place, so the
+> delayed cleanup would later run `exitByPid` on that pid and delete what was by
+> then the **live** successor's node, along with the start time just read for it.
+> During the same window the node also still carried the dead process's `comm`,
+> `cmdline` and `path`, so an alert could name the wrong command.
 >
-> During the same window the node also still carries the dead process's `comm`,
-> `cmdline` and `path`, so an alert can name the wrong command.
+> Both are now fixed: a fork or exec on a pid with a pending exit retires the
+> predecessor properly — reparenting its children rather than merely dropping the
+> pending entry, which would leave them to be inherited by the successor. See
+> [process-id-reuse-hardening.md](./process-id-reuse-hardening.md), which also
+> covers the two recycle cases this guard never saw: one discovered only by the
+> `/proc` scan, and a delayed exit arriving for a node that is provably newer.
 >
-> Both are the pre-existing pid-reuse behaviour, tracked separately. The fix is
-> to retire the predecessor when a fork reuses a pid with a pending exit —
-> reparenting its children rather than merely dropping the pending entry, which
-> would leave them to be inherited by the successor.
+> The guard here still earns its place. It is what keeps the identity and display
+> halves of the start time from disagreeing, and it remains the fallback when the
+> teardown cannot complete because reparenting failed.
 
-The entry is deleted at the same point the tree node is deleted. Note that per
-the above, the node deleted may by then belong to a different process than the
-one whose exit scheduled the deletion.
+The entry is deleted at the same point the tree node is deleted.
 
 ## Reading it
 

--- a/docs/features/process-tree-exit-manager-lifecycle.md
+++ b/docs/features/process-tree-exit-manager-lifecycle.md
@@ -79,11 +79,15 @@ Removing a node reparents its children, unlinks it from its parent, deletes the
 node, and deletes the pid's entry in the process-identity side map. See
 [process-start-time.md](./process-start-time.md) for that side map.
 
-> `exitByPid` matches on **pid alone**. It does not check that the node holding
-> that pid is still the process the exit was for, so when the kernel recycles a
-> pid inside the cleanup window, a dead process's delayed exit removes the *live*
-> successor's node. Tracked as SUB-7846 — this document describes the lifecycle,
-> not a fix for that.
+> `exitByPid` no longer matches on **pid alone**. A fork or exec retires a
+> recycled predecessor before the delayed cleanup can reach it, and the cleanup
+> itself skips a node whose recorded boot-relative creation time postdates the
+> exit's arrival.
+>
+> The window is narrowed, not closed: a node with no recorded creation time has
+> nothing to compare, so it still falls through to unconditional deletion. See
+> [process-id-reuse-hardening.md](./process-id-reuse-hardening.md) for the layers
+> and for what each deliberately does not cover.
 
 ## Testing
 

--- a/docs/features/process-tree-exit-manager-lifecycle.md
+++ b/docs/features/process-tree-exit-manager-lifecycle.md
@@ -1,0 +1,100 @@
+# Process-tree exit manager — lifecycle and concurrency contract
+
+The exit manager is the background half of `pkg/processtree/creator`. A process's
+exit does **not** remove its tree node immediately: `handleExitEvent` only records
+a pending exit, and a ticker goroutine removes the node later, once the exit has
+aged past `exitCleanup::cleanupDelay`. The delay exists so a node is still
+present when an alert refers to a process that has just died.
+
+| Setting | Default | Role |
+|---|---|---|
+| `exitCleanup::cleanupInterval` | `30s` | How often the loop looks for due exits |
+| `exitCleanup::cleanupDelay` | `5m` | How long an exit waits before its node is removed |
+| `exitCleanup::maxPendingExits` | `1000` | Cap; reaching it force-drains the oldest pending exits immediately |
+
+Because of the cap, the window in which an exited process's node is still in the
+tree is **min(cleanupDelay, time-to-cap)** — on a busy node it is far shorter than
+five minutes.
+
+## Starting and stopping
+
+`Start()` arms the manager; `Stop()` shuts it down. The state is carried by one
+field, `exitCleanupStopChan`:
+
+- **non-nil** — the manager is armed.
+- **nil** — the manager is stopped, and `Start()` may bring it back up. The
+  manager is restartable, and `Stop()` on an already-stopped manager is a no-op.
+
+The field is an **intent** flag, not a liveness flag, and the difference matters
+when reading or testing this code. It is non-nil before the goroutine has been
+scheduled, and nil while a signalled loop is still finishing its current
+iteration. Nothing should read it as "the loop is running".
+
+Two rules make that safe, and both matter:
+
+**Closing the channel is the stop signal. Clearing the field is only the
+"not running" flag.** These are separate jobs that happen to use one field.
+
+**The loop never reads the field.** `exitCleanupLoop` takes the channel as an
+argument, so it holds its own reference for its whole lifetime and is unaffected
+by a concurrent `Stop()` clearing the field. This is not a stylistic choice —
+reading the field from the loop's `select` on every iteration, while `Stop()` wrote
+to it, was a data race (SUB-7847). It accounted for every race the detector
+reported in `pkg/processtree`, and it had two further consequences:
+
+- Two concurrent `Stop()` calls could both observe an open channel and both close
+  it: `panic: close of closed channel`.
+- A loop that read the *cleared* field rather than the *closed* channel blocked
+  forever on a nil-channel receive. That killed the stop arm of its `select`, so
+  the loop kept ticking — and kept mutating the tree — for the lifetime of the
+  process.
+
+Both lifecycle transitions are therefore held under `exitCleanupMutex`, which
+makes the check-and-close one atomic step.
+
+### Why a dedicated mutex and not the tree lock
+
+`performExitCleanup` holds `pt.mutex`, the tree-wide write lock, for its whole
+pass. Guarding the lifecycle with that same lock would make shutdown wait on
+tree contention, and the tree is shared by every alert type. `exitCleanupMutex`
+guards only the two transitions and is never held while doing tree work, so the
+two locks are never held together and cannot order against each other.
+
+### `Stop()` is not instantaneous
+
+Closing the channel does not preempt an in-flight iteration, and when both arms
+of the loop's `select` are ready the Go runtime picks between them **at random**.
+So a cleanup pass — occasionally more than one — can still run after `Stop()`
+returns. The guarantee is that the loop terminates promptly, not that it performs
+zero further work.
+
+Tests that assert "nothing was cleaned up after `Stop()`" must let the loop
+observe the close before seeding whatever they measure; asserting on the very
+next tick is flaky by construction. `TestExitManager_StopHaltsCleanupLoop` pins
+the real contract — cleanup does not continue indefinitely — and documents this.
+
+## What removal does, and one thing it does not check
+
+Removing a node reparents its children, unlinks it from its parent, deletes the
+node, and deletes the pid's entry in the process-identity side map. See
+[process-start-time.md](./process-start-time.md) for that side map.
+
+> `exitByPid` matches on **pid alone**. It does not check that the node holding
+> that pid is still the process the exit was for, so when the kernel recycles a
+> pid inside the cleanup window, a dead process's delayed exit removes the *live*
+> successor's node. Tracked as SUB-7846 — this document describes the lifecycle,
+> not a fix for that.
+
+## Testing
+
+This package cannot be built or tested on macOS:
+`inspektor-gadget/pkg/utils/host` excludes darwin and everything under
+`pkg/processtree` imports it transitively. Concurrency changes here need the race
+detector, which the pull-request workflow does not currently run
+(`CGO_ENABLED: 0` is hardcoded, gating the race step off — SUB-7848), so run it
+locally:
+
+```bash
+docker run --rm -v "$PWD":/src -v "$(go env GOMODCACHE)":/go/pkg/mod -w /src \
+  -e GOFLAGS=-mod=mod golang:1.25 go test -race ./pkg/processtree/...
+```

--- a/pkg/processtree/creator/boottime_linux.go
+++ b/pkg/processtree/creator/boottime_linux.go
@@ -1,0 +1,23 @@
+package processtreecreator
+
+import "golang.org/x/sys/unix"
+
+// readBootTimeNs returns CLOCK_BOOTTIME now, in nanoseconds since boot.
+//
+// This is deliberately the same clock domain as the pidStartTimeNs side map,
+// which holds /proc/<pid>/stat field 22 converted to nanoseconds. Timestamping
+// exit arrivals on this clock lets the delayed-deletion guard compare
+// boot-relative against boot-relative, with no btime skew and no wall-clock
+// margin heuristic. Never substitute time.Now() here: that is a different clock
+// domain, and the comparison would be meaningless rather than merely imprecise.
+//
+// A failed read returns 0, which every consumer treats as "unknown" and which
+// makes the guard fall through to today's unconditional deletion.
+func readBootTimeNs() uint64 {
+	var ts unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
+		return 0
+	}
+
+	return uint64(ts.Sec)*1_000_000_000 + uint64(ts.Nsec)
+}

--- a/pkg/processtree/creator/exit_manager.go
+++ b/pkg/processtree/creator/exit_manager.go
@@ -12,11 +12,20 @@ import (
 )
 
 type pendingExit struct {
-	PID         uint32
+	PID uint32
+	// StartTimeNs is NOT a process start time. It is the exit event's wall-clock
+	// timestamp, and it exists only to order performExitCleanup's sort. Do not
+	// repurpose it for identity, and never compare it against the boot-relative
+	// pidStartTimeNs side map.
 	StartTimeNs uint64
 	Comm        string
 	Timestamp   time.Time
-	Children    []*armotypes.Process
+	// ArrivalBootNs is when this exit was recorded, on CLOCK_BOOTTIME — the same
+	// clock domain as pidStartTimeNs, so the two are comparable. Zero means the
+	// clock read failed or was never wired, and makes the reuse guard fall
+	// through to today's unconditional deletion.
+	ArrivalBootNs uint64
+	Children      []*armotypes.Process
 }
 
 func (pt *processTreeCreatorImpl) startExitManager() {
@@ -52,7 +61,13 @@ func (pt *processTreeCreatorImpl) stopExitManager() {
 	pt.exitCleanupStopChan = nil
 }
 
-func (pt *processTreeCreatorImpl) addPendingExit(event conversion.ProcessEvent) {
+// addPendingExit records a deferred exit. arrivalBootNs is passed in rather than
+// read here, because the only caller holds pt.mutex and reading the boot clock is
+// a syscall — see handleExitEvent. Zero means unknown and disables the reuse
+// guard for this entry, falling through to today's unconditional deletion.
+//
+// Caller must hold pt.mutex.
+func (pt *processTreeCreatorImpl) addPendingExit(event conversion.ProcessEvent, arrivalBootNs uint64) {
 	if len(pt.pendingExits) >= pt.config.ExitCleanup.MaxPendingExits {
 		logger.L().Debug("Exit: Maximum pending exits reached, forcing cleanup",
 			helpers.String("pending_count", fmt.Sprintf("%d", len(pt.pendingExits))),
@@ -61,11 +76,24 @@ func (pt *processTreeCreatorImpl) addPendingExit(event conversion.ProcessEvent) 
 	}
 
 	pt.pendingExits[event.PID] = &pendingExit{
-		PID:         event.PID,
-		StartTimeNs: event.StartTimeNs,
-		Comm:        event.Comm,
-		Timestamp:   time.Now(),
+		PID:           event.PID,
+		StartTimeNs:   event.StartTimeNs,
+		Comm:          event.Comm,
+		Timestamp:     time.Now(),
+		ArrivalBootNs: arrivalBootNs,
 	}
+}
+
+// bootTimeNs reads the boot clock through the injectable hook, returning 0 when
+// the hook is absent or the read failed. Zero means "unknown" everywhere it is
+// consumed, so an unset hook degrades every guard to today's behaviour rather
+// than panicking — struct literals in tests need not wire it.
+func (pt *processTreeCreatorImpl) bootTimeNs() uint64 {
+	if pt.nowBootNs == nil {
+		return 0
+	}
+
+	return pt.nowBootNs()
 }
 
 // exitCleanupLoop runs until it observes stopChan closed — which is not the same
@@ -129,12 +157,13 @@ func (pt *processTreeCreatorImpl) forceCleanupOldest() {
 		return toRemove[i].Timestamp.Before(toRemove[j].Timestamp)
 	})
 
+	// One pass. There was a second, redundant pass over the same slice: harmless
+	// while a repeat call always found the node already gone and returned silently,
+	// but the reuse guard can now legitimately KEEP a node and consume its pending
+	// entry on the first pass, so the second pass would find a node with no pending
+	// entry and log a warning for it.
 	for _, pending := range toRemove {
 		pt.exitByPid(pending.PID)
-	}
-
-	for i := 0; i < len(toRemove); i++ {
-		pt.exitByPid(toRemove[i].PID)
 	}
 
 	logger.L().Debug("Exit: Force cleanup completed",
@@ -142,12 +171,104 @@ func (pt *processTreeCreatorImpl) forceCleanupOldest() {
 		helpers.Int("pids number", pt.processMap.Len()))
 }
 
+// retireRecycledPredecessor tears down the tree node of a dead process whose pid
+// has been recycled, when a fork or exec proves a new incarnation now holds it.
+//
+// A fork or exec can only come from a live process — a zombie can do neither — so
+// a pending exit on that pid must belong to a dead predecessor. Retiring it here
+// does two things: it stops the new process inheriting the dead one's identity
+// (handleForkEvent fills only empty fields, and a stale node is not empty), and
+// it disarms the delayed deletion that would otherwise remove the new process's
+// node up to cleanupDelay after the predecessor's exit.
+//
+// Retiring means the full exitByPid teardown, NOT merely dropping the pending
+// entry. The dead process's children have to be reparented; leaving them linked
+// to the pid would hand them to the new process as its own children, which is a
+// quieter and worse corruption than the one being fixed.
+//
+// handleProcfsEvent must never call this. /proc lists zombies, so a procfs event
+// can legitimately belong to the same incarnation that already exited, and the
+// mere existence of a pending exit proves nothing there. Procfs recycle detection
+// compares the recorded start time instead.
+//
+// Caller must hold pt.mutex.
+func (pt *processTreeCreatorImpl) retireRecycledPredecessor(pid uint32) {
+	if _, pending := pt.pendingExits[pid]; !pending {
+		return
+	}
+
+	pt.exitByPid(pid)
+}
+
 func (pt *processTreeCreatorImpl) exitByPid(pid uint32) {
-	proc, ok := pt.processMap.Load(pid)
-	if !ok {
+	// Pid-reuse guard (L2): if the node under this pid records a creation time
+	// LATER than the moment this exit event arrived, it cannot be the process the
+	// exit was for — the pid was recycled, and the predecessor's node is already
+	// gone. Consume the pending entry so it is not retried forever, and keep the
+	// node.
+	//
+	// Both sides are boot-relative nanoseconds: the side map is procfs ticks x
+	// 10^7, the arrival is CLOCK_BOOTTIME. No btime skew, no wall-clock margin.
+	// pendingExit.Timestamp and pendingExit.StartTimeNs are wall-clock values and
+	// must never be used here.
+	//
+	// A zero on either side means unknown and falls through to today's deletion.
+	// The guard must never KEEP a node it cannot prove is newer: retaining stale
+	// state is the harmful direction, re-deleting a node is not. Nodes with no
+	// recorded start time are therefore not covered by this layer at all — the
+	// fork/exec guard covers those, needing no clock.
+	// The node-absent case is settled first, so the guard below cannot return
+	// while leaving an orphaned side-map entry behind. Side-map entries only exist
+	// alongside nodes today, so ordering these the other way round is unreachable
+	// rather than wrong — but it would depend on that invariant silently.
+	if _, exists := pt.processMap.Load(pid); !exists {
 		delete(pt.pendingExits, pid)
 		delete(pt.pidStartTimeNs, pid)
 		return
+	}
+
+	if pending := pt.pendingExits[pid]; pending != nil && pending.ArrivalBootNs != 0 {
+		if startNs := pt.pidStartTimeNs[pid]; startNs > pending.ArrivalBootNs {
+			delete(pt.pendingExits, pid)
+			return
+		}
+	}
+
+	pending := pt.pendingExits[pid]
+	if pending == nil {
+		logger.L().Warning("exitByPid: pendingExits[pid] is nil", helpers.String("pid", fmt.Sprintf("%d", pid)))
+		return
+	}
+
+	children, removed := pt.removeProcessNode(pid)
+	pending.Children = children
+
+	if !removed {
+		// Reparenting failed, so the node is still in the tree. Leave the pending
+		// entry in place for the next cleanup tick — today's behaviour.
+		return
+	}
+
+	delete(pt.pendingExits, pid)
+}
+
+// removeProcessNode tears one node out of the tree: it reparents the node's
+// children, unlinks it from its parent, and deletes the node together with its
+// process-identity entry. It returns the children it reparented, and false when
+// the node could not be removed — today that means reparenting failed, and the
+// caller must leave its own bookkeeping untouched so the operation degrades to
+// today's retry-on-the-next-tick behaviour.
+//
+// Deliberately independent of pendingExits: the procfs recycle rebuild needs this
+// exact teardown for a pid that has no pending exit at all, and duplicating the
+// reparenting logic for it is how the two paths would drift.
+//
+// Caller must hold pt.mutex.
+func (pt *processTreeCreatorImpl) removeProcessNode(pid uint32) ([]*armotypes.Process, bool) {
+	proc, ok := pt.processMap.Load(pid)
+	if !ok {
+		delete(pt.pidStartTimeNs, pid)
+		return nil, true
 	}
 
 	// Collect children for reparenting
@@ -158,19 +279,24 @@ func (pt *processTreeCreatorImpl) exitByPid(pid uint32) {
 		}
 	}
 
-	pending := pt.pendingExits[pid]
-	if pending == nil {
-		logger.L().Warning("exitByPid: pendingExits[pid] is nil", helpers.String("pid", fmt.Sprintf("%d", pid)))
-		return
-	}
+	if len(children) > 0 {
+		// NewProcessTreeCreator leaves this nil if the strategy set cannot be
+		// built, so treat a missing one as a removal failure rather than
+		// dereferencing it. Unreachable today — NewReparentingLogic ends in an
+		// unconditional `return rl, nil` — but the alternative is a nil-interface
+		// panic, and with no recover() anywhere in the agent that takes the whole
+		// process down rather than just this goroutine. This teardown also now has
+		// a second caller on the procfs rebuild path.
+		if pt.reparentingStrategies == nil {
+			logger.L().Warning("removeProcessNode: no reparenting strategy, keeping node",
+				helpers.String("pid", fmt.Sprintf("%d", pid)))
+			return children, false
+		}
 
-	pending.Children = children
-
-	if len(pending.Children) > 0 {
-		newParentPID, err := pt.reparentingStrategies.Reparent(pid, pending.Children, pt.containerTree, &pt.processMap)
+		newParentPID, err := pt.reparentingStrategies.Reparent(pid, children, pt.containerTree, &pt.processMap)
 		if err != nil {
-			logger.L().Warning("exitByPid: reparentingLogic.HandleProcessExit failed", helpers.String("pid", fmt.Sprintf("%d", pid)), helpers.Error(err))
-			return
+			logger.L().Warning("removeProcessNode: reparenting failed", helpers.String("pid", fmt.Sprintf("%d", pid)), helpers.Error(err))
+			return children, false
 		}
 
 		var newParentComm string
@@ -178,7 +304,7 @@ func (pt *processTreeCreatorImpl) exitByPid(pid uint32) {
 			newParentComm = newParent.Comm
 		}
 
-		for _, child := range pending.Children {
+		for _, child := range children {
 			if child != nil {
 				child.PPID = newParentPID
 				if newParentComm != "" {
@@ -194,7 +320,7 @@ func (pt *processTreeCreatorImpl) exitByPid(pid uint32) {
 			if _, ok := parent.ChildrenMap[armotypes.CommPID{PID: pid}]; ok {
 				delete(parent.ChildrenMap, armotypes.CommPID{PID: pid})
 			} else {
-				logger.L().Warning("exitByPid: process not found in parent's children map", helpers.String("pid", fmt.Sprintf("%d", pid)))
+				logger.L().Warning("removeProcessNode: process not found in parent's children map", helpers.String("pid", fmt.Sprintf("%d", pid)))
 			}
 		}
 	}
@@ -202,5 +328,6 @@ func (pt *processTreeCreatorImpl) exitByPid(pid uint32) {
 	pt.processMap.Delete(pid)
 	// The process identity dies with the node it identifies.
 	delete(pt.pidStartTimeNs, pid)
-	delete(pt.pendingExits, pid)
+
+	return children, true
 }

--- a/pkg/processtree/creator/exit_manager.go
+++ b/pkg/processtree/creator/exit_manager.go
@@ -20,26 +20,36 @@ type pendingExit struct {
 }
 
 func (pt *processTreeCreatorImpl) startExitManager() {
+	pt.exitCleanupMutex.Lock()
+	defer pt.exitCleanupMutex.Unlock()
+
 	if pt.exitCleanupStopChan != nil {
 		return
 	}
 
-	pt.exitCleanupStopChan = make(chan struct{})
-	go pt.exitCleanupLoop()
+	// Hand the channel to the loop by value. The loop must never read the field
+	// itself: the field is mutable state shared with stopExitManager, and reading
+	// it on every select iteration is what made this a data race.
+	stopChan := make(chan struct{})
+	pt.exitCleanupStopChan = stopChan
+	go pt.exitCleanupLoop(stopChan)
 }
 
 func (pt *processTreeCreatorImpl) stopExitManager() {
+	pt.exitCleanupMutex.Lock()
+	defer pt.exitCleanupMutex.Unlock()
+
 	if pt.exitCleanupStopChan == nil {
 		return
 	}
 
-	select {
-	case <-pt.exitCleanupStopChan:
-		return
-	default:
-		close(pt.exitCleanupStopChan)
-		pt.exitCleanupStopChan = nil
-	}
+	// Closing is the signal that stops the loop; nil is only the "not running"
+	// flag that lets startExitManager bring it back up. Holding the mutex across
+	// the check and the close makes the transition atomic — previously two
+	// concurrent Stop() calls could both find the channel open and both close it,
+	// panicking with "close of closed channel".
+	close(pt.exitCleanupStopChan)
+	pt.exitCleanupStopChan = nil
 }
 
 func (pt *processTreeCreatorImpl) addPendingExit(event conversion.ProcessEvent) {
@@ -58,13 +68,21 @@ func (pt *processTreeCreatorImpl) addPendingExit(event conversion.ProcessEvent) 
 	}
 }
 
-func (pt *processTreeCreatorImpl) exitCleanupLoop() {
+// exitCleanupLoop runs until it observes stopChan closed — which is not the same
+// instant the close happens: an in-flight iteration is not preempted, and when
+// both arms are ready the runtime picks between them at random, so one or two
+// further cleanup passes after Stop() are normal.
+//
+// stopChan is a parameter rather than a field read so the loop holds its own
+// reference for its whole lifetime, unaffected by a concurrent stopExitManager
+// clearing the field.
+func (pt *processTreeCreatorImpl) exitCleanupLoop(stopChan <-chan struct{}) {
 	ticker := time.NewTicker(pt.config.ExitCleanup.CleanupInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-pt.exitCleanupStopChan:
+		case <-stopChan:
 			return
 		case <-ticker.C:
 			pt.performExitCleanup()

--- a/pkg/processtree/creator/exit_manager_lifecycle_test.go
+++ b/pkg/processtree/creator/exit_manager_lifecycle_test.go
@@ -1,0 +1,139 @@
+package processtreecreator
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSpinningExitManagerCreator builds a creator whose cleanup loop re-evaluates
+// its select on a sub-millisecond tick. The stock helper's 30-second interval
+// leaves the loop parked inside one select for the whole test, so the window in
+// which the lifecycle fields are touched concurrently is practically
+// unobservable.
+func newSpinningExitManagerCreator() *processTreeCreatorImpl {
+	pt := createTestProcessTreeCreator()
+	pt.pidStartTimeNs = make(map[uint32]uint64)
+	pt.config.ExitCleanup.CleanupInterval = 100 * time.Microsecond
+	pt.config.ExitCleanup.CleanupDelay = time.Hour
+
+	return pt
+}
+
+// The cleanup loop used to read pt.exitCleanupStopChan directly in its select
+// while stopExitManager wrote to the same field, neither side synchronised. That
+// single site was the whole of SUB-7847: all seven race reports in this package's
+// -race baseline were this one field pair. The loop now takes the channel as an
+// argument, so this test is the regression guard for that.
+// NOTE: the race detector is this test's real assertion, and the pull-request
+// pipeline does not run it (CGO_ENABLED: 0 — SUB-7848). The lifecycle assertion
+// below keeps the test from being entirely vacuous there, but race evidence for
+// this package has to come from a local -race run.
+func TestExitManager_StopIsRaceFreeAgainstCleanupLoop(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		pt := newSpinningExitManagerCreator()
+		pt.Start()
+		// Let the loop reach its select and start cycling through iterations.
+		time.Sleep(2 * time.Millisecond)
+		pt.Stop()
+		require.Nil(t, pt.exitCleanupStopChan, "Stop must leave the manager in the stopped state")
+	}
+}
+
+// Two concurrent Stop() calls used to be able to both pass the nil check and both
+// reach the select's default branch, so both called close() on the same channel
+// and the second panicked with "close of closed channel". The check and the close
+// have to be one atomic transition, which is what the lifecycle mutex makes them.
+func TestExitManager_ConcurrentStopDoesNotPanic(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		pt := newSpinningExitManagerCreator()
+		pt.Start()
+
+		var wg sync.WaitGroup
+		for g := 0; g < 8; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pt.Stop()
+			}()
+		}
+		wg.Wait()
+	}
+}
+
+// After Stop() the cleanup goroutine must actually exit — not merely be signalled.
+// This used to be decided by the race: a loop that read the nilled field rather
+// than the closed channel blocked forever on a nil-channel receive, killing that
+// select arm, so the loop kept ticking and mutating the tree for the lifetime of
+// the process. The loop now holds its own channel reference and always observes
+// the close.
+//
+// What this test does NOT claim is that cleanup stops instantly; see the comment
+// at the settle window below.
+func TestExitManager_StopHaltsCleanupLoop(t *testing.T) {
+	pt := newSpinningExitManagerCreator()
+	// Every pending exit is immediately due, so one tick drains it.
+	pt.config.ExitCleanup.CleanupDelay = 0
+
+	pt.Start()
+
+	// Establish that the loop is live: a pending exit gets drained promptly.
+	pt.mutex.Lock()
+	pt.processMap.Set(100, createTestProcess(100, 1, "before-stop"))
+	pt.pendingExits[100] = &pendingExit{PID: 100, Timestamp: time.Now()}
+	pt.mutex.Unlock()
+
+	require.Eventually(t, func() bool {
+		pt.mutex.RLock()
+		defer pt.mutex.RUnlock()
+		_, stillPending := pt.pendingExits[100]
+		return !stillPending
+	}, 2*time.Second, time.Millisecond, "a running loop should drain a due pending exit")
+
+	pt.Stop()
+
+	// Let the loop observe the closed channel and return before seeding the
+	// sentinel. Closing does not preempt an in-flight iteration, and when both
+	// select arms are ready the runtime picks between them at random — so a
+	// ticker this hot can win several rounds, and a cleanup pass or two after
+	// Stop() is expected rather than a leak. What must not happen is cleanup
+	// continuing indefinitely, which is what the sentinel below measures.
+	time.Sleep(20 * time.Millisecond)
+
+	// With the loop gone, a newly due pending exit must never be drained.
+	pt.mutex.Lock()
+	pt.processMap.Set(200, createTestProcess(200, 1, "after-stop"))
+	pt.pendingExits[200] = &pendingExit{PID: 200, Timestamp: time.Now()}
+	pt.mutex.Unlock()
+
+	// ~500 tick intervals: ample for a surviving loop to reveal itself.
+	time.Sleep(50 * time.Millisecond)
+
+	pt.mutex.RLock()
+	_, stillPending := pt.pendingExits[200]
+	pt.mutex.RUnlock()
+	assert.True(t, stillPending, "cleanup ran after Stop: the loop goroutine leaked")
+}
+
+// The stopped state is signalled by a nil channel, and Start() must be able to
+// bring the manager back up — the behaviour TestExitManager_StartStop and
+// TestStartStop pin. Preserved deliberately: the fix removes the race, not the
+// lifecycle contract.
+func TestExitManager_RestartAfterStop(t *testing.T) {
+	pt := newSpinningExitManagerCreator()
+
+	pt.Start()
+	require.NotNil(t, pt.exitCleanupStopChan, "Start must arm the stop channel")
+
+	pt.Stop()
+	require.Nil(t, pt.exitCleanupStopChan, "Stop must leave the manager in the restartable nil state")
+
+	pt.Start()
+	require.NotNil(t, pt.exitCleanupStopChan, "the exit manager must be restartable after Stop")
+
+	pt.Stop()
+	require.Nil(t, pt.exitCleanupStopChan)
+}

--- a/pkg/processtree/creator/exit_manager_test.go
+++ b/pkg/processtree/creator/exit_manager_test.go
@@ -126,7 +126,7 @@ func TestExitManager_AddPendingExit(t *testing.T) {
 	// Test adding a pending exit
 	pt.mutex.Lock()
 	event := createTestExitEvent(100, 12345)
-	pt.addPendingExit(event)
+	pt.addPendingExit(event, 0)
 	pt.mutex.Unlock()
 
 	// Check that the exit was added
@@ -354,7 +354,7 @@ func TestExitManager_ThreadSafety(t *testing.T) {
 			pid := uint32(i + 1)
 			pt.mutex.Lock()
 			event := createTestExitEvent(pid, uint64(i))
-			pt.addPendingExit(event)
+			pt.addPendingExit(event, 0)
 			pt.mutex.Unlock()
 			time.Sleep(1 * time.Millisecond)
 		}

--- a/pkg/processtree/creator/pid_reuse_test.go
+++ b/pkg/processtree/creator/pid_reuse_test.go
@@ -1,0 +1,363 @@
+package processtreecreator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/goradd/maps"
+	"github.com/kubescape/node-agent/pkg/config"
+	processtreecreatorconfig "github.com/kubescape/node-agent/pkg/processtree/config"
+	"github.com/kubescape/node-agent/pkg/processtree/conversion"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newReuseTestCreator builds a creator with a cleanup delay long enough that
+// pending exits sit untouched until a test flushes them explicitly, and with no
+// background loop running (Start is deliberately not called).
+func newReuseTestCreator(t *testing.T) *processTreeCreatorImpl {
+	t.Helper()
+
+	pt := &processTreeCreatorImpl{
+		processMap:            maps.SafeMap[uint32, *armotypes.Process]{},
+		containerTree:         &mockContainerProcessTree{},
+		reparentingStrategies: &mockReparentingLogic{},
+		pendingExits:          make(map[uint32]*pendingExit),
+		pidStartTimeNs:        make(map[uint32]uint64),
+		config: config.Config{
+			KubernetesMode: false,
+			ExitCleanup: processtreecreatorconfig.ExitCleanupConfig{
+				MaxPendingExits: 1000,
+				CleanupInterval: time.Hour,
+				CleanupDelay:    time.Hour,
+			},
+		},
+	}
+
+	// Neutralise the on-demand /proc start-time read. These synthetic pids must
+	// not accidentally resolve against the container's real /proc, and several
+	// premises here — "a fork-created node has no identity yet" — depend on the
+	// side map holding exactly what the test fed it.
+	pt.readStartTime = func(uint32) (uint64, time.Time) { return 0, time.Time{} }
+
+	return pt
+}
+
+// flushPendingExits fires the delayed cleanup the way the background loop would.
+func flushPendingExits(pt *processTreeCreatorImpl) {
+	pt.mutex.Lock()
+	defer pt.mutex.Unlock()
+	for pid := range pt.pendingExits {
+		pt.exitByPid(pid)
+	}
+}
+
+// BUG 1 — inheritance. handleForkEvent fills only EMPTY fields, and a recycled
+// pid's node is not empty: it still holds the dead process's identity. The new
+// process therefore reports the dead one's comm, cmdline and path, and an alert
+// raised in this window names the wrong command.
+func TestPidReuse_ForkAfterExit_DoesNotInheritDeadFields(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "malware"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExecEvent, PID: 100, PPID: 1, Comm: "malware",
+		Cmdline: "malware --evil", Path: "/tmp/malware"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	// The kernel recycles pid 100 for an innocent worker before cleanup fires.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 2, Comm: "worker"})
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "worker", node.Comm, "recycled pid must not report the dead process's comm")
+	assert.NotEqual(t, "malware --evil", node.Cmdline, "recycled pid must not inherit the dead process's cmdline")
+	assert.NotEqual(t, "/tmp/malware", node.Path, "recycled pid must not inherit the dead process's path")
+}
+
+// BUG 2 — delayed deletion. exitByPid matches on pid alone, so the dead
+// process's exit, fired up to CleanupDelay after the fact, deletes whatever node
+// holds that pid by then: here, a live process. Its children are reparented
+// around a process that is still running.
+func TestPidReuse_DelayedExit_DoesNotDeleteNewProcess(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "old"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 2, Comm: "new"})
+
+	flushPendingExits(pt)
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	assert.NotNil(t, node, "the new incarnation's node must survive the old incarnation's delayed exit")
+}
+
+// A pending exit can outlive its node: the exit may arrive for a pid the tree
+// never created a node for, or another path may already have removed it. The pid
+// is then recycled, the fork builds a fresh node, and the stale pending exit
+// deletes THAT node when cleanup fires — the same corruption, reached without a
+// stale node ever being found.
+//
+// So the guard has to run BEFORE the node lookup, not only in the branch where a
+// stale node was found. Gating it on an existing node would leave this case open.
+func TestPidReuse_ForkAfterExit_ConsumesPendingExitWithNoNode(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	// An exit for a pid that has no node in the tree.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	pt.mutex.RLock()
+	_, pending := pt.pendingExits[100]
+	pt.mutex.RUnlock()
+	require.True(t, pending, "precondition: a pending exit exists with no node behind it")
+
+	// The kernel recycles the pid.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 2, Comm: "new"})
+
+	flushPendingExits(pt)
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node, "the new process's node must survive a pending exit that had no node of its own")
+	assert.Equal(t, "new", node.Comm)
+}
+
+// THE TRAP. Dropping the pending-exit entry alone — delete(pt.pendingExits, pid)
+// — makes both tests above pass while leaving the dead process's children linked
+// to the recycled pid, so the new process silently inherits them. That is a
+// quieter corruption than the one being fixed: the tree now claims an unrelated
+// live process is the parent of another process's children, and every alert built
+// from that branch inherits the lie.
+//
+// Retiring the predecessor properly reparents the children away first. This test
+// exists so that simplification cannot be made without a test going red.
+func TestPidReuse_ForkAfterExit_DoesNotInheritDeadChildren(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "old-parent"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 101, PPID: 100, Comm: "old-child"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	// The kernel recycles pid 100 for a process unrelated to that child.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 2, Comm: "new"})
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "new", node.Comm)
+	assert.Empty(t, node.ChildrenMap,
+		"the dead process's children must be reparented away, not inherited by the recycled pid")
+
+	// The child must survive — reparented, not deleted along with its parent.
+	child, err := pt.GetProcessNode(101)
+	require.NoError(t, err)
+	require.NotNil(t, child, "the child must survive its parent's retirement")
+	assert.NotEqual(t, uint32(100), child.PPID, "the child must no longer point at the recycled pid")
+}
+
+// BUG 2b — a recycle the fork/exec guard cannot see, because no fork event was
+// observed for the new incarnation: the scan discovered it instead. The guard
+// here is purely temporal — a node whose recorded creation postdates the exit
+// event's arrival cannot be the process that exit was for. Both values are
+// boot-domain, so no btime skew is involved.
+func TestPidReuse_DelayedExit_SkipsNodeCreatedAfterExitArrival(t *testing.T) {
+	pt := newReuseTestCreator(t)
+	fakeNow := uint64(1_000_000_000_000) // 1000s after boot
+	pt.nowBootNs = func() uint64 { return fakeNow }
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 1, Comm: "old",
+		StartTimeNs: 900_000_000_000})
+	// The exit arrives at 1000s.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	// Recycled, and rediscovered by the scan at 1010s — after the exit arrived.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 2, Comm: "new",
+		StartTimeNs: 1_010_000_000_000})
+
+	pt.mutex.Lock()
+	pt.exitByPid(100)
+	pt.mutex.Unlock()
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node, "a node provably newer than the exit must survive")
+	assert.Equal(t, "new", node.Comm)
+
+	pt.mutex.RLock()
+	_, stillPending := pt.pendingExits[100]
+	pt.mutex.RUnlock()
+	assert.False(t, stillPending, "the stale pending exit is consumed, not retried forever")
+}
+
+// The same guarantee, but reaching layer 2 rather than layer 3.
+//
+// The test above discovers the successor with a procfs event on a pid the side map
+// already has a value for, so the start-time-change rebuild fires first, tears the
+// node down and consumes the pending entry — exitByPid then takes its
+// pending == nil early return and layer 2's comparison is never evaluated. That
+// makes it a layer 3 test wearing layer 2's name: deleting layer 2 entirely leaves
+// it green.
+//
+// Here the predecessor has NO side-map entry (fork only, with the on-demand read
+// neutralised), so the rebuild declines — it requires a non-zero prior value — and
+// the procfs event merely records the successor's start time. exitByPid therefore
+// reaches layer 2 with a live pending entry, which is the branch under test.
+func TestPidReuse_DelayedExit_LayerTwoKeepsNewerNodeWithoutRebuild(t *testing.T) {
+	pt := newReuseTestCreator(t)
+	pt.nowBootNs = func() uint64 { return 1_000_000_000_000 } // exit arrives at 1000s
+
+	// Predecessor known only from a fork, so pidStartTimeNs[100] stays unset.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "old"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	pt.mutex.RLock()
+	prev := pt.pidStartTimeNs[100]
+	pt.mutex.RUnlock()
+	require.Zero(t, prev, "precondition: no prior start time, so the L3 rebuild must decline")
+
+	// The scan sees the successor at 1010s — after the exit arrived.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 2, Comm: "new",
+		StartTimeNs: 1_010_000_000_000})
+
+	pt.mutex.RLock()
+	_, stillPendingBefore := pt.pendingExits[100]
+	pt.mutex.RUnlock()
+	require.True(t, stillPendingBefore, "precondition: the pending exit must still be armed, or L2 is not reached")
+
+	pt.mutex.Lock()
+	pt.exitByPid(100)
+	pt.mutex.Unlock()
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node, "L2 must keep a node whose recorded creation postdates the exit's arrival")
+
+	pt.mutex.RLock()
+	_, stillPending := pt.pendingExits[100]
+	pt.mutex.RUnlock()
+	assert.False(t, stillPending, "L2 consumes the stale pending entry rather than retrying forever")
+}
+
+// Layer 1 applies to exec, not only fork. An exec proves a live process holds the
+// pid just as a fork does, and while exec already overwrites comm/cmdline/path,
+// the predecessor's delayed exit would still delete this live node and its
+// children would still be inherited.
+//
+// Ordering matters here: the exec must arrive AFTER the exit, otherwise the guard
+// is a no-op and the test proves nothing.
+func TestPidReuse_ExecAfterExit_RetiresPredecessor(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "old-parent"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 101, PPID: 100, Comm: "old-child"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	// The pid is recycled and the successor is first seen execing.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExecEvent, PID: 100, PPID: 2, Comm: "new",
+		Cmdline: "new --serve", Path: "/usr/bin/new"})
+
+	pt.mutex.RLock()
+	_, stillPending := pt.pendingExits[100]
+	pt.mutex.RUnlock()
+	assert.False(t, stillPending, "the exec must disarm the predecessor's delayed deletion")
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "new", node.Comm)
+	assert.Empty(t, node.ChildrenMap, "the dead process's children must not be inherited by the exec'd successor")
+
+	// The predecessor's delayed exit must no longer be able to delete this node.
+	flushPendingExits(pt)
+
+	node, err = pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node, "the live successor's node must survive the predecessor's cleanup")
+}
+
+// Unknown start time means exactly today's behaviour. The guard must never keep a
+// node it cannot prove is newer, so this population — nodes with no recorded
+// creation time — falls through to deletion rather than being covered by a guess.
+func TestPidReuse_DelayedExit_UnknownStartTimeStillDeletes(t *testing.T) {
+	pt := newReuseTestCreator(t)
+	pt.nowBootNs = func() uint64 { return 1_000_000_000_000 }
+
+	// Fork only: no procfs event, and readStartTime is neutralised, so the side
+	// map has no entry for this pid.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 100, PPID: 1, Comm: "old"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	pt.mutex.Lock()
+	pt.exitByPid(100)
+	pt.mutex.Unlock()
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	assert.Nil(t, node, "no identity data means conservative deletion, byte-for-byte today's logic")
+}
+
+// The mirror of the guard: an exit that arrives AFTER the node was recorded — the
+// ordinary, non-recycled case — must still delete. This is the assertion that
+// stops the guard being written with the comparison inverted, which would leak
+// every exited process's node forever.
+func TestPidReuse_DelayedExit_NormalExitStillDeletes(t *testing.T) {
+	pt := newReuseTestCreator(t)
+	pt.nowBootNs = func() uint64 { return 1_000_000_000_000 } // exit arrives at 1000s
+
+	// Node recorded at 900s, comfortably before the exit arrived.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 1, Comm: "app",
+		StartTimeNs: 900_000_000_000})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ExitEvent, PID: 100, Comm: "exit", Timestamp: time.Now()})
+
+	pt.mutex.Lock()
+	pt.exitByPid(100)
+	pt.mutex.Unlock()
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	assert.Nil(t, node, "an ordinary exit must still remove its own process's node")
+}
+
+// BUG 1b — a recycle seen only through the procfs scan merges the two
+// incarnations. handleProcfsEvent overwrites non-empty event fields but performs
+// no identity comparison, so stale fields the new process does not have — Cwd
+// here — survive from the dead one.
+func TestPidReuse_ProcfsStartTimeChange_RebuildsNode(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 1,
+		Comm: "malware", Cmdline: "malware --evil", Cwd: "/tmp/.hidden", StartTimeNs: 900_000_000_000})
+
+	// Recycled: same pid, a different program, no Cwd readable yet.
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 2,
+		Comm: "worker", Cmdline: "worker --queue=q1", StartTimeNs: 1_010_000_000_000})
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "worker", node.Comm)
+	assert.Equal(t, "worker --queue=q1", node.Cmdline)
+	assert.Empty(t, node.Cwd, "stale Cwd from the dead incarnation must not survive the rebuild")
+	assert.Equal(t, uint64(1_010_000_000_000), pt.GetProcessBootTimeNs(100))
+}
+
+// Same start time means the same process, so today's merge semantics must be
+// left exactly as they are: fields refreshed, nothing torn down, children kept.
+// This is the control for the test above — it must pass before and after the fix.
+func TestPidReuse_ProcfsSameStartTime_MergesAsToday(t *testing.T) {
+	pt := newReuseTestCreator(t)
+
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 1, Comm: "app",
+		StartTimeNs: 900_000_000_000})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ForkEvent, PID: 101, PPID: 100, Comm: "child"})
+	pt.FeedEvent(conversion.ProcessEvent{Type: conversion.ProcfsEvent, PID: 100, PPID: 1, Comm: "app",
+		Cwd: "/srv", StartTimeNs: 900_000_000_000})
+
+	node, err := pt.GetProcessNode(100)
+	require.NoError(t, err)
+	require.NotNil(t, node)
+	assert.Equal(t, "/srv", node.Cwd)
+	assert.Len(t, node.ChildrenMap, 1, "children survive a same-incarnation refresh")
+}

--- a/pkg/processtree/creator/processtree_creator.go
+++ b/pkg/processtree/creator/processtree_creator.go
@@ -23,8 +23,22 @@ type processTreeCreatorImpl struct {
 	config                config.Config
 
 	// Exit manager fields
-	pendingExits        map[uint32]*pendingExit // PID -> pending exit
+	pendingExits map[uint32]*pendingExit // PID -> pending exit
+
+	// exitCleanupStopChan is the loop's stop signal while it is armed, and nil once
+	// stopped, which is what lets startExitManager bring the loop back up. It is
+	// an intent flag, not a liveness flag: it is non-nil before the goroutine has
+	// been scheduled, and nil while a signalled loop is still finishing its current
+	// iteration. Do not read it as "the loop is running".
+	//
+	// Every access in non-test code is under exitCleanupMutex, and NOT under
+	// pt.mutex: the tree lock is held across performExitCleanup, so reusing it for
+	// lifecycle transitions would couple shutdown to tree contention. Tests read
+	// the field directly, which is safe only because those reads are sequenced
+	// after Start/Stop returns and the loop never touches the field — it receives
+	// the channel as an argument.
 	exitCleanupStopChan chan struct{}
+	exitCleanupMutex    sync.Mutex
 
 	// pidStartTimeNs maps a live pid to its creation time in nanoseconds since
 	// boot, sourced EXCLUSIVELY from /proc/<pid>/stat field 22 (never from

--- a/pkg/processtree/creator/processtree_creator.go
+++ b/pkg/processtree/creator/processtree_creator.go
@@ -54,6 +54,12 @@ type processTreeCreatorImpl struct {
 	// does not wait up to a full scan interval for its identity. Returns zeros
 	// when the process is already gone. Injectable for tests.
 	readStartTime func(pid uint32) (uint64, time.Time)
+
+	// nowBootNs reads CLOCK_BOOTTIME in nanoseconds, the same clock domain as
+	// pidStartTimeNs, so an exit's arrival can be compared against a node's
+	// recorded creation time. Injectable for tests; read through pt.bootTimeNs(),
+	// which tolerates a nil hook by returning 0 ("unknown").
+	nowBootNs func() uint64
 }
 
 func NewProcessTreeCreator(containerTree containerprocesstree.ContainerProcessTree, config config.Config) ProcessTreeCreator {
@@ -71,6 +77,7 @@ func NewProcessTreeCreator(containerTree containerprocesstree.ContainerProcessTr
 		pendingExits:          make(map[uint32]*pendingExit),
 		pidStartTimeNs:        make(map[uint32]uint64),
 		readStartTime:         newProcfsStartTimeReader(),
+		nowBootNs:             readBootTimeNs,
 		config:                config,
 	}
 
@@ -237,25 +244,29 @@ func (pt *processTreeCreatorImpl) handleForkEvent(event conversion.ProcessEvent)
 	pt.mutex.Lock()
 	defer pt.mutex.Unlock()
 
+	// A fork's pid is newborn, so a pending exit on it can only belong to a dead
+	// predecessor whose pid the kernel recycled. Retire that predecessor — node,
+	// children and pending entry — before touching the node below.
+	pt.retireRecycledPredecessor(event.PID)
+
 	proc, ok := pt.processMap.Load(event.PID)
 	if !ok {
 		proc = pt.getOrCreateProcess(event.PID)
 	} else if _, exited := pt.pendingExits[event.PID]; exited {
-		// The previous holder of this pid exited but its node is still around —
-		// exits linger for exitCleanup.cleanupDelay, 5 minutes by default — so a
-		// fork on it means the kernel recycled the pid. Drop BOTH halves of the
-		// stale start time, the identity value and the display value, so they
-		// cannot disagree, and let applyStartTime restamp them below.
+		// Reached only when retireRecycledPredecessor could not tear the node
+		// down: exitByPid bails out when reparenting fails, leaving both the node
+		// and the pending entry in place. Fall back to the narrower start-time
+		// guard — drop BOTH halves of the stale value, identity and display, so
+		// they cannot disagree, and let applyStartTime restamp them below.
 		//
 		// Gated on a pending exit rather than on the node merely existing: an
 		// existing node alone only means some other path created it first, and
 		// wiping on that weaker signal would discard a good scan-recorded value
 		// whenever the on-demand read then fails.
 		//
-		// Scoped to the start time. This is NOT pid-reuse hardening: the node
-		// still carries the dead process's comm, cmdline and path, and the dead
-		// process's pendingExits entry still schedules a delayed exitByPid that
-		// will remove this live successor's node. Both belong to SUB-7846.
+		// On this path the node keeps the dead process's comm, cmdline and path.
+		// That is deliberate: a failed reparent must fall through to exactly
+		// today's behaviour rather than invent a partial teardown.
 		delete(pt.pidStartTimeNs, event.PID)
 		proc.StartTime = time.Time{}
 	}
@@ -304,6 +315,45 @@ func (pt *processTreeCreatorImpl) handleProcfsEvent(event conversion.ProcessEven
 		proc = pt.getOrCreateProcess(event.PID)
 	}
 
+	// Pid-reuse guard (L3): two procfs readings of the same process always yield
+	// the identical starttime ticks, so a different NON-ZERO value proves the
+	// kernel recycled this pid. No tolerance is needed, and none should be added.
+	//
+	// Never merge across incarnations. The overwrite-only-if-non-empty block below
+	// preserves any field the new process does not report, so the dead process's
+	// Cwd, Path and friends would otherwise survive into it — a node describing
+	// two processes at once. Tear the stale node down instead and rebuild from this
+	// event. A pending exit for the dead incarnation is consumed here too, which
+	// disarms its delayed deletion.
+	//
+	// The children are reparented by the teardown. Most belonged to the dead
+	// process, but not necessarily all: this fires up to a scan interval after the
+	// recycle, so the successor may already have forked. Detaching a live child is
+	// a worse-in-one-direction trade against retaining a dead parent, and it
+	// self-corrects on the child's next scan — see the doc's observable changes.
+	//
+	// A zero on either side proves nothing and falls through to today's merge, so
+	// this never fires for a pid the side map has no prior value for. That is also
+	// why a pending exit must NOT be the signal on this path: /proc lists zombies,
+	// so the same incarnation can legitimately have one.
+	if event.StartTimeNs != 0 {
+		if prev := pt.pidStartTimeNs[event.PID]; prev != 0 && prev != event.StartTimeNs {
+			if _, removed := pt.removeProcessNode(event.PID); removed {
+				delete(pt.pendingExits, event.PID)
+
+				// Re-apply the host-process policy the absent-node path above
+				// enforces. Rebuilding unconditionally would let a host procfs
+				// event materialise a node that a first sighting would refuse.
+				if pt.config.KubernetesMode && event.ContainerID == armotypes.HostContainerID {
+					return
+				}
+
+				proc = pt.getOrCreateProcess(event.PID)
+			}
+			// If the teardown failed, fall through and merge as before.
+		}
+	}
+
 	if event.PPID != 0 {
 		pt.UpdatePPID(proc, event)
 	}
@@ -348,6 +398,13 @@ func (pt *processTreeCreatorImpl) handleProcfsEvent(event conversion.ProcessEven
 func (pt *processTreeCreatorImpl) handleExecEvent(event conversion.ProcessEvent) {
 	pt.mutex.Lock()
 	defer pt.mutex.Unlock()
+
+	// An exec proves a live process holds this pid, so a pending exit on it
+	// belongs to a recycled predecessor. Exec already overwrites comm, cmdline and
+	// path, so the visible identity would self-correct — but the predecessor's
+	// delayed exit would still delete this live process's node, and its children
+	// would still be inherited. Retire it for those two reasons.
+	pt.retireRecycledPredecessor(event.PID)
 
 	proc, ok := pt.processMap.Load(event.PID)
 	if !ok {
@@ -397,10 +454,18 @@ func (pt *processTreeCreatorImpl) handleExecEvent(event conversion.ProcessEvent)
 
 // handleExitEvent handles exit events - now uses delayed removal via integrated exit manager
 func (pt *processTreeCreatorImpl) handleExitEvent(event conversion.ProcessEvent) {
+	// Read the boot clock BEFORE taking the tree lock. unix.ClockGettime is a raw
+	// syscall — x/sys does not route it through the vDSO the way the runtime does
+	// for time.Now — and exits are about as frequent as forks, thousands per second
+	// on a busy node. Holding pt.mutex across it would put syscall latency on the
+	// tree-wide write lock that every alert type reads through, which is the same
+	// mistake the fork path's start-time read avoids, for the same reason.
+	arrivalBootNs := pt.bootTimeNs()
+
 	pt.mutex.Lock()
 	defer pt.mutex.Unlock()
 
-	pt.addPendingExit(event)
+	pt.addPendingExit(event, arrivalBootNs)
 }
 
 func (pt *processTreeCreatorImpl) getOrCreateProcess(pid uint32) *armotypes.Process {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Ticket

- [SUB-7847](https://cyberarmor-io.atlassian.net/browse/SUB-7847) — fix the exit-manager data race on its stop channel (**shutdown** path)
- [SUB-7846](https://cyberarmor-io.atlassian.net/browse/SUB-7846) — harden the tree against process-id reuse (**recycle** path)

## Summary

**This PR carries two fixes to one mechanism — the process-tree exit-cleanup lifecycle in
`pkg/processtree/creator` — so you are approving two decisions, not one.**

| | Fix | Path |
|---|---|---|
| SUB-7847 | The cleanup loop and `Stop()` raced on the stop-channel field | shutdown |
| SUB-7846 | A recycled pid inherited the dead process's identity, and the dead process's delayed exit deleted the live successor's node | recycle |

They belong together because they are the same subsystem and the same window: **deferred
deletion.** The exit manager keeps an exited process's node for up to
`exitCleanup::cleanupDelay`, and both fixes are about that window — one is the shutdown of the
loop that drives it, the other is what happens when a pid is recycled inside it.

**Each commit is independently complete, independently correct, and independently revertable.**
They are deliberately **not** squashed:

> **`git checkout 21a4fed6` and run the race command below — you should see a clean baseline
> before the second commit lands on top of it.** I verified exactly that on a separate detached
> worktree: 0 race reports, all packages green. That is the entire reason for the two-commit
> shape, since the hardening touches concurrency-adjacent code in the same package and otherwise
> could not be distinguished from the pre-existing race.

Review order matters: **commit 1 first.**

---

## First fix — the exit-manager data race (SUB-7847)

`exitCleanupLoop` read the `exitCleanupStopChan` field in its `select` on **every iteration**
while `stopExitManager` wrote `nil` to that same field. Neither side synchronised.

**Every data race the detector reported in `pkg/processtree` was this one field pair** —
`exit_manager.go:41` write against `:67` read. Seven reports, five failing tests in the creator
package. Two further defects fell out of the same code, both reproduced rather than inferred:

- **`panic: close of closed channel`** — two concurrent `Stop()` calls could both pass the nil
  check and both reach the `select`'s `default` branch, so both closed the channel.
- **A goroutine leak** — a loop that read the *cleared* field rather than the *closed* channel
  blocked forever on a nil-channel receive. That killed the stop arm of its `select`, so the loop
  kept ticking, and kept mutating the tree, for the lifetime of the process. Which of the two
  happened was decided by the race.

### The fix, and one deliberate deviation from the ticket

`exitCleanupLoop` now takes the channel **as an argument** and never reads the field, so it holds
its own reference for its whole lifetime. Both lifecycle transitions are held under a dedicated
`exitCleanupMutex`, making check-and-close atomic.

**The ticket says "close the channel rather than nilling it". This closes *and* nils, on
purpose.** Dropping the nil would break the two pre-existing tests that pin
`exitCleanupStopChan == nil` after `Stop()` (`TestStartStop`, `TestExitManager_StartStop`) —
which would contradict the ticket's other requirement, that the fix be behaviour-preserving. The
race is eliminated because the loop no longer reads the field at all, so the nil is safe: it is
now purely the mutex-guarded "not running" flag that makes the manager restartable. **Both tests
pass unmodified.** Flagging it here rather than letting it pass silently.

A dedicated mutex rather than `pt.mutex`, because the tree lock is held across
`performExitCleanup` for its whole pass; reusing it would make shutdown wait on tree contention,
and the tree is shared by every alert type. The two locks are never held together, so there is no
order to invert.

### Honest scoping

`ProcessTreeManagerImpl.Stop()` currently has **no callers**, and `Start()` is called once — so
in production this race was effectively unreachable, and it surfaced as CI flakiness. **The
justification for fixing it first is the clean `-race` baseline commit 2 needs**, not a
production incident. Worth stating plainly rather than implying a field crash.

### One property to know before writing tests here

Closing the channel does not preempt an in-flight iteration, and when both `select` arms are
ready **the runtime chooses at random** — so a cleanup pass, occasionally two, can still run
after `Stop()` returns. The guarantee is prompt termination, not zero further work. A test
asserting "nothing was cleaned up after `Stop()`" is flaky by construction unless it lets the
loop observe the close first. This is not hypothetical: my own first version of that test failed
**49.4% of 1000 runs**, and **35% of full-package runs under this repo's exact PR CI
configuration** — worse than the race it fixes. Fixed with a settle window, then re-measured at
**0/1000 in both configurations.**

---

## Second fix — process-id reuse hardening (SUB-7846)

**The bug is confirmed and reproducible, not inferred.** The delayed-deletion half was found by
**@matthyx** reviewing #873 and reproduced on that PR's head. The reproductions are committed as
executable tests in `pkg/processtree/creator/pid_reuse_test.go`; each fails on the parent commit
for the specific reason quoted below.

The kernel recycles pids. Because the tree retains an exited process's node for up to
`cleanupDelay`, a pid can be held by a **live** process while the tree still holds the **dead**
one's node under it. Nothing noticed:

1. **The successor reported the dead process's identity.** `handleForkEvent` fills only *empty*
   fields, and a stale node is not empty, so a recycled pid kept the predecessor's `Comm`,
   `Cmdline`, `Path`, `Cwd`, `Uid` and `Gid`. **A runtime alert of any type could name the wrong
   command.** Fails with `expected "worker"` / `should not be "malware --evil"` / `should not be
   "/tmp/malware"`.
2. **The dead process's delayed exit deleted the live process's node.** `exitByPid` matches on pid
   alone, so cleanup removed whatever node held that pid by then — reparenting a running
   process's children around it and taking its start time with it. Fails with `Expected value not
   to be nil`.

Neither self-corrects where it matters: an alert emitted inside the window has already been
exported with the wrong command, and the deletion leaves children reparented around a process
that is alive. What *does* self-correct is field staleness on a pid that later execs or gets
rescanned — which is why likelihood is **medium, not high** — and `maxPendingExits` shortens the
real window to `min(cleanupDelay, time-to-cap)` rather than a flat five minutes.

### Three layers

Each is independent and each falls through to today's behaviour when its input is unknown. **No
layer ever *keeps* a node it cannot prove is newer** — retaining stale state is the harmful
direction; re-deleting is not.

| Layer | Signal | Needs a clock? |
|---|---|---|
| A fork or exec retires a pending-exit predecessor | The event itself | No |
| A delayed exit skips a node newer than the exit's arrival | `CLOCK_BOOTTIME` comparison | Yes |
| The procfs scan rebuilds a node whose start time changed | Start-time inequality | No |

A fork or exec **proves** a live incarnation holds the pid — a zombie can do neither — so a
pending exit must belong to a dead predecessor. Layer 1 needs no clock, which is why it is the
half that could ship independently of the start-time work.

Layer 1 is the shape matthyx proposed on the ticket, with one difference: his snippet forces
`ok = false` from inside the branch where a stale node was found; here the guard runs **before**
the lookup, so `ok` is false naturally and no stale `proc` pointer exists. That also closes a
case the in-branch position misses — a pending exit can outlive its node, and the recycled fork
then builds a fresh node the stale entry deletes at the next cleanup.
`TestPidReuse_ForkAfterExit_ConsumesPendingExitWithNoNode` fails if the guard is gated on an
existing node.

Layer 2 compares boot-relative against boot-relative only: the side map is `/proc` starttime
ticks × 10⁷, the arrival is `CLOCK_BOOTTIME`. **No wall clock enters the comparison.**
`pendingExit.Timestamp` and `pendingExit.StartTimeNs` keep their existing roles — cleanup ageing
and sort ordering — and `StartTimeNs` in particular is *not* a process start time at all, it is
the exit event's timestamp.

Layer 3 uses exact inequality: two procfs readings of one process yield identical ticks, so a
different non-zero value is proof, and no tolerance should ever be added. Its rebuild re-applies
the Kubernetes host-process policy that the first-sighting path enforces, which an unconditional
rebuild would bypass.

### ⚠️ The wrong fix that looks right

**Dropping the pending-exit entry alone is not the fix, and it is the tempting simplification:**

```go
// WRONG — passes the obvious tests, corrupts the tree more quietly
delete(pt.pendingExits, pid)
```

It does stop the delayed deletion and does let the successor's fields be written. But the dead
process's **children stay linked to the pid**, so the new process silently inherits them. The
tree then claims an unrelated live process is the parent of another process's children, and every
alert built from that branch carries the lie — harder to notice than the bug it replaces.

`retireRecycledPredecessor` therefore performs the **full teardown**, reparenting the children
away first. I verified the guard test genuinely catches a regression by temporarily substituting
the naive version: `TestPidReuse_ForkAfterExit_DoesNotInheritDeadChildren` fails with
`Should be empty, but was map[{ 101}:...]`, and the orphan-survival assertion fails too.
**Please do not "simplify" this back.**

### Why a pending exit is not the signal on the procfs path

`handleProcfsEvent` must **never** treat a pending exit as recycle proof: `/proc` lists zombies,
so a procfs event can legitimately belong to the same incarnation that already exited. The same
asymmetry applies to "the node already exists", which is a much weaker signal than it looks —
another path may simply have created the node first, and per the ticket an earlier version of the
start-time guard destroyed a correct scan-recorded value on exactly that basis. Every guard here
gates on a **pending exit** or a **changed start time**, never on mere existence.

### This is shared lifecycle — how existing behaviour was verified

`GetContainerProcessTree` serves the rule manager and every exporter, so this path sits behind
**every alert type**. That is why it is a separate commit from the schema and streaming work:
bundling it would make a detection regression indistinguishable from an attribution bug.

Preservation is pinned by controls, and **every guard was mutation-tested — deleting it must turn
a named test red**:

- `ProcfsSameStartTime_MergesAsToday` — an equal start time means the same process, so the refresh
  keeps today's merge semantics **and** the node's children.
- `DelayedExit_NormalExitStillDeletes` — an ordinary exit still removes its own node. **Without
  this, writing layer 2's comparison the wrong way round would leak every exited node forever and
  nothing else would catch it.**
- `DelayedExit_UnknownStartTimeStillDeletes` — the no-identity-data case stays byte-for-byte
  today's logic.
- `DelayedExit_LayerTwoKeepsNewerNodeWithoutRebuild` — reaches layer 2's keep-branch *without*
  layer 3 firing first, so the guard itself is under test rather than layer 3's teardown.
- `ExecAfterExit_RetiresPredecessor` — layer 1 on the exec path, with the exec arriving after the
  exit so the guard is not a no-op.
- `removeProcessNode` (the teardown extraction, shared by the exit path and the procfs rebuild so
  they cannot drift) landed with **all 24 exit-manager and reparenting tests green before layer 3
  used it**. It returns `false` when reparenting fails, and both callers then leave their own
  bookkeeping untouched, so the operation degrades to today's retry-on-the-next-tick rather than
  inventing a partial teardown.

### Cost

Under `pt.mutex` the additions are a map lookup and an integer comparison, and **no `/proc` read
is added**. The one syscall this work needs — `CLOCK_BOOTTIME` for layer 2 — is read in
`handleExitEvent` **before** the lock and passed into `addPendingExit`, because
`unix.ClockGettime` is a raw syscall rather than a vDSO call and exits are about as frequent as
forks. Same pattern, same reason, as the fork path's ~7.5 µs start-time read; this package has a
prior mutex-stall fix in its history.

### Three limitations documented rather than fixed

Both are bounded and self-healing, and both are written up in the feature doc so they are not
rediscovered as bugs:

- **Layer 1 cannot tell a recycle from a reordered exit.** "A fork proves a new incarnation" is a
  *kernel*-ordering argument, and the tracers do not preserve kernel order — fork, exec and exit
  are separate gadgets feeding one queue that is sorted only within a drain batch. A late exit is
  read as a recycle, which leaves a dead node in the tree rather than deleting a live one, and
  `sendExitEvents` re-synthesises the exit within one pid-scan interval (5 s).
- **Layer 3 declines when the side map holds no prior value**, so on that path the scan *merges*
  into the dead node and layer 2 can then keep a node that was never rebuilt. Closing it would
  require firing layer 3 on a zero prior value, which cannot distinguish "recycled" from "first
  ever reading" and would tear down healthy nodes on first sight.
- **A fork processed *before* the exit it follows defeats all three layers**, and both original
  bugs survive it — raised by @matthyx on review and confirmed against the implementation. Layer 1
  has no pending exit to retire yet; layer 2 sees the successor's real start time, which precedes
  the late exit's arrival; layer 3 finds the side map already matching. The window is roughly one
  drain batch of the event queue, so a pid would have to wrap the 32,768-entry space in
  milliseconds. Left documented rather than fixed, because closing it means making the guards
  depend on event ordering they cannot verify.

### Observable changes

The first three are recycle-scenario only:

- A fork or exec on a pid with a pending exit reparents the dead process's children
  **immediately** rather than after the cleanup delay.
- A delayed exit no longer deletes a node whose recorded creation postdates the exit's arrival.
- A procfs start-time change rebuilds the node instead of merging two incarnations. Because the
  rebuild reparents every child, a child the successor forked before the scan noticed is detached
  to init — a trade against today's retaining of dead children, self-correcting on the child's
  next scan.
- `forceCleanupOldest` loses its second, redundant pass over the same pending exits. That pass was
  silent while a repeat call always found the node already gone; now that a guard can keep a node
  and consume its pending entry, it would log a warning for every node kept.

---

## AI Review

Reviewed by **Claude Opus 5**, one independent fresh-context pass per commit, each in a clean
subagent applying `armosec-shared-rules:code-review-standards`, with no knowledge of the other's
findings.

**Commit 1 — verdict: approve.** The reviewer reproduced the race on the parent, confirmed
`exitCleanupStopChan` is touched at exactly five sites all under `exitCleanupMutex`, confirmed no
lock-ordering hazard against `pt.mutex`, and confirmed double-close is structurally impossible.
It independently quantified my first version of `StopHaltsCleanupLoop` at **494 failures in 1000
runs** and **35% of full-package runs under the PR CI config**, proving the flake with an
instrumented build (261 post-close cleanup passes in 500 runs) — then measured the fixed version
at **0/1000 in both configurations**. Remaining findings were comment accuracy, all applied: two
comments still described the deleted `select`/`default` in the present tense, and the field's
"non-nil exactly while the loop is running" claim was false in both directions.

**Commit 2 — verdict: approve with changes. All three blocking findings are fixed:**

1. **A `clock_gettime` syscall was added under `pt.mutex`** — `addPendingExit` called
   `pt.bootTimeNs()`, and its only caller holds the tree lock. `unix.ClockGettime` is a raw
   syscall, not vDSO. My commit and doc both asserted "nothing new under the lock", which was
   **false as written** — and this was the one constraint I had singled out as the thing to
   preserve. **Fixed** by hoisting the read above the lock in `handleExitEvent`, matching the fork
   path.
2. **Layer 2's protective branch had zero coverage** — deleting the guard entirely left the suite
   green, because the test named for it introduced the successor via a procfs event, so layer 3
   fired first and consumed the pending entry; the assertion was satisfied by layer 3's delete.
   **Fixed** with `DelayedExit_LayerTwoKeepsNewerNodeWithoutRebuild`, which keeps the side map
   empty for the predecessor so layer 3 declines. Deleting the guard now fails it.
3. **Layer 1's exec path was untested** — deleting the exec-path retire left the suite green.
   **Fixed** with `ExecAfterExit_RetiresPredecessor`. Deleting it now fails.

Also applied from that review: the Kubernetes host-process policy is re-applied on layer 3's
rebuild; `forceCleanupOldest`'s redundant second pass is removed (my guard turned it into a
warning generator); and three inaccurate doc claims are corrected — layer 1's unqualified "the
event is the proof", layer 3's "its children belonged to the dead process", and the missing
not-covered entry for layer 3 declining on a zero prior value.

The reviewer separately confirmed `removeProcessNode` is a **faithful extraction**, diffing it
line-by-line against the original teardown: ordering preserved, `pendingExit.Children` populated
on both the success and reparent-failure paths, the reparent-failure early return preserved, and
the node-absent path left verbatim in `exitByPid`. It also confirmed the guard arithmetic (every
unknown falls through to deletion; a false positive is impossible for the same incarnation since
the tick truncation rounds *down*), clock-domain discipline, and that all new call sites hold the
write lock.

Findings deliberately not actioned, as the reviewer classified them non-blocking and
self-healing: the layer-1 reorder ambiguity and the layer-3 un-rebuilt-node path are documented
above and in the feature doc instead. Two Warning strings were renamed
`exitByPid:` → `removeProcessNode:`; nothing in the repo greps them, but a Loki query pinned to
the old text would stop matching.

## Verification

**macOS cannot build this package** — `inspektor-gadget/pkg/utils/host` excludes darwin and
everything under `pkg/processtree` imports it transitively. Every run below is in the Linux
container:

```bash
docker run --rm -v "$PWD":/src -v "$(go env GOMODCACHE)":/go/pkg/mod -w /src \
  -e GOFLAGS=-mod=mod golang:1.25 sh -c 'go vet ./pkg/processtree/... && go test -race ./pkg/processtree/...'
```

### The `-race` position, at each commit

| Revision | Race reports | Creator package |
|---|---|---|
| `8866b6c8` (base) | **7** — all `exit_manager.go:41` write / `:67` read | 5 tests failing |
| `21a4fed6` (commit 1) | **0** | green |
| `dd16818c` (commit 2) | **0** | green |

Base failures were `TestExitManager_StartStop`, `TestExitManager_ThreadSafety`,
`TestHandleExitEvent`, `TestConcurrentAccess`, `TestReparentingIntegration`. **Commit 1 was
verified on its own detached worktree**, not merely as a prefix of the branch.

`go vet ./pkg/processtree/...` clean at both commits. Package green under `-race -count=2`; the
lifecycle tests additionally stressed at `-count=25` without `-race` and `-count=10` with it.

### Full suite

`go test ./pkg/...` matches the `8866b6c8` baseline exactly: 52 packages ok, and the only
failures are the 19 pre-existing environmental ones — 18 `pkg/containerwatcher/v2/tracers` field
tests plus `pkg/validator/TestCheckPrerequisites` — which **fail identically on the base
commit**. All of `pkg/processtree/...` is green.

### CI notes

- **The race detector never runs on pull requests in this repo.** `CGO_ENABLED: 0` is hardcoded at
  `.github/workflows/pr-created.yaml:19`, gating the "Test race conditions" step at
  `.github/workflows/go-basic-tests.yaml:98` off, so CI takes the non-race path. That is SUB-7848,
  and it is why a real data race survived unnoticed here. **The container runs above are the race
  evidence for this PR.** Note the consequence for commit 1's regression guard:
  `TestExitManager_StopIsRaceFreeAgainstCleanupLoop` can only fail under `-race`, so on the PR
  pipeline it is near-vacuous by design.
- `build-and-push-image` is expected to fail: it gets no Quay secrets on a cross-fork pull
  request. Structural for fork-based contribution, not introduced by this branch.

## Docs

- **New** `docs/features/process-tree-exit-manager-lifecycle.md` — the exit manager's lifecycle and
  concurrency contract, previously undocumented: the deferred-deletion model and its
  `min(cleanupDelay, time-to-cap)` window, close-is-the-signal versus nil-is-the-restartable-flag,
  why a dedicated mutex, and the non-instantaneous `Stop()` property.
- **New** `docs/features/process-id-reuse-hardening.md` — the three layers, the wrong-fix trap, the
  clock-domain rule, the clock-read-outside-the-lock constraint, and what each layer deliberately
  does *not* cover.
- **Updated** `docs/features/process-start-time.md` — its blockquote described this reuse hazard as
  unfixed and tracked elsewhere. It now points at the hardening doc and records what the narrower
  start-time guard still earns: keeping the identity and display halves consistent, and acting as
  the fallback when a teardown cannot complete.
