### PR TITLE
fix(rulebinding): exact namespace match and skip invalid selectors

### DIFF
--- a/pkg/rulebindingmanager/cache/cache.go
+++ b/pkg/rulebindingmanager/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -411,14 +410,22 @@ func (c *RBCache) addPod(ctx context.Context, pod *corev1.Pod) []rulebindingmana
 		rbName := uniqueName(&rb)
 
 		// check pod selectors
-		podSelector, _ := metav1.LabelSelectorAsSelector(&rb.Spec.PodSelector)
+		podSelector, err := metav1.LabelSelectorAsSelector(&rb.Spec.PodSelector)
+		if err != nil {
+			logger.L().Warning("RBCache - failed to parse pod selector", helpers.String("ruleBiding", uniqueName(&rb)), helpers.Error(err))
+			continue
+		}
 		if !podSelector.Matches(labels.Set(pod.GetLabels())) {
 			// pod selectors doesnt match
 			continue
 		}
 
 		// check namespace selectors
-		nsSelector, _ := metav1.LabelSelectorAsSelector(&rb.Spec.NamespaceSelector)
+		nsSelector, err := metav1.LabelSelectorAsSelector(&rb.Spec.NamespaceSelector)
+		if err != nil {
+			logger.L().Warning("RBCache - failed to parse ns selector", helpers.String("ruleBiding", uniqueName(&rb)), helpers.Error(err))
+			continue
+		}
 		nsSelectorStr := nsSelector.String()
 		if len(nsSelectorStr) != 0 {
 			// get related namespaces
@@ -427,7 +434,7 @@ func (c *RBCache) addPod(ctx context.Context, pod *corev1.Pod) []rulebindingmana
 				logger.L().Warning("RBCache - failed to list namespaces", helpers.String("ruleBiding", uniqueName(&rb)), helpers.String("nsSelector", nsSelectorStr), helpers.Error(err))
 				continue
 			}
-			if !strings.Contains(namespaces.String(), pod.GetNamespace()) {
+			if !namespaceListHasName(namespaces, pod.GetNamespace()) {
 				// namespace selectors dont match
 				continue
 			}

--- a/pkg/rulebindingmanager/cache/helpers.go
+++ b/pkg/rulebindingmanager/cache/helpers.go
@@ -10,10 +10,26 @@ import (
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// namespaceListHasName reports whether name is an exact member of list.Items.
+// Do not use strings.Contains(list.String(), name): NamespaceList.String() is a
+// debug dump, so substrings (e.g. "dev" in "devel") falsely match.
+func namespaceListHasName(list *corev1.NamespaceList, name string) bool {
+	if list == nil {
+		return false
+	}
+	for i := range list.Items {
+		if list.Items[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 func uniqueNameToName(n string) (string, string) {
 	if str := strings.Split(n, "/"); len(str) == 2 {

--- a/pkg/rulebindingmanager/cache/helpers_test.go
+++ b/pkg/rulebindingmanager/cache/helpers_test.go
@@ -11,6 +11,25 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+func TestNamespaceListHasName(t *testing.T) {
+	list := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: metav1.ObjectMeta{Name: "devel"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "production"}},
+		},
+	}
+
+	assert.True(t, namespaceListHasName(list, "devel"))
+	assert.True(t, namespaceListHasName(list, "production"))
+	// Substring of "devel" / "production" must not match (regression for
+	// strings.Contains(namespaces.String(), ns)).
+	assert.False(t, namespaceListHasName(list, "dev"))
+	assert.False(t, namespaceListHasName(list, "prod"))
+	assert.False(t, namespaceListHasName(list, "missing"))
+	assert.False(t, namespaceListHasName(nil, "devel"))
+	assert.False(t, namespaceListHasName(&corev1.NamespaceList{}, "devel"))
+}
+
 func TestResourcesToWatch(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
## Overview
Fix rulebinding cache matching in `pkg/rulebindingmanager/cache`
fixes https://github.com/kubescape/operator/issues/401

- Match namespaces by exact name instead of `strings.Contains(namespaces.String(), …)` (avoids `dev` matching `devel`)
- Skip bindings when `LabelSelectorAsSelector` fails instead of calling `Matches` on nil

## How to Test
- Unit: `TestNamespaceListHasName`
- Binding with `namespaceSelector` on `devel` only → pod in `devel` matches, pod in `dev` does not

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pod and namespace label selector validation.
  - Invalid rule bindings are now skipped with parsing errors logged.
  - Namespace matching now uses exact names, preventing incorrect substring matches.
  - Added safe handling for empty or unavailable namespace lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->