### PR TITLE
feat(networkstream): process attribution on the network stream (SUB-7786)

### DIFF
--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -97,6 +97,11 @@ per-entity event maps, so the delivered value is immune to everything the
 producer does next. Both sends happen outside the lock, and the 100 ms sleep is
 **deleted rather than shortened** — there is no shared state left to race on.
 
+The channel send stays blocking, so a slow consumer applies backpressure rather
+than losing traffic, but it now selects on context cancellation as well. That was
+impossible while the send held the lock; without it a stalled consumer would pin
+the flush goroutine past shutdown.
+
 ### Lock discipline
 
 This file has a history of mutex stalls on this path, so the bound is part of the

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -126,9 +126,10 @@ fresh nodes per branch, so event trees are not shared with the process tree's
 live map — only with its 1-minute LRU entry, which nothing writes to after
 construction. Anything that would modify a tree copies it first.
 
-Transient memory outside the lock is one capped tree copy per distinct process —
-at most connections × p90 tree size ≈ 283 × 5.1 KB ≈ 1.4 MB worst case, freed
-after the HTTP send.
+Transient memory outside the lock is one capped tree copy per *selected* process,
+so it is bounded by `maxProcessTreeBytes` (2.5 MiB) rather than by the connection
+count, and freed after the HTTP send. `capTreeCopy` runs only for candidates that
+fit the budget.
 
 The wire copy is derived **before** the snapshot goes on the channel. Once the
 consumer has it, its maps are the consumer's; reading them afterwards would depend
@@ -201,46 +202,71 @@ liveness probes) can reach that.
 | Mean connections per batch | ~42 (prod-us ~32) | `network_reputation_events_in_total` ÷ topic message count |
 | ⇒ bytes per connection, no tree | ~530 B of JSON | derived from the two above |
 | Largest batch ever observed | 283 connections | SUB-7850 |
-| Tree size | ~2 KB median, ~7 KB p90 | SUB-7850 (note: the implementation plan says 5.1 KB p90, the epic plan's ~2 MB ÷ 283 implies ~7 KB — the larger figure is used here) |
+| Tree size | ~4.3 KB marshalled for a fully-populated 10-node chain | measured here (the plan documents give ~2 KB median and disagree on p90 — 5.1 KB vs the ~7 KB implied by its own ~2 MB ÷ 283) |
 
-`maxProcessTreeBytes` is **2.5 MiB** of estimated tree bytes. Measured against the
-worst case it exists for — *every* connection from a distinct process, so trees
-scale 1:1 with connections:
+`maxProcessTreeBytes` is **2.5 MiB** of estimated tree bytes. Measured end to end
+against the worst case it exists for — *every* connection from a distinct process,
+so trees scale 1:1 with connections — with production-weight connection entries
+(530 B) included:
 
-| Connections (all distinct processes) | Tree size | Trees shipped | JSON | after base64 |
-|---|---|---|---|---|
-| 42 (the mean) | 7 KB | all 42 | 0.28 MB | 0.37 MB |
-| **283 (observed worst)** | **7 KB** | **all 283** | 1.87 MB | **2.50 MB — 48% of limit** |
-| 500 | 7 KB | 356 (budget binds) | 2.38 MB | 3.17 MB |
-| 4000 | 7 KB | 356 | 2.89 MB | 3.85 MB |
-| 4000 | 2 KB | 1069 | 2.90 MB | 3.86 MB |
+| Connections (all distinct processes) | Trees shipped | JSON | after base64 |
+|---|---|---|---|
+| 42 (the mean) | all 42 | 0.20 MiB | 0.26 MiB |
+| **283 (observed worst)** | **all 283** | 1.33 MiB | **1.77 MiB — 35% of limit** |
+| 500 | all 500 | 2.35 MiB | 3.13 MiB |
+| 1000 | 513 (budget binds) | 2.70 MiB | 3.60 MiB |
+| 4000 | 513 | 4.50 MiB | **6.01 MiB — over the limit, on entries alone** |
 
-The load-bearing row is the third: **the budget must not bind on traffic
-production actually produces**, or it degrades attribution on exactly the busiest
-nodes. A tighter 1.5 MiB was tried first and rejected — it binds at 213 of 283
-trees, while the payload there is under half the limit.
-`TestBuildWireStream_ObservedWorstCaseFitsBudget` pins this, and fails at 1.5 MiB.
+Two load-bearing rows. The **283** row: the budget must not bind on traffic
+production actually produces, or it degrades attribution on exactly the busiest
+nodes — a tighter 1.5 MiB was tried first and rejected, because it clips 70 of those
+283 trees while the payload is barely a third of the limit.
+`TestBuildWireStream_ObservedWorstCaseFitsBudget` pins that and fails at 1.5 MiB.
+The **4000** row is the residual below: past ~3,300 connections the entries alone
+exceed the limit no matter how tightly trees are bounded.
 
-- **A byte budget, not a tree count.** Tree size varies ~3.5× even with the
-  command-line cap (~2 KB median, ~7 KB p90, ~12 KB for a deep chain of capped
-  command lines), so no count bounds the payload. The estimator counts the command
-  line at its *capped* length and overestimates real marshalled size by 1–6% —
-  conservative in the safe direction.
+- **A byte budget, not a tree count.** Tree size is not uniform — depth varies,
+  fields are variable-length, and JSON escaping inflates some content ~6× (below),
+  so no count bounds the payload. The estimator overestimates real marshalled size
+  by ~19% for realistic trees, and `TestEstimateTreeBytes_NeverUnderestimates`
+  enforces that it never goes the other way.
+
+#### JSON escaping is what makes the estimate honest
+
+`len(s)` is **not** what reaches the wire, and getting this wrong silently voided
+the bound. `encoding/json` escapes `"` and `\`, every control byte, and — because
+`Marshal` enables HTML escaping — `<`, `>` and `&`, which real command lines are
+full of (`sh -c 'cmd > /dev/null 2>&1'`). Invalid UTF-8 is replaced byte-for-byte
+with `�`, and process argv is arbitrary kernel bytes, not guaranteed UTF-8.
+Each such byte costs up to **six** where `len()` counts one.
+
+Charging `len()` therefore let a payload six times the estimate pass the budget: 629
+processes with 1 KB of non-UTF-8 argv each estimated at 29% of the budget, dropped
+nothing, logged nothing, and produced **5.37 MB after base64** — rejected by the
+broker, so the node lost its entire interval of traffic. `escapedLen` charges the
+true escaped cost (rounding every escape up to 6 bytes), which is what makes
+`maxProcessTreeBytes` an actual bound. Note this is reachable deliberately by
+anyone able to exec in any container on the node, which made it a detection-evasion
+primitive rather than merely a bug.
 - **Connections are never dropped** — that is the data loss this change exists to
   fix. Only trees are, and the refs stay on the connections, so pid identity
   survives and `ProcessTreeFor` returns nil for them as specified.
-- **Ranked by connection count**, ties broken on the ref. A process that reached
-  many endpoints is both the most expensive attribution to lose and the shape
-  reputation cares about most; tie-breaking on the ref keeps the payload
-  independent of map iteration order.
-- At p90 tree size the budget is ~360 trees and at median ~1280 — above anything
-  yet observed, so it is a safety valve rather than a routine limiter.
+- **Ranked smallest-tree-first**, ties broken on the ref. That maximises the number
+  of processes keeping an attributable tree, which is the best objective available
+  given the sensor cannot know which process will matter. Ranking by connection
+  count was tried and rejected: a low-and-slow beacon opens exactly *one*
+  connection per interval, so it would sort last and lose its tree first — the
+  precise case reputation attribution exists to catch. The ref tie-break keeps the
+  shipped set independent of map iteration order, which
+  `TestSelectProcessTrees_IsDeterministic` pins.
+- The budget holds ~513 fully-populated 10-node chains — 1.8x the observed worst
+  batch — so it is a safety valve rather than a routine limiter.
 
 **Residual, deliberately not fixed here.** With trees bounded, the connection
-*entries* alone would still breach the limit somewhere around 2,500–4,400
-connections (the range is per-entry richness: ~530 B derived from production versus
-~300 B for a lean entry). That is 9–16× the observed worst batch. The fix for that
-regime is splitting the message — as the container profile does on HTTP 413,
+*entries* alone breach the limit at roughly **3,300 connections** at the
+production-derived ~530 B per entry — 11x the observed worst batch, and measured at
+6.01 MiB for 4,000. No tree budget can help there. The fix for that regime is
+splitting the message — as the container profile does on HTTP 413,
 `docs/features/container-profile-split-on-413.md` — not dropping connections. The
 logging below is what would tell us it is being approached.
 
@@ -257,9 +283,9 @@ and it is bounded above by 1.
 
 Two log lines make it answerable after rollout:
 
-- `NetworkStream - process tree budget exceeded` — with `distinctProcesses`,
+- `NetworkStream - process tree budget exceeded` — with `processesWithTrees`,
   `treesShipped`, `treesDropped`, `connectionsWithoutTree` and the byte totals.
-  Fires only when the budget binds.
+  Fires once per flush, and only when the budget binds.
 - `NetworkStream - large payload` — above `payloadWarnBytes` (2 MiB), with the
   marshalled size, entity, connection and tree counts. Reports the tail
   approaching the limit; quiet at the ~30 KB fleet mean.

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -175,6 +175,69 @@ are reading. `copyCappedProcess` is read-only instead, normalising the deprecate
 recursive walk here is bounded by `maxTreeDepth` (64), so a malformed or cyclic
 tree costs a truncated payload rather than the agent's stack.
 
+### The process-tree budget
+
+Attribution changed **what sizes the payload**. Before, the batch key collapsed
+every process reaching one endpoint into a single entry carrying no tree, so size
+tracked *distinct endpoints*. Now the key splits per process and each distinct
+process contributes a tree, so size tracks **distinct processes that connected
+during the interval** — and nothing bounded that.
+
+The original payload analysis (SUB-7850) modelled bytes per connection at a fixed
+count of 283 connections. That is exactly the quantity the key change stops
+holding fixed, so the multiplier on connection *count* was never budgeted.
+
+Measured, with ~2 KB trees and all connections to one endpoint:
+
+| Distinct processes | JSON | after base64 (×1.333) |
+|---|---|---|
+| 283 | 0.35 MB | 0.47 MB |
+| 1000 | 1.25 MB | 1.66 MB |
+| 4000 | 4.99 MB | **6.65 MB — over the 5 MiB limit** |
+
+Exceeding the limit is not a graceful degradation: `sendNetworkEvent` gets a
+non-2xx, returns an error, `Start()` logs it and drops the snapshot. **The node
+loses its entire interval of traffic** — no retry, no split. A node with heavy
+short-lived process churn (a cron loop shelling out, a CI runner, exec-based
+liveness probes) can reach that.
+
+So `maxProcessTreeBytes` (1.5 MiB of estimated tree bytes) bounds the trees:
+
+- **A byte budget, not a tree count.** Tree size varies ~2.5× even with the
+  command-line cap (~2 KB median, ~5 KB p90, ~12 KB for a deep chain of capped
+  command lines), so no count bounds the payload.
+- **Connections are never dropped** — that is the data loss this change exists to
+  fix. Only trees are, and the refs stay on the connections, so pid identity
+  survives and `ProcessTreeFor` returns nil for them as specified.
+- **Ranked by connection count**, ties broken on the ref. A process that reached
+  many endpoints is both the most expensive attribution to lose and the shape
+  reputation cares about most; tie-breaking on the ref keeps the payload
+  independent of map iteration order.
+- At p90 tree size the budget is ~300 trees, above the largest message observed in
+  production (283 connections, so at most 283 distinct processes) — a safety valve,
+  not a routine limiter.
+
+### Observability, because the real distribution is not knowable yet
+
+How often a real node exceeds the budget **cannot be measured from today's data**:
+the current sensor strips trees and puts no process identity on the wire, so
+distinct-processes-per-batch does not exist in any message. Fleet-wide, today's
+messages average ~30 KB (`pulsar_average_msg_size` on
+`persistent://armo/internal/network-stream-v1`, ~175× under the limit), which says
+the baseline is comfortable but nothing about the new multiplier.
+
+Two log lines make it answerable after rollout:
+
+- `NetworkStream - process tree budget exceeded` — with `distinctProcesses`,
+  `treesShipped`, `treesDropped`, `connectionsWithoutTree` and the byte totals.
+  Fires only when the budget binds.
+- `NetworkStream - large payload` — above `payloadWarnBytes` (2 MiB), with the
+  marshalled size, entity, connection and tree counts. Reports the tail
+  approaching the limit; quiet at the ~30 KB fleet mean.
+
+If the first line turns out to fire routinely, the budget should become
+configurable rather than being raised blind.
+
 ### Command-line cap
 
 Each node's `Cmdline` is capped at **1024 bytes on the wire copy only**, with a

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -248,6 +248,15 @@ true escaped cost (rounding every escape up to 6 bytes), which is what makes
 `maxProcessTreeBytes` an actual bound. Note this is reachable deliberately by
 anyone able to exec in any container on the node, which made it a detection-evasion
 primitive rather than merely a bug.
+
+Two further accounting gaps were closed after CodeRabbit review. A child's `comm` is
+emitted **twice** — as its own field and inside the parent's `childrenMap` key, which
+`CommPID.MarshalText` renders as `comm␟pid` — so it is now charged twice, together with
+the key's structural bytes; and `containerID` was charged with a bare `len()`. Neither
+was reachable in production: comm is only ever 15 bytes because every source is a kernel
+`TASK_COMM_LEN` buffer, and container IDs are hex. But the estimate must not rest on an
+invariant nothing in this repo enforces — with an unbounded comm the old accounting ran
+**48% under**, and a bound that depends on an unenforced assumption is not a bound.
 - **Connections are never dropped** — that is the data loss this change exists to
   fix. Only trees are, and the refs stay on the connections, so pid identity
   survives and `ProcessTreeFor` returns nil for them as specified.

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -241,15 +241,19 @@ so trees scale 1:1 with connections — with production-weight connection entrie
 | **283 (observed worst)** | **all 283** | 1.33 MiB | **1.77 MiB — 35% of limit** |
 | 500 | 461 (budget binds) | 2.19 MiB | 2.92 MiB |
 | 1000 | 461 | 2.49 MiB | 3.31 MiB |
-| 4000 | 461 | 4.29 MiB | **5.72 MiB — over the limit, on entries alone** |
+| 4000 | 461 | 3.93 MiB | **5.24 MiB — over the limit** |
+
+Tree bytes are measured; entry bytes are **modelled** at the production-derived 530 B,
+not measured, so the two are added rather than read off one payload — see the residual
+section for why that distinction matters.
 
 Two load-bearing rows. The **283** row: the budget must not bind on traffic
 production actually produces, or it degrades attribution on exactly the busiest
 nodes — a tighter 1.5 MiB was tried first and rejected, because it clips 70 of those
 283 trees while the payload is barely a third of the limit.
 `TestBuildWireStream_ObservedWorstCaseFitsBudget` pins that and fails at 1.5 MiB.
-The **4000** row is the residual below: past ~3,000 connections the entries alone
-exceed the limit no matter how tightly trees are bounded.
+The **4000** row is the residual below: with the tree budget saturated, the message
+exceeds the limit at roughly 3,000 connections.
 
 - **A byte budget, not a tree count.** Tree size is not uniform — depth varies,
   fields are variable-length, and JSON escaping inflates some content ~6× (below),
@@ -306,12 +310,37 @@ with distinct processes even though the payload is trimmed on the way out. Cappi
 would mean dropping connections, which is the data loss this change exists to fix, so
 the honest position is that it is unbounded and monitored rather than bounded.
 
-Second, the connection *entries* alone breach the message limit at roughly **3,000
-connections** at the production-derived ~530 B per entry — 10x the observed worst
-batch, and measured at 5.72 MiB for 4,000. No tree budget can help there. The fix for that regime is
-splitting the message — as the container profile does on HTTP 413,
-`docs/features/container-profile-split-on-413.md` — not dropping connections. The
-logging below is what would tell us it is being approached.
+Second, connection volume alone can exceed the message limit. Be precise about which
+number means what, because the difference decides what an operator should do:
+
+| | connections |
+|---|---|
+| Breach **with the tree budget saturated** (today's configuration) | ~3,000 |
+| Breach from connection **entries alone**, if trees took no space at all | ~7,400 |
+
+The usable budget is 3.75 MiB of JSON (5 MiB after base64's x1.333). At 4,000
+connections the entries are 4,000 x 530 B = 2.02 MiB and the saturated trees are
+~1.91 MiB; back the trees out and 3.75 - 1.91 leaves room for ~2,900 entries, which is
+where the ~3,000 comes from. Entries alone would not breach until 3,932,160 / 530 =
+~7,400.
+
+**So the tree budget IS a lever in that regime** — trees are roughly half the payload,
+and tightening `maxProcessTreeBytes` moves the breach point out, toward ~7,400 as the
+budget approaches zero. That is the fastest thing to reach for during an incident: no
+protocol change, no backend coordination.
+
+Splitting the message remains the better long-term fix, because tightening the budget
+buys headroom by shipping fewer process trees — the attribution this feature exists to
+deliver — whereas splitting keeps all of it. One prerequisite before anyone builds it:
+the container-profile precedent
+(`docs/features/container-profile-split-on-413.md`) reacts to a **synchronous** HTTP 413
+from storage's `QueueManager`. This path posts elsewhere, handles no 413 anywhere, and
+the 5 MiB cap is a broker limit whose enforcement point is unverified (SUB-7850). If it
+is enforced downstream at the broker, the sensor sees `200 OK` and never learns, so
+reactive splitting is unavailable and the split must be decided before the first send.
+Settle that before designing.
+
+The logging below is what would tell us any of this is being approached.
 
 ### Observability, because the real distribution is not knowable yet
 

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -58,9 +58,16 @@ The key now appends the ref:
 | Attributed DNS query | `evil.example.com./101/5000000000` |
 
 **Appended, never reordered.** An unattributed key stays byte-identical to the
-pre-attribution format, and an attributed key always carries two more components,
-so the two can never collide. First-writer-wins is retained for the *same*
-process, so a chatty process does not inflate the batch.
+pre-attribution format. For IP connections the two forms cannot collide: the
+address, port and protocol components are structured, so an attributed key always
+carries exactly two more of them. For DNS the name is unstructured, so an
+unattributed query for a name that itself ends in `/<pid>/<startTimeNs>` would
+collide with an attributed query for the name's prefix, and one of the two records
+would be dropped. Contrived, and it costs one record rather than corrupting
+attribution, but it is not impossible the way the IP case is.
+
+First-writer-wins is retained for the *same* process, so a chatty process does not
+inflate the batch.
 
 Accepted consequence: an attributed and an unattributed connection to one
 endpoint become two entries. The traffic-view write path collapses them to one
@@ -122,6 +129,17 @@ construction. Anything that would modify a tree copies it first.
 Transient memory outside the lock is one capped tree copy per distinct process —
 at most connections × p90 tree size ≈ 283 × 5.1 KB ≈ 1.4 MB worst case, freed
 after the HTTP send.
+
+The wire copy is derived **before** the snapshot goes on the channel. Once the
+consumer has it, its maps are the consumer's; reading them afterwards would depend
+on that consumer never writing to what it receives.
+
+The table above covers the flush only. `eventsStorageMutex` is also held by
+`handleNetworkEvent` across `buildNetworkEvent`, which calls `ResolveIPAddress`
+and — on a cache miss — an unbounded `net.LookupAddr`. That is pre-existing and
+untouched here (this change strictly reduces flush-side contention), but it is the
+larger contributor to hold time on that mutex and should not be mistaken for
+covered ground.
 
 ## The wire copy (`wire.go`)
 

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -247,6 +247,14 @@ Tree bytes are measured; entry bytes are **modelled** at the production-derived 
 not measured, so the two are added rather than read off one payload — see the residual
 section for why that distinction matters.
 
+This is why the 4000 row exceeding the limit does **not** contradict
+`TestBuildWireStream_EscapeHeavyPayloadStaysUnderLimit` and
+`TestBuildWireStream_OverBudgetDropsTreesNotConnections`, which drive comparable process
+counts and assert the payload stays *under* 5 MiB. Those tests build synthetic events
+carrying only a ref and a key — roughly 94 B each — where a production connection entry
+is ~530 B. The tests bound what the code emits; the table adds the real-world entry
+weight on top. Neither is a failing bound.
+
 Two load-bearing rows. The **283** row: the budget must not bind on traffic
 production actually produces, or it degrades attribution on exactly the busiest
 nodes — a tighter 1.5 MiB was tried first and rejected, because it clips 70 of those

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -187,25 +187,45 @@ The original payload analysis (SUB-7850) modelled bytes per connection at a fixe
 count of 283 connections. That is exactly the quantity the key change stops
 holding fixed, so the multiplier on connection *count* was never budgeted.
 
-Measured, with ~2 KB trees and all connections to one endpoint:
-
-| Distinct processes | JSON | after base64 (×1.333) |
-|---|---|---|
-| 283 | 0.35 MB | 0.47 MB |
-| 1000 | 1.25 MB | 1.66 MB |
-| 4000 | 4.99 MB | **6.65 MB — over the 5 MiB limit** |
-
 Exceeding the limit is not a graceful degradation: `sendNetworkEvent` gets a
 non-2xx, returns an error, `Start()` logs it and drops the snapshot. **The node
 loses its entire interval of traffic** — no retry, no split. A node with heavy
 short-lived process churn (a cron loop shelling out, a CI runner, exec-based
 liveness probes) can reach that.
 
-So `maxProcessTreeBytes` (1.5 MiB of estimated tree bytes) bounds the trees:
+#### Calibration, from measured production traffic
 
-- **A byte budget, not a tree count.** Tree size varies ~2.5× even with the
-  command-line cap (~2 KB median, ~5 KB p90, ~12 KB for a deep chain of capped
-  command lines), so no count bounds the payload.
+| Input | Value | Source |
+|---|---|---|
+| Mean message on the topic | 29 KB (prod-us 32 KB) | `pulsar_average_msg_size` on `network-stream-v1` |
+| Mean connections per batch | ~42 (prod-us ~32) | `network_reputation_events_in_total` ÷ topic message count |
+| ⇒ bytes per connection, no tree | ~530 B of JSON | derived from the two above |
+| Largest batch ever observed | 283 connections | SUB-7850 |
+| Tree size | ~2 KB median, ~7 KB p90 | SUB-7850 (note: the implementation plan says 5.1 KB p90, the epic plan's ~2 MB ÷ 283 implies ~7 KB — the larger figure is used here) |
+
+`maxProcessTreeBytes` is **2.5 MiB** of estimated tree bytes. Measured against the
+worst case it exists for — *every* connection from a distinct process, so trees
+scale 1:1 with connections:
+
+| Connections (all distinct processes) | Tree size | Trees shipped | JSON | after base64 |
+|---|---|---|---|---|
+| 42 (the mean) | 7 KB | all 42 | 0.28 MB | 0.37 MB |
+| **283 (observed worst)** | **7 KB** | **all 283** | 1.87 MB | **2.50 MB — 48% of limit** |
+| 500 | 7 KB | 356 (budget binds) | 2.38 MB | 3.17 MB |
+| 4000 | 7 KB | 356 | 2.89 MB | 3.85 MB |
+| 4000 | 2 KB | 1069 | 2.90 MB | 3.86 MB |
+
+The load-bearing row is the third: **the budget must not bind on traffic
+production actually produces**, or it degrades attribution on exactly the busiest
+nodes. A tighter 1.5 MiB was tried first and rejected — it binds at 213 of 283
+trees, while the payload there is under half the limit.
+`TestBuildWireStream_ObservedWorstCaseFitsBudget` pins this, and fails at 1.5 MiB.
+
+- **A byte budget, not a tree count.** Tree size varies ~3.5× even with the
+  command-line cap (~2 KB median, ~7 KB p90, ~12 KB for a deep chain of capped
+  command lines), so no count bounds the payload. The estimator counts the command
+  line at its *capped* length and overestimates real marshalled size by 1–6% —
+  conservative in the safe direction.
 - **Connections are never dropped** — that is the data loss this change exists to
   fix. Only trees are, and the refs stay on the connections, so pid identity
   survives and `ProcessTreeFor` returns nil for them as specified.
@@ -213,18 +233,27 @@ So `maxProcessTreeBytes` (1.5 MiB of estimated tree bytes) bounds the trees:
   many endpoints is both the most expensive attribution to lose and the shape
   reputation cares about most; tie-breaking on the ref keeps the payload
   independent of map iteration order.
-- At p90 tree size the budget is ~300 trees, above the largest message observed in
-  production (283 connections, so at most 283 distinct processes) — a safety valve,
-  not a routine limiter.
+- At p90 tree size the budget is ~360 trees and at median ~1280 — above anything
+  yet observed, so it is a safety valve rather than a routine limiter.
+
+**Residual, deliberately not fixed here.** With trees bounded, the connection
+*entries* alone would still breach the limit somewhere around 2,500–4,400
+connections (the range is per-entry richness: ~530 B derived from production versus
+~300 B for a lean entry). That is 9–16× the observed worst batch. The fix for that
+regime is splitting the message — as the container profile does on HTTP 413,
+`docs/features/container-profile-split-on-413.md` — not dropping connections. The
+logging below is what would tell us it is being approached.
 
 ### Observability, because the real distribution is not knowable yet
 
-How often a real node exceeds the budget **cannot be measured from today's data**:
-the current sensor strips trees and puts no process identity on the wire, so
-distinct-processes-per-batch does not exist in any message. Fleet-wide, today's
-messages average ~30 KB (`pulsar_average_msg_size` on
-`persistent://armo/internal/network-stream-v1`, ~175× under the limit), which says
-the baseline is comfortable but nothing about the new multiplier.
+The calibration above bounds the worst case, but **how often a real node actually
+has that many distinct processes cannot be measured from today's data**: the
+current sensor strips trees and puts no process identity on the wire, so
+distinct-processes-per-batch exists in no message. What is measurable — connections
+per batch (~42 mean) and message size (~30 KB mean, ~175× under the limit) — bounds
+the worst case only under the pessimistic assumption that *every* connection comes
+from a different process. The real ratio of processes to connections is the unknown,
+and it is bounded above by 1.
 
 Two log lines make it answerable after rollout:
 

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -78,6 +78,32 @@ The ref is computed **before** `eventsStorageMutex` is taken. The lookup acquire
 the process tree's read lock, and holding the storage mutex across it would add a
 storage→tree lock-order edge for no benefit.
 
+### Known cost: the ref lookup is on the packet path
+
+`processRefFor` runs for **every** network and DNS event, including duplicates —
+unavoidably, since the dedup key contains the ref, so the ref must exist before the key
+can be built. It takes `ProcessTreeManagerImpl.mutex.RLock()` and then the creator's
+`RLock()` to read one map entry, and `ProcessTreeManagerImpl.ReportEvent` write-locks
+that same manager mutex for every exec/fork/exit/procfs event. Before attribution the
+network path never touched those locks at all.
+
+Measured on the duplicate-connection path (8 threads, real `ProcessTreeManagerImpl`;
+control is the same benchmark with the lookup short-circuited):
+
+| | ns/op |
+|---|---|
+| Idle tree, control | 210 |
+| Idle tree, with ref lookup | 244 |
+| 4 goroutines of exec churn, control | 254–271 |
+| 4 goroutines of exec churn, with ref lookup | 996–1035 |
+
+~16% idle, **~3.9× under exec churn** — essentially all write-lock contention, so it
+lands hardest on the fork-heavy nodes this feature's budget was calibrated for. The
+lookup is inherent to the design; the contention is not. A dedicated RWMutex for the
+creator's `pidStartTimeNs` side map, or an atomic/sharded read, would keep packet
+handling off the process-tree writer's critical path. That change belongs in
+`pkg/processtree/creator` and is left to the workstream that owns it.
+
 ## The flush: one snapshot, two consumers
 
 The flush has two consumers with different needs:
@@ -213,22 +239,22 @@ so trees scale 1:1 with connections — with production-weight connection entrie
 |---|---|---|---|
 | 42 (the mean) | all 42 | 0.20 MiB | 0.26 MiB |
 | **283 (observed worst)** | **all 283** | 1.33 MiB | **1.77 MiB — 35% of limit** |
-| 500 | all 500 | 2.35 MiB | 3.13 MiB |
-| 1000 | 513 (budget binds) | 2.70 MiB | 3.60 MiB |
-| 4000 | 513 | 4.50 MiB | **6.01 MiB — over the limit, on entries alone** |
+| 500 | 461 (budget binds) | 2.19 MiB | 2.92 MiB |
+| 1000 | 461 | 2.49 MiB | 3.31 MiB |
+| 4000 | 461 | 4.29 MiB | **5.72 MiB — over the limit, on entries alone** |
 
 Two load-bearing rows. The **283** row: the budget must not bind on traffic
 production actually produces, or it degrades attribution on exactly the busiest
 nodes — a tighter 1.5 MiB was tried first and rejected, because it clips 70 of those
 283 trees while the payload is barely a third of the limit.
 `TestBuildWireStream_ObservedWorstCaseFitsBudget` pins that and fails at 1.5 MiB.
-The **4000** row is the residual below: past ~3,300 connections the entries alone
+The **4000** row is the residual below: past ~3,000 connections the entries alone
 exceed the limit no matter how tightly trees are bounded.
 
 - **A byte budget, not a tree count.** Tree size is not uniform — depth varies,
   fields are variable-length, and JSON escaping inflates some content ~6× (below),
   so no count bounds the payload. The estimator overestimates real marshalled size
-  by ~19% for realistic trees, and `TestEstimateTreeBytes_NeverUnderestimates`
+  by ~33% for realistic trees, and `TestEstimateTreeBytes_NeverUnderestimates`
   enforces that it never goes the other way.
 
 #### JSON escaping is what makes the estimate honest
@@ -268,13 +294,21 @@ invariant nothing in this repo enforces — with an unbounded comm the old accou
   precise case reputation attribution exists to catch. The ref tie-break keeps the
   shipped set independent of map iteration order, which
   `TestSelectProcessTrees_IsDeterministic` pins.
-- The budget holds ~513 fully-populated 10-node chains — 1.8x the observed worst
+- The budget holds ~461 fully-populated 10-node chains — 1.6x the observed worst
   batch — so it is a safety valve rather than a routine limiter.
 
-**Residual, deliberately not fixed here.** With trees bounded, the connection
-*entries* alone breach the limit at roughly **3,300 connections** at the
-production-derived ~530 B per entry — 11x the observed worst batch, and measured at
-6.01 MiB for 4,000. No tree budget can help there. The fix for that regime is
+**Residual, deliberately not fixed here.** Two things this budget does not cover.
+
+First, **it bounds the wire, not the heap.** With the process-aware key,
+`networkEventsStorage` retains one entry per (process, endpoint) for the whole flush
+interval, each pinning a `*ProcessTree`, and nothing caps that — resident memory grows
+with distinct processes even though the payload is trimmed on the way out. Capping it
+would mean dropping connections, which is the data loss this change exists to fix, so
+the honest position is that it is unbounded and monitored rather than bounded.
+
+Second, the connection *entries* alone breach the message limit at roughly **3,000
+connections** at the production-derived ~530 B per entry — 10x the observed worst
+batch, and measured at 5.72 MiB for 4,000. No tree budget can help there. The fix for that regime is
 splitting the message — as the container profile does on HTTP 413,
 `docs/features/container-profile-split-on-413.md` — not dropping connections. The
 logging below is what would tell us it is being approached.

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -1,0 +1,142 @@
+# Network-stream process attribution
+
+Every streamed connection carries the identity of the process that opened it, so
+a malicious-endpoint finding can land on the same incident as the exec, file and
+other findings from that same process chain. Before this, the network stream
+carried no process data on the wire at all: the sensor captured a process tree
+per connection and then stripped it before sending, to save bytes.
+
+Schema lives in `armosec/armoapi-go` (pinned `v0.0.742`); this document covers
+the **sensor** side, in `pkg/networkstream/v1`.
+
+## What goes on the wire
+
+```go
+// per connection
+NetworkStreamEvent.ProcessRef *ProcessRef   // "processRef" — NOT "process"
+
+// per message
+NetworkStream.Processes                 map[ProcessRef]*ProcessTree
+NetworkStream.ProcessAttributionVersion int   // NetworkStreamProcessAttributionV1 = 1
+```
+
+`ProcessRef{PID, StartTimeNs}` text-marshals to `"<pid>/<startTimeNs>"` and is
+deliberately both the per-event reference and the map key, so the join cannot
+drift. Consumers must resolve it with `NetworkStream.ProcessTreeFor(event)`, never
+a bare map index — indexing panics on a nil ref and cannot distinguish a missing
+entry from a present-but-nil one.
+
+`StartTimeNs` is **boot-relative nanoseconds**, taken from
+`ProcessTreeManager.GetProcessBootTimeNs` and emitted **verbatim**. It is
+converted from clock ticks exactly once, on the way in from `/proc` — see
+[process-start-time.md](./process-start-time.md). Scaling it here would compile,
+parse, and even join correctly *within* one message (the key and the ref share a
+producer), while silently breaking identity across messages by seven orders of
+magnitude. If you find yourself dividing this value, that is a bug.
+
+A zero `StartTimeNs` is legal and means *unknown* — the process was not yet
+`/proc`-scanned, died before its creation event was processed, or is a
+Kubernetes-mode host process. The ref is emitted anyway: it degrades to pid-only
+identity, where dropping it would lose attribution entirely for that population.
+A pid of 0 is not an identity, and yields no ref at all.
+
+## The batch key — this fixed data loss, not just attribution
+
+Connections are batched per entity under a key from
+`getNetworkEndpointIdentifier`. That key was `"<addr>/<port>/<proto>"` with
+first-writer-wins, so when two processes in one container reached the same
+endpoint inside a flush interval, the second connection was **silently
+discarded** — it never reached the wire under any identity. The same held for two
+processes resolving one domain, keyed on the DNS name alone.
+
+The key now appends the ref:
+
+| Case | Key |
+|---|---|
+| Attributed connection | `1.2.3.4/443/TCP/101/5000000000` |
+| Unattributed (pid 0) | `1.2.3.4/443/TCP` |
+| Attributed DNS query | `evil.example.com./101/5000000000` |
+
+**Appended, never reordered.** An unattributed key stays byte-identical to the
+pre-attribution format, and an attributed key always carries two more components,
+so the two can never collide. First-writer-wins is retained for the *same*
+process, so a chatty process does not inflate the batch.
+
+Accepted consequence: an attributed and an unattributed connection to one
+endpoint become two entries. The traffic-view write path collapses them to one
+row — its row identity contains no process field — so this is not
+customer-visible and needs no migration (verified, SUB-7851).
+
+The ref is computed **before** `eventsStorageMutex` is taken. The lookup acquires
+the process tree's read lock, and holding the storage mutex across it would add a
+storage→tree lock-order edge for no benefit.
+
+## The flush: one snapshot, two consumers
+
+The flush has two consumers with different needs:
+
+- **The in-process notification channel** — `private-node-agent`'s host network
+  sensor reads `outbound.ProcessTree` from it. It keeps the trees. (In the
+  open-source repo `cmd/main.go` passes a nil channel, which makes the field look
+  dead. It is not.)
+- **The HTTP exporter** — gets a derived wire copy where trees move into the
+  message-level `Processes` map.
+
+### Why the snapshot is independent
+
+The flush used to hand the channel the **live** storage struct, then — still
+holding `eventsStorageMutex` — sleep 100 ms and strip every process tree from the
+maps the consumer was reading. The sleep was the only thing standing between the
+host sensor and having its data erased mid-read. A test showed worse: a
+connection recorded 300 ms *after* the flush appeared inside the
+already-delivered snapshot, because the clear loop and the consumer shared the
+same maps.
+
+`snapshotNetworkStream` now allocates its own `Entities` map and its own
+per-entity event maps, so the delivered value is immune to everything the
+producer does next. Both sends happen outside the lock, and the 100 ms sleep is
+**deleted rather than shortened** — there is no shared state left to race on.
+
+### Lock discipline
+
+This file has a history of mutex stalls on this path, so the bound is part of the
+design rather than an afterthought:
+
+| | Inside `eventsStorageMutex` | Outside |
+|---|---|---|
+| Work | Allocate the snapshot's maps; copy each event **by value**; clear the live storage | Both sends; the wire copy's tree deep-copies and command-line caps |
+| Bound | O(entities + connections) small struct copies — at the largest observed message (109 entities, 283 connections) a few hundred copies | one capped tree copy per distinct process |
+
+Process-tree **pointers** are copied into the snapshot, never walked. That is
+what keeps the lock body cheap, and it is safe because a tree is immutable once
+attached to an event: nothing mutates one in place. `buildBranchToShim` allocates
+fresh nodes per branch, so event trees are not shared with the process tree's
+live map — only with its 1-minute LRU entry, which nothing writes to after
+construction. Anything that would modify a tree operates on a `DeepCopy`.
+
+## Handoff note for the host/ECS workstream
+
+This change owns `pkg/networkstream/v1`; `cmd/host`, `cmd/ecs` and the
+Kubernetes-mode streaming gate are untouched. Inheriting from it:
+
+- The tree strip is gone, and with it the **shared-map race the host sensor's
+  100 ms sleep existed to survive**. The channel now delivers an independent
+  snapshot, still with trees.
+- The batch key gained a process suffix (above).
+- Outside Kubernetes mode the HTTP export is disabled entirely, so that
+  in-process channel is the only consumer today.
+- In Kubernetes mode, pre-existing **host** (non-container) processes carry no
+  start time, because the tree refuses to create nodes for them.
+
+## Testing
+
+This package cannot be built or tested on macOS: `inspektor-gadget/pkg/utils/host`
+excludes darwin and is imported transitively.
+
+```bash
+docker run --rm -v "$PWD":/src -v "$(go env GOMODCACHE)":/go/pkg/mod -w /src \
+  -e GOFLAGS=-mod=mod golang:1.25 go test ./pkg/networkstream/...
+```
+
+`pkg/networkstream/v1` had two test functions before this change, so it carries
+its own coverage rather than leaning on a surrounding suite.

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -253,7 +253,7 @@ nodes — a tighter 1.5 MiB was tried first and rejected, because it clips 70 of
 283 trees while the payload is barely a third of the limit.
 `TestBuildWireStream_ObservedWorstCaseFitsBudget` pins that and fails at 1.5 MiB.
 The **4000** row is the residual below: with the tree budget saturated, the message
-exceeds the limit at roughly 3,000 connections.
+exceeds the limit at roughly 3,600 connections.
 
 - **A byte budget, not a tree count.** Tree size is not uniform — depth varies,
   fields are variable-length, and JSON escaping inflates some content ~6× (below),
@@ -315,14 +315,20 @@ number means what, because the difference decides what an operator should do:
 
 | | connections |
 |---|---|
-| Breach **with the tree budget saturated** (today's configuration) | ~3,000 |
+| Breach **with the tree budget saturated** (today's configuration) | ~3,600 |
 | Breach from connection **entries alone**, if trees took no space at all | ~7,400 |
 
-The usable budget is 3.75 MiB of JSON (5 MiB after base64's x1.333). At 4,000
-connections the entries are 4,000 x 530 B = 2.02 MiB and the saturated trees are
-~1.91 MiB; back the trees out and 3.75 - 1.91 leaves room for ~2,900 entries, which is
-where the ~3,000 comes from. Entries alone would not breach until 3,932,160 / 530 =
-~7,400.
+The usable budget is 3.75 MiB of JSON (5 MiB after base64's x1.333). A saturated tree
+map **measures** 1,978,505 B (1.89 MiB) — marshalled, not inferred — which leaves
+3,932,160 - 1,978,505 = 1,953,655 B (1.86 MiB), so ~3,690 entries at 530 B. Independent
+measurements put it at ~3,580 and ~3,600, hence **~3,600** above: rounding low is the
+right direction for a breach threshold. Entries alone would not breach until
+3,932,160 / 530 = ~7,400.
+
+Derive this from the *measured* tree total, never from a payload figure that already
+contains entries. Getting that wrong produced two successive errors here — a table row
+that counted entries twice, and a ~3,000 threshold that survived the correction of the
+tree figure it had been derived from.
 
 **So the tree budget IS a lever in that regime** — trees are roughly half the payload,
 and tightening `maxProcessTreeBytes` moves the breach point out, toward ~7,400 as the

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -112,7 +112,57 @@ what keeps the lock body cheap, and it is safe because a tree is immutable once
 attached to an event: nothing mutates one in place. `buildBranchToShim` allocates
 fresh nodes per branch, so event trees are not shared with the process tree's
 live map — only with its 1-minute LRU entry, which nothing writes to after
-construction. Anything that would modify a tree operates on a `DeepCopy`.
+construction. Anything that would modify a tree copies it first.
+
+Transient memory outside the lock is one capped tree copy per distinct process —
+at most connections × p90 tree size ≈ 283 × 5.1 KB ≈ 1.4 MB worst case, freed
+after the HTTP send.
+
+## The wire copy (`wire.go`)
+
+`buildWireStream` derives the HTTP payload from the snapshot:
+
+- Each event's tree moves into `Processes`, keyed by the event's own ref, and the
+  per-event `ProcessTree` is cleared **on the copy only**.
+- `ProcessAttributionVersion` is set **unconditionally**, including when nothing
+  was attributable. `len(Processes) == 0` is not a capability signal — a sensor
+  that ran and found nothing must stay distinguishable from one that predates
+  attribution.
+- `Processes` is left nil when empty, so `omitempty` drops it.
+- A ref whose tree never resolved still ships. It dangles, and `ProcessTreeFor`
+  is specified to return nil for that; dropping the ref would lose the pid too.
+
+**One tree per process, not per connection.** Trees dominate the payload; the
+duplicated ref bytes do not. The ref therefore travels twice per connection (map
+key and event value) by design — do not "optimise" that away.
+
+**On collision the deeper chain wins.** The process-tree cache TTL (1 minute) is
+shorter than the flush interval (2 minutes), so two lookups for one process
+inside a single interval can legitimately return chains with different amounts of
+ancestry resolved. First-wins would discard the richer chain *and* would make the
+payload depend on Go's randomised map iteration order.
+
+### Why not `Process.DeepCopy`
+
+`armotypes.Process.DeepCopy` **mutates its receiver**: it calls `MigrateToMap`,
+which allocates `ChildrenMap` and nils `Children`, and it does so on every child
+it recurses into — nodes the LRU cache, the alert paths and the channel consumer
+are reading. `copyCappedProcess` is read-only instead, normalising the deprecated
+`Children` slice into the copy's `ChildrenMap` without touching the source. Every
+recursive walk here is bounded by `maxTreeDepth` (64), so a malformed or cyclic
+tree costs a truncated payload rather than the agent's stack.
+
+### Command-line cap
+
+Each node's `Cmdline` is capped at **1024 bytes on the wire copy only**, with a
+trailing `…` so a cut is visible to a human. `cmdline` is ~40% of a tree's bytes
+and unbounded — a single pathological java or node command line can exceed
+100 KB — so this is the lever that keeps the payload tail bounded, not an
+optimisation. 1024 bytes keeps >99% of real command lines intact, and the cut
+never splits a UTF-8 rune.
+
+The cap is applied **during** the copy, so the legacy alert paths and the
+notification-channel consumer keep the uncapped values.
 
 ## Handoff note for the host/ECS workstream
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/anchore/syft v1.42.3
 	github.com/aquilax/truncate v1.0.0
-	github.com/armosec/armoapi-go v0.0.696
+	github.com/armosec/armoapi-go v0.0.742
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.696 h1:+0Ll7y4oWNaKEO47qbGDFIQLxkSJeKYzylS0FwI84XE=
-github.com/armosec/armoapi-go v0.0.696/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/armoapi-go v0.0.742 h1:iEUAbG6eLpGAhpsgozLXNu2KZgr+Nnbe40ixgn+6CEw=
 github.com/armosec/armoapi-go v0.0.742/go.mod h1:1l+70fBK09F7zI2jArrPUWVHaLkijg+sQutFTmE6HRs=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/armosec/armoapi-go v0.0.696 h1:+0Ll7y4oWNaKEO47qbGDFIQLxkSJeKYzylS0FwI84XE=
 github.com/armosec/armoapi-go v0.0.696/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.742 h1:iEUAbG6eLpGAhpsgozLXNu2KZgr+Nnbe40ixgn+6CEw=
+github.com/armosec/armoapi-go v0.0.742/go.mod h1:1l+70fBK09F7zI2jArrPUWVHaLkijg+sQutFTmE6HRs=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -176,18 +176,14 @@ func (ns *NetworkStream) Start() {
 				logger.L().Info("NetworkStream - stopping")
 				return
 			case <-ticker.C:
+				// Everything under the lock is O(entities + connections) map and struct
+				// copies; process-tree POINTERS are copied, never walked. Both sends and
+				// the wire copy's tree deep-copies happen outside it. This file has a
+				// history of mutex stalls on this path, so the bound matters: at the
+				// largest observed message (109 entities / 283 connections) this is a few
+				// hundred small copies, where the previous body held the lock across a
+				// blocking channel send plus a 100 ms sleep.
 				ns.eventsStorageMutex.Lock()
-				// Send the network events to the notification channel
-				if ns.eventsNotificationChannel != nil {
-					ns.eventsNotificationChannel <- ns.networkEventsStorage
-					// Add a small delay to ensure consumers have time to process
-					time.Sleep(100 * time.Millisecond)
-				}
-
-				// Remove process tree from events (to reduce size)
-				removeProcessTreeFromEvents(&ns.networkEventsStorage)
-
-				// Snapshot for HTTP send — allows releasing the lock before the network call
 				snapshot := snapshotNetworkStream(&ns.networkEventsStorage)
 
 				// Clear the storage
@@ -204,6 +200,15 @@ func (ns *NetworkStream) Start() {
 					Outbound: make(map[string]armotypes.NetworkStreamEvent),
 				}
 				ns.eventsStorageMutex.Unlock()
+
+				// The snapshot is independent of the live storage, so the consumer gets it
+				// outside the lock and WITH its process trees intact — private-node-agent's
+				// host network sensor reads outbound.ProcessTree from this channel. There is
+				// no shared state left to race on, which is why the historical 100 ms
+				// "give consumers time to process" sleep is gone rather than shortened.
+				if ns.eventsNotificationChannel != nil {
+					ns.eventsNotificationChannel <- *snapshot
+				}
 
 				// Send the snapshot outside the lock so event recording is never stalled by I/O
 				if err := ns.sendNetworkEvent(snapshot); err != nil {
@@ -565,33 +570,34 @@ func isEmptyNetworkStream(networkStream *armotypes.NetworkStream) bool {
 	return true
 }
 
-func removeProcessTreeFromEvents(networkStream *armotypes.NetworkStream) {
-	for entityId, entity := range networkStream.Entities {
-		for eventId, event := range entity.Inbound {
-			event.ProcessTree = nil
-			entity.Inbound[eventId] = event
-		}
-		for eventId, event := range entity.Outbound {
-			event.ProcessTree = nil
-			entity.Outbound[eventId] = event
-		}
-		networkStream.Entities[entityId] = entity
-	}
-}
-
-// snapshotNetworkStream returns a new NetworkStream with an independent Entities map so that
-// the caller can release eventsStorageMutex before the HTTP send. A new map is required because
-// the clearing loop replaces entity structs in the live Entities map; copying the entity structs
-// by value is sufficient because the clearing loop never mutates the old Inbound/Outbound maps
-// in place — it allocates new ones and assigns them to the new struct.
+// snapshotNetworkStream returns a NetworkStream that shares no mutable state with the
+// live storage, so eventsStorageMutex can be released before either send.
+//
+// The Entities map and both event maps per entity are freshly allocated; events are
+// copied by value. Process-tree POINTERS are shared rather than walked — that is what
+// keeps this O(entities + connections) cheap struct copies instead of a deep tree walk,
+// and it is safe because a tree is immutable once attached to an event: nothing mutates
+// one in place (buildWireStream caps command lines on a DeepCopy, never on the shared
+// nodes, which the process-tree manager's LRU cache and the legacy alert paths hold too).
 func snapshotNetworkStream(src *armotypes.NetworkStream) *armotypes.NetworkStream {
 	dst := &armotypes.NetworkStream{
 		Entities: make(map[string]armotypes.NetworkStreamEntity, len(src.Entities)),
 	}
 	for entityID, entity := range src.Entities {
-		dst.Entities[entityID] = entity // struct copy; Inbound/Outbound map pointers are safe to share
+		e := entity // struct copy: scalar entity metadata
+		e.Inbound = copyEvents(entity.Inbound)
+		e.Outbound = copyEvents(entity.Outbound)
+		dst.Entities[entityID] = e
 	}
 	return dst
+}
+
+func copyEvents(events map[string]armotypes.NetworkStreamEvent) map[string]armotypes.NetworkStreamEvent {
+	out := make(map[string]armotypes.NetworkStreamEvent, len(events))
+	for key, event := range events {
+		out[key] = event
+	}
+	return out
 }
 
 func (ns *NetworkStream) getProcessTreeByPid(pid uint32, comm string, processTree *armotypes.ProcessTree) *armotypes.ProcessTree {

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -30,9 +30,8 @@ import (
 const (
 	timeoutDefaultSeconds = 30 // Default timeout for HTTP requests if not set in the config
 
-	// payloadWarnBytes is the size above which a flush logs its shape. Set well
-	// under the broker's 5 MiB limit and far above the ~30 KB fleet mean, so it
-	// reports the tail approaching the limit without being chatty.
+	// payloadWarnBytes is the size above which a flush logs its shape — well under
+	// the broker's 5 MiB limit, far above the ~30 KB fleet mean.
 	payloadWarnBytes = 2 << 20
 )
 
@@ -181,13 +180,8 @@ func (ns *NetworkStream) Start() {
 				logger.L().Info("NetworkStream - stopping")
 				return
 			case <-ticker.C:
-				// Everything under the lock is O(entities + connections) map and struct
-				// copies; process-tree POINTERS are copied, never walked. Both sends and
-				// the wire copy's tree deep-copies happen outside it. This file has a
-				// history of mutex stalls on this path, so the bound matters: at the
-				// largest observed message (109 entities / 283 connections) this is a few
-				// hundred small copies, where the previous body held the lock across a
-				// blocking channel send plus a 100 ms sleep.
+				// Snapshot and clear only; both sends and the tree copies stay outside
+				// the lock. This path has a history of mutex stalls.
 				ns.eventsStorageMutex.Lock()
 				snapshot := snapshotNetworkStream(&ns.networkEventsStorage)
 
@@ -206,22 +200,14 @@ func (ns *NetworkStream) Start() {
 				}
 				ns.eventsStorageMutex.Unlock()
 
-				// Derive the wire copy BEFORE handing the snapshot away. Both are outside
-				// the lock — the tree copies and command-line caps are the only expensive
-				// part of a flush — but the order matters: once the snapshot is on the
-				// channel its maps belong to the consumer, and reading them here afterwards
-				// would depend on that consumer never writing to what it receives.
+				// Before the send: once the snapshot is on the channel, its maps belong
+				// to the consumer.
 				wire := buildWireStream(snapshot)
 
-				// The snapshot is independent of the live storage, so the consumer gets it
-				// outside the lock and WITH its process trees intact — private-node-agent's
-				// host network sensor reads outbound.ProcessTree from this channel. There is
-				// no shared state left to race on, which is why the historical 100 ms
-				// "give consumers time to process" sleep is gone rather than shortened.
-				// The send stays blocking, so a slow consumer applies backpressure rather
-				// than losing traffic — but it now honours shutdown, which it could not
-				// while it held the lock. Without this a stalled consumer would pin this
-				// goroutine past ctx cancellation.
+				// The consumer gets the snapshot WITH its trees — private-node-agent's
+				// host network sensor reads outbound.ProcessTree from here. The send
+				// blocks so a slow consumer applies backpressure instead of losing
+				// traffic, and selects on ctx so it cannot outlive shutdown.
 				if ns.eventsNotificationChannel != nil {
 					select {
 					case ns.eventsNotificationChannel <- *snapshot:
@@ -504,11 +490,8 @@ func (ns *NetworkStream) sendNetworkEvent(networkStream *armotypes.NetworkStream
 	if err != nil {
 		return fmt.Errorf("marshal network stream: %w", err)
 	}
-	// Attribution made the payload scale with the number of distinct processes that
-	// connected, so how close real messages get to the broker's 5 MiB limit is worth
-	// knowing rather than assuming. Today's fleet mean is ~30 KB, so this is quiet
-	// unless something has changed materially. Note the synchronizer envelope is
-	// base64, costing a further x1.333 on top of what is logged here.
+	// Quiet at the ~30 KB fleet mean; reports the tail approaching the broker's 5 MiB
+	// limit. Note the synchronizer envelope is base64, a further x1.333 on this size.
 	if len(bodyBytes) > payloadWarnBytes {
 		logger.L().Warning("NetworkStream - large payload",
 			helpers.Int("bytes", len(bodyBytes)),
@@ -544,11 +527,10 @@ func (ns *NetworkStream) sendNetworkEvent(networkStream *armotypes.NetworkStream
 	return nil
 }
 
-// getNetworkEndpointIdentifier builds the per-batch connection key. The process
-// ref is APPENDED, never reordered: a nil ref leaves the key byte-identical to
-// the pre-attribution format, and an attributed key always carries two more
-// components, so the two can never collide. The traffic-view write path collapses
-// process-split entries back to one row (verified, SUB-7851).
+// getNetworkEndpointIdentifier builds the per-batch connection key. The ref is
+// APPENDED, never reordered: a nil ref leaves the key byte-identical to the
+// pre-attribution format, and an attributed key carries two more components, so the
+// two forms cannot collide.
 func getNetworkEndpointIdentifier(event utils.NetworkEvent, ref *armotypes.ProcessRef) string {
 	id := fmt.Sprintf("%s/%d/%s", event.GetDstEndpoint().Addr, event.GetDstPort(), event.GetProto())
 	if ref != nil {
@@ -558,8 +540,7 @@ func getNetworkEndpointIdentifier(event utils.NetworkEvent, ref *armotypes.Proce
 }
 
 // getDnsOutboundIdentifier keys a DNS query by name plus the querying process, so
-// two processes resolving one domain no longer overwrite each other. The ref is
-// appended on the same terms as getNetworkEndpointIdentifier's.
+// two processes resolving one domain no longer overwrite each other.
 func getDnsOutboundIdentifier(dnsName string, ref *armotypes.ProcessRef) string {
 	if ref == nil {
 		return dnsName
@@ -569,20 +550,15 @@ func getDnsOutboundIdentifier(dnsName string, ref *armotypes.ProcessRef) string 
 
 // processRefFor builds the wire identity of the process behind an event.
 //
-// StartTimeNs is boot-relative NANOSECONDS, read from the procfs-fed identity map
-// and emitted VERBATIM — never scale it. A division here would still join
-// correctly within one message (key and ref share a producer) while silently
-// breaking identity across messages by seven orders of magnitude. See
-// docs/features/process-start-time.md.
+// StartTimeNs is boot-relative NANOSECONDS, emitted VERBATIM — never scale it. A
+// division here still joins correctly within one message while breaking identity
+// across messages by seven orders of magnitude, so the bug is nearly invisible.
+// See docs/features/process-start-time.md.
 //
-// Zero is legal: it means unknown (process not yet scanned, died before its
-// creation event was processed, or a Kubernetes-mode host process), leaving
-// pid-only identity. The ref is emitted anyway — dropping it would lose
-// attribution entirely for that population.
+// Zero is legal and means unknown, leaving pid-only identity; emit the ref anyway.
 //
-// Called BEFORE eventsStorageMutex is taken: the lookup acquires the process
-// tree's read lock, and holding the storage mutex across it would add a
-// storage->tree lock-order edge for no benefit.
+// Call this BEFORE taking eventsStorageMutex — the lookup takes the process tree's
+// read lock, and holding both would add a storage->tree lock-order edge.
 func (ns *NetworkStream) processRefFor(pid uint32) *armotypes.ProcessRef {
 	if pid == 0 || ns.processTreeManager == nil {
 		return nil // nothing to attribute
@@ -610,15 +586,12 @@ func isEmptyNetworkStream(networkStream *armotypes.NetworkStream) bool {
 	return true
 }
 
-// snapshotNetworkStream returns a NetworkStream that shares no mutable state with the
-// live storage, so eventsStorageMutex can be released before either send.
+// snapshotNetworkStream returns a NetworkStream sharing no mutable state with the live
+// storage, so eventsStorageMutex can be released before either send.
 //
-// The Entities map and both event maps per entity are freshly allocated; events are
-// copied by value. Process-tree POINTERS are shared rather than walked — that is what
-// keeps this O(entities + connections) cheap struct copies instead of a deep tree walk,
-// and it is safe because a tree is immutable once attached to an event: nothing mutates
-// one in place (buildWireStream caps command lines on a DeepCopy, never on the shared
-// nodes, which the process-tree manager's LRU cache and the legacy alert paths hold too).
+// Tree POINTERS are shared rather than walked, which keeps this to cheap struct copies.
+// That is safe only because a tree is immutable once attached to an event — anything
+// that would modify one copies it first.
 func snapshotNetworkStream(src *armotypes.NetworkStream) *armotypes.NetworkStream {
 	dst := &armotypes.NetworkStream{
 		Entities: make(map[string]armotypes.NetworkStreamEntity, len(src.Entities)),

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -285,6 +285,10 @@ func (ns *NetworkStream) ReportEvent(eventType utils.EventType, event utils.K8sE
 }
 
 func (ns *NetworkStream) handleDnsEvent(event utils.DNSEvent, processTree *armotypes.ProcessTree) {
+	// Resolved before the lock: see processRefFor on the lock ordering.
+	ref := ns.processRefFor(event.GetPID())
+	outboundKey := getDnsOutboundIdentifier(event.GetDNSName(), ref)
+
 	ns.eventsStorageMutex.Lock()
 	defer ns.eventsStorageMutex.Unlock()
 
@@ -304,7 +308,7 @@ func (ns *NetworkStream) handleDnsEvent(event utils.DNSEvent, processTree *armot
 	}
 
 	// We get only DNS response events, so we put them in the outbound map
-	if _, exists := entity.Outbound[event.GetDNSName()]; exists {
+	if _, exists := entity.Outbound[outboundKey]; exists {
 		// If the event already exists, we can skip it
 		return
 	}
@@ -319,8 +323,9 @@ func (ns *NetworkStream) handleDnsEvent(event utils.DNSEvent, processTree *armot
 
 	processTree = ns.getProcessTreeByPid(event.GetPID(), event.GetComm(), processTree)
 	networkEvent.ProcessTree = processTree
+	networkEvent.ProcessRef = ref
 
-	entity.Outbound[event.GetDNSName()] = networkEvent
+	entity.Outbound[outboundKey] = networkEvent
 	ns.networkEventsStorage.Entities[entityId] = entity
 }
 
@@ -343,7 +348,8 @@ func (ns *NetworkStream) shouldReportDnsEvent(dnsEvent utils.DNSEvent) bool {
 }
 
 func (ns *NetworkStream) handleNetworkEvent(event utils.NetworkEvent, processTree *armotypes.ProcessTree) {
-	endpointID := getNetworkEndpointIdentifier(event)
+	ref := ns.processRefFor(event.GetPID())
+	endpointID := getNetworkEndpointIdentifier(event, ref)
 
 	ns.eventsStorageMutex.Lock()
 	defer ns.eventsStorageMutex.Unlock()
@@ -368,20 +374,20 @@ func (ns *NetworkStream) handleNetworkEvent(event utils.NetworkEvent, processTre
 			// If the event already exists, we can skip it
 			return
 		}
-		networkEvent := ns.buildNetworkEvent(event, processTree)
+		networkEvent := ns.buildNetworkEvent(event, processTree, ref)
 		entity.Outbound[endpointID] = networkEvent
 	} else {
 		if _, exists := entity.Inbound[endpointID]; exists {
 			// If the event already exists, we can skip it
 			return
 		}
-		networkEvent := ns.buildNetworkEvent(event, processTree)
+		networkEvent := ns.buildNetworkEvent(event, processTree, ref)
 		entity.Inbound[endpointID] = networkEvent
 	}
 	ns.networkEventsStorage.Entities[entityId] = entity
 }
 
-func (ns *NetworkStream) buildNetworkEvent(event utils.NetworkEvent, processTree *armotypes.ProcessTree) armotypes.NetworkStreamEvent {
+func (ns *NetworkStream) buildNetworkEvent(event utils.NetworkEvent, processTree *armotypes.ProcessTree, ref *armotypes.ProcessRef) armotypes.NetworkStreamEvent {
 	var domain string
 	var ok bool
 	dstEndpoint := event.GetDstEndpoint()
@@ -444,6 +450,7 @@ func (ns *NetworkStream) buildNetworkEvent(event utils.NetworkEvent, processTree
 
 	processTree = ns.getProcessTreeByPid(event.GetPID(), event.GetComm(), processTree)
 	networkEvent.ProcessTree = processTree
+	networkEvent.ProcessRef = ref
 
 	return networkEvent
 }
@@ -500,8 +507,50 @@ func (ns *NetworkStream) sendNetworkEvent(networkStream *armotypes.NetworkStream
 	return nil
 }
 
-func getNetworkEndpointIdentifier(event utils.NetworkEvent) string {
-	return fmt.Sprintf("%s/%d/%s", event.GetDstEndpoint().Addr, event.GetDstPort(), event.GetProto())
+// getNetworkEndpointIdentifier builds the per-batch connection key. The process
+// ref is APPENDED, never reordered: a nil ref leaves the key byte-identical to
+// the pre-attribution format, and an attributed key always carries two more
+// components, so the two can never collide. The traffic-view write path collapses
+// process-split entries back to one row (verified, SUB-7851).
+func getNetworkEndpointIdentifier(event utils.NetworkEvent, ref *armotypes.ProcessRef) string {
+	id := fmt.Sprintf("%s/%d/%s", event.GetDstEndpoint().Addr, event.GetDstPort(), event.GetProto())
+	if ref != nil {
+		id += "/" + ref.String()
+	}
+	return id
+}
+
+// getDnsOutboundIdentifier keys a DNS query by name plus the querying process, so
+// two processes resolving one domain no longer overwrite each other. The ref is
+// appended on the same terms as getNetworkEndpointIdentifier's.
+func getDnsOutboundIdentifier(dnsName string, ref *armotypes.ProcessRef) string {
+	if ref == nil {
+		return dnsName
+	}
+	return dnsName + "/" + ref.String()
+}
+
+// processRefFor builds the wire identity of the process behind an event.
+//
+// StartTimeNs is boot-relative NANOSECONDS, read from the procfs-fed identity map
+// and emitted VERBATIM — never scale it. A division here would still join
+// correctly within one message (key and ref share a producer) while silently
+// breaking identity across messages by seven orders of magnitude. See
+// docs/features/process-start-time.md.
+//
+// Zero is legal: it means unknown (process not yet scanned, died before its
+// creation event was processed, or a Kubernetes-mode host process), leaving
+// pid-only identity. The ref is emitted anyway — dropping it would lose
+// attribution entirely for that population.
+//
+// Called BEFORE eventsStorageMutex is taken: the lookup acquires the process
+// tree's read lock, and holding the storage mutex across it would add a
+// storage->tree lock-order edge for no benefit.
+func (ns *NetworkStream) processRefFor(pid uint32) *armotypes.ProcessRef {
+	if pid == 0 || ns.processTreeManager == nil {
+		return nil // nothing to attribute
+	}
+	return &armotypes.ProcessRef{PID: pid, StartTimeNs: ns.processTreeManager.GetProcessBootTimeNs(pid)}
 }
 
 func isEmptyNetworkStream(networkStream *armotypes.NetworkStream) bool {

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -210,8 +210,10 @@ func (ns *NetworkStream) Start() {
 					ns.eventsNotificationChannel <- *snapshot
 				}
 
-				// Send the snapshot outside the lock so event recording is never stalled by I/O
-				if err := ns.sendNetworkEvent(snapshot); err != nil {
+				// The wire copy is derived outside the lock too: it deep-copies one tree
+				// per distinct process and caps command lines, which is the only
+				// expensive part of a flush.
+				if err := ns.sendNetworkEvent(buildWireStream(snapshot)); err != nil {
 					logger.L().Error("NetworkStream - failed to send network events", helpers.Error(err))
 				}
 				logger.L().Debug("NetworkStream - sent network events")

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -201,6 +201,13 @@ func (ns *NetworkStream) Start() {
 				}
 				ns.eventsStorageMutex.Unlock()
 
+				// Derive the wire copy BEFORE handing the snapshot away. Both are outside
+				// the lock — the tree copies and command-line caps are the only expensive
+				// part of a flush — but the order matters: once the snapshot is on the
+				// channel its maps belong to the consumer, and reading them here afterwards
+				// would depend on that consumer never writing to what it receives.
+				wire := buildWireStream(snapshot)
+
 				// The snapshot is independent of the live storage, so the consumer gets it
 				// outside the lock and WITH its process trees intact — private-node-agent's
 				// host network sensor reads outbound.ProcessTree from this channel. There is
@@ -219,10 +226,7 @@ func (ns *NetworkStream) Start() {
 					}
 				}
 
-				// The wire copy is derived outside the lock too: it deep-copies one tree
-				// per distinct process and caps command lines, which is the only
-				// expensive part of a flush.
-				if err := ns.sendNetworkEvent(buildWireStream(snapshot)); err != nil {
+				if err := ns.sendNetworkEvent(wire); err != nil {
 					logger.L().Error("NetworkStream - failed to send network events", helpers.Error(err))
 				}
 				logger.L().Debug("NetworkStream - sent network events")

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -29,6 +29,11 @@ import (
 
 const (
 	timeoutDefaultSeconds = 30 // Default timeout for HTTP requests if not set in the config
+
+	// payloadWarnBytes is the size above which a flush logs its shape. Set well
+	// under the broker's 5 MiB limit and far above the ~30 KB fleet mean, so it
+	// reports the tail approaching the limit without being chatty.
+	payloadWarnBytes = 2 << 20
 )
 
 type NetworkStream struct {
@@ -499,6 +504,18 @@ func (ns *NetworkStream) sendNetworkEvent(networkStream *armotypes.NetworkStream
 	if err != nil {
 		return fmt.Errorf("marshal network stream: %w", err)
 	}
+	// Attribution made the payload scale with the number of distinct processes that
+	// connected, so how close real messages get to the broker's 5 MiB limit is worth
+	// knowing rather than assuming. Today's fleet mean is ~30 KB, so this is quiet
+	// unless something has changed materially. Note the synchronizer envelope is
+	// base64, costing a further x1.333 on top of what is logged here.
+	if len(bodyBytes) > payloadWarnBytes {
+		logger.L().Warning("NetworkStream - large payload",
+			helpers.Int("bytes", len(bodyBytes)),
+			helpers.Int("entities", len(networkStream.Entities)),
+			helpers.Int("connections", countConnections(networkStream)),
+			helpers.Int("processTrees", len(networkStream.Processes)))
+	}
 	bodyReader := bytes.NewReader(bodyBytes)
 	// prepare the request
 	req, err := http.NewRequest(ns.cfg.Exporters.HTTPExporterConfig.Method,
@@ -571,6 +588,14 @@ func (ns *NetworkStream) processRefFor(pid uint32) *armotypes.ProcessRef {
 		return nil // nothing to attribute
 	}
 	return &armotypes.ProcessRef{PID: pid, StartTimeNs: ns.processTreeManager.GetProcessBootTimeNs(pid)}
+}
+
+func countConnections(networkStream *armotypes.NetworkStream) int {
+	total := 0
+	for _, entity := range networkStream.Entities {
+		total += len(entity.Inbound) + len(entity.Outbound)
+	}
+	return total
 }
 
 func isEmptyNetworkStream(networkStream *armotypes.NetworkStream) bool {

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -206,8 +206,17 @@ func (ns *NetworkStream) Start() {
 				// host network sensor reads outbound.ProcessTree from this channel. There is
 				// no shared state left to race on, which is why the historical 100 ms
 				// "give consumers time to process" sleep is gone rather than shortened.
+				// The send stays blocking, so a slow consumer applies backpressure rather
+				// than losing traffic — but it now honours shutdown, which it could not
+				// while it held the lock. Without this a stalled consumer would pin this
+				// goroutine past ctx cancellation.
 				if ns.eventsNotificationChannel != nil {
-					ns.eventsNotificationChannel <- *snapshot
+					select {
+					case ns.eventsNotificationChannel <- *snapshot:
+					case <-ns.ctx.Done():
+						logger.L().Info("NetworkStream - stopping")
+						return
+					}
 				}
 
 				// The wire copy is derived outside the lock too: it deep-copies one tree

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -333,8 +333,13 @@ func TestFlush_ChannelSnapshotSurvivesTheProducer(t *testing.T) {
 		t.Fatal("no flush arrived on the notification channel")
 	}
 
-	// Let the producer finish the flush and record another connection.
-	time.Sleep(300 * time.Millisecond)
+	// Wait for the producer to actually finish the flush — an emptied live storage is
+	// the observable signal that its clear loop ran — then record another connection.
+	require.Eventually(t, func() bool {
+		ns.eventsStorageMutex.RLock()
+		defer ns.eventsStorageMutex.RUnlock()
+		return len(ns.networkEventsStorage.Entities[testNodeName].Outbound) == 0
+	}, 5*time.Second, 5*time.Millisecond, "the flush never cleared the live storage")
 	ns.handleNetworkEvent(outboundEvent(202, "9.9.9.9", 80), treeFor(202, "wget"))
 
 	outbound := received.Entities[testNodeName].Outbound
@@ -344,4 +349,67 @@ func TestFlush_ChannelSnapshotSurvivesTheProducer(t *testing.T) {
 		assert.Equal(t, "curl", ev.ProcessTree.ProcessTree.Comm)
 		require.NotNil(t, ev.ProcessRef)
 	}
+}
+
+// TestFlush_BlockedChannelSendHonoursShutdown: the channel send is deliberately
+// blocking, so a slow consumer applies backpressure rather than losing traffic.
+// That makes it a goroutine leak unless it also selects on context cancellation —
+// which the send could not do while it held eventsStorageMutex. Nothing else in
+// this suite enters the blocked path, because every other channel test buffers
+// specifically so the producer never blocks.
+func TestFlush_BlockedChannelSendHonoursShutdown(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	ctx, cancel := context.WithCancel(context.Background())
+	// Unbuffered and never read: the flush blocks on the send.
+	ch := make(chan armotypes.NetworkStream)
+	ns, err := NewNetworkStream(ctx, config.Config{NetworkStreamingInterval: 20 * time.Millisecond},
+		nil, stubResolver{}, testNodeName, ch, true, mgr)
+	require.NoError(t, err)
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+
+	ns.Start()
+
+	// The flush is past the lock body once the live storage is cleared, so from here
+	// it is parked on the send with nobody reading.
+	require.Eventually(t, func() bool {
+		ns.eventsStorageMutex.RLock()
+		defer ns.eventsStorageMutex.RUnlock()
+		return len(ns.networkEventsStorage.Entities[testNodeName].Outbound) == 0
+	}, 5*time.Second, 5*time.Millisecond, "the flush never reached its channel send")
+
+	cancel()
+	// Give the parked select a moment to observe cancellation. Only ctx.Done() is
+	// ready at this point — the send cannot be, because there is still no receiver —
+	// so a correct implementation abandons the send and returns.
+	time.Sleep(100 * time.Millisecond)
+
+	// Now become a receiver. If the goroutine were still parked on a plain blocking
+	// send it would hand us the snapshot; having exited, it never can.
+	select {
+	case <-ch:
+		t.Fatal("the flush completed its channel send after ctx cancellation: it is still parked on a send that ignores shutdown")
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// TestHandleDnsEvent_NoPidKeepsLegacyKey mirrors the network-event case: with no
+// pid the DNS key stays the bare name, byte-identical to the old format.
+func TestHandleDnsEvent_NoPidKeepsLegacyKey(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleDnsEvent(&utils.StructEvent{DNSName: "example.com.", DstPort: 53, Timestamp: time.Now().UnixNano()}, nil)
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	require.Len(t, entity.Outbound, 1)
+	for key, ev := range entity.Outbound {
+		assert.Equal(t, "example.com.", key)
+		assert.Nil(t, ev.ProcessRef, "pid 0 is not an identity")
+	}
+}
+
+// TestProcessRefFor_NoManager: the constructor accepts a nil process-tree manager
+// (TestNewNetworkStream passes one), so the ref lookup must not dereference it.
+func TestProcessRefFor_NoManager(t *testing.T) {
+	ns := newTestStream(t, nil)
+	assert.Nil(t, ns.processRefFor(101), "no manager means nothing to attribute, not a panic")
+	assert.Nil(t, ns.processRefFor(0))
 }

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -41,6 +41,17 @@ func newTestStream(t *testing.T, mgr processtree.ProcessTreeManager) *NetworkStr
 	return ns
 }
 
+// newTestStreamWithChannel additionally wires a notification channel and a flush
+// interval, so Start()'s ticker body can be exercised.
+func newTestStreamWithChannel(t *testing.T, mgr processtree.ProcessTreeManager, ch chan armotypes.NetworkStream, interval time.Duration) *NetworkStream {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ns, err := NewNetworkStream(ctx, config.Config{NetworkStreamingInterval: interval}, nil, stubResolver{}, testNodeName, ch, true, mgr)
+	require.NoError(t, err)
+	return ns
+}
+
 func outboundEvent(pid uint32, addr string, port uint16) *utils.StructEvent {
 	return &utils.StructEvent{
 		Pid:         pid,
@@ -265,5 +276,72 @@ func TestNewNetworkStream(t *testing.T) {
 				t.Error("eventsNotificationChannel not set correctly")
 			}
 		})
+	}
+}
+
+// TestSnapshotNetworkStream_OwnsItsEventMaps: the flush snapshot must own its
+// Inbound/Outbound maps. Sharing them means the producer keeps writing into maps
+// a consumer already holds — the race the flush path's 100 ms sleep exists to
+// paper over.
+func TestSnapshotNetworkStream_OwnsItsEventMaps(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
+	ns := newTestStream(t, mgr)
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+
+	snap := snapshotNetworkStream(&ns.networkEventsStorage)
+	require.Len(t, snap.Entities[testNodeName].Outbound, 1)
+
+	// Mutate the LIVE maps in place, exactly as removeProcessTreeFromEvents did.
+	live := ns.networkEventsStorage.Entities[testNodeName]
+	for k, ev := range live.Outbound {
+		ev.ProcessTree = nil
+		live.Outbound[k] = ev
+	}
+	delete(live.Outbound, "gone")
+
+	for _, ev := range snap.Entities[testNodeName].Outbound {
+		assert.NotNil(t, ev.ProcessTree, "the snapshot must not see in-place mutation of the live storage")
+	}
+}
+
+// TestFlush_ChannelSnapshotSurvivesTheProducer pins the notification-channel
+// contract end to end. private-node-agent's host network sensor reads
+// outbound.ProcessTree off this channel, so what it receives must (a) still carry
+// trees and (b) be immune to everything the producer does after the send —
+// stripping trees, clearing entities, recording new events.
+//
+// Against the pre-attribution flush this fails deterministically: the channel
+// carried the live storage struct, so the strip nils the trees the consumer is
+// about to read and the clear empties its Outbound map.
+func TestFlush_ChannelSnapshotSurvivesTheProducer(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
+	// Buffered so a later tick cannot block the producer: the pre-attribution flush
+	// sent while holding eventsStorageMutex, so a full channel would deadlock this
+	// test against its own handleNetworkEvent call rather than failing an assertion.
+	ch := make(chan armotypes.NetworkStream, 16)
+	ns := newTestStreamWithChannel(t, mgr, ch, 200*time.Millisecond)
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+
+	ns.Start()
+
+	var received armotypes.NetworkStream
+	select {
+	case received = <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no flush arrived on the notification channel")
+	}
+
+	// Let the producer finish the flush and record another connection.
+	time.Sleep(300 * time.Millisecond)
+	ns.handleNetworkEvent(outboundEvent(202, "9.9.9.9", 80), treeFor(202, "wget"))
+
+	outbound := received.Entities[testNodeName].Outbound
+	require.Len(t, outbound, 1, "the received snapshot must keep its own events after the producer clears and re-fills storage")
+	for _, ev := range outbound {
+		require.NotNil(t, ev.ProcessTree, "the channel consumer keeps trees — the host network sensor reads them")
+		assert.Equal(t, "curl", ev.ProcessTree.ProcessTree.Comm)
+		require.NotNil(t, ev.ProcessRef)
 	}
 }

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -2,13 +2,157 @@ package networkstream
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/dnsmanager"
 	"github.com/kubescape/node-agent/pkg/exporters"
+	"github.com/kubescape/node-agent/pkg/processtree"
+	"github.com/kubescape/node-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+const testNodeName = "test-node"
+
+// stubResolver reports every address as resolved so buildNetworkEvent skips its
+// net.LookupAddr fallback: these tests must not depend on the sandbox having DNS.
+type stubResolver struct{}
+
+var _ dnsmanager.DNSResolver = (*stubResolver)(nil)
+
+func (stubResolver) ResolveIPAddress(string) (string, bool) { return "", true }
+func (stubResolver) ResolveContainerProcessToCloudServices(string, uint32) mapset.Set[string] {
+	return nil
+}
+
+// newTestStream builds a NetworkStream with KubernetesMode off, so there is no k8s
+// inventory to reach for and sendNetworkEvent is a no-op. Events land on the host
+// entity because k8sObjectCache is nil.
+func newTestStream(t *testing.T, mgr processtree.ProcessTreeManager) *NetworkStream {
+	t.Helper()
+	ns, err := NewNetworkStream(context.Background(), config.Config{}, nil, stubResolver{}, testNodeName, nil, true, mgr)
+	require.NoError(t, err)
+	return ns
+}
+
+func outboundEvent(pid uint32, addr string, port uint16) *utils.StructEvent {
+	return &utils.StructEvent{
+		Pid:         pid,
+		PktType:     "OUTGOING",
+		Proto:       "TCP",
+		DstPort:     port,
+		DstEndpoint: types.L3Endpoint{Addr: addr},
+		Timestamp:   time.Now().UnixNano(),
+	}
+}
+
+func treeFor(pid uint32, comm string) *armotypes.ProcessTree {
+	return &armotypes.ProcessTree{ProcessTree: armotypes.Process{PID: pid, Comm: comm}}
+}
+
+// TestHandleNetworkEvent_TwoProcessesSameEndpoint pins the DATA LOSS this change
+// fixes, not merely the attribution: the batch key is address/port/protocol with
+// first-writer-wins, so the second process's connection is silently DISCARDED —
+// it never reaches the wire under any process identity at all.
+func TestHandleNetworkEvent_TwoProcessesSameEndpoint(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
+	mgr.SetProcessBootTimeNs(202, 7_010_000_000)
+	ns := newTestStream(t, mgr)
+
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+	ns.handleNetworkEvent(outboundEvent(202, "1.2.3.4", 443), treeFor(202, "wget"))
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	require.Len(t, entity.Outbound, 2, "both processes' connections to one endpoint must survive the batch; today the second is dropped")
+
+	refs := map[string]string{}
+	for key, ev := range entity.Outbound {
+		require.NotNil(t, ev.ProcessRef, "every attributed connection carries a processRef")
+		assert.True(t, strings.HasSuffix(key, "/"+ev.ProcessRef.String()),
+			"batch key %q must end with the event's own ref %q", key, ev.ProcessRef.String())
+		require.NotNil(t, ev.ProcessTree)
+		refs[ev.ProcessRef.String()] = ev.ProcessTree.ProcessTree.Comm
+	}
+	// The comm proves each surviving entry kept its OWN process's data rather than
+	// inheriting the first writer's.
+	assert.Equal(t, map[string]string{"101/5000000000": "curl", "202/7010000000": "wget"}, refs)
+}
+
+// TestHandleNetworkEvent_SameProcessSameEndpoint: first-writer-wins is retained
+// for one process, so the batch does not grow per repeated connection.
+func TestHandleNetworkEvent_SameProcessSameEndpoint(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
+	ns := newTestStream(t, mgr)
+
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+
+	assert.Len(t, ns.networkEventsStorage.Entities[testNodeName].Outbound, 1)
+}
+
+// TestHandleNetworkEvent_UnknownStartTime: a zero StartTimeNs is legal pid-only
+// identity (process not yet procfs-scanned, or a Kubernetes-mode host process).
+// The ref must still be emitted — dropping it would lose attribution entirely
+// for that population.
+func TestHandleNetworkEvent_UnknownStartTime(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock()) // reports 0 for every pid
+	ns.handleNetworkEvent(outboundEvent(303, "5.6.7.8", 80), nil)
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	require.Len(t, entity.Outbound, 1)
+	for key, ev := range entity.Outbound {
+		require.NotNil(t, ev.ProcessRef)
+		assert.Equal(t, "303/0", ev.ProcessRef.String())
+		assert.Equal(t, "5.6.7.8/80/TCP/303/0", key)
+	}
+}
+
+// TestHandleNetworkEvent_NoPidKeepsLegacyKey: with no pid there is nothing to
+// attribute, and the key must stay byte-identical to today's format — no
+// trailing separator — so an unattributed key can never collide with an
+// attributed one (which always carries two more components).
+func TestHandleNetworkEvent_NoPidKeepsLegacyKey(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(outboundEvent(0, "9.9.9.9", 53), nil)
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	require.Len(t, entity.Outbound, 1)
+	for key, ev := range entity.Outbound {
+		assert.Equal(t, "9.9.9.9/53/TCP", key)
+		assert.Nil(t, ev.ProcessRef, "pid 0 is not an identity")
+	}
+}
+
+// TestHandleDnsEvent_TwoProcessesSameDomain: the same first-writer-wins data loss
+// exists for two processes querying one domain.
+func TestHandleDnsEvent_TwoProcessesSameDomain(t *testing.T) {
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
+	mgr.SetProcessBootTimeNs(202, 7_010_000_000)
+	ns := newTestStream(t, mgr)
+
+	dnsEvent := func(pid uint32) *utils.StructEvent {
+		return &utils.StructEvent{Pid: pid, DNSName: "evil.example.com.", DstPort: 53, Timestamp: time.Now().UnixNano()}
+	}
+	ns.handleDnsEvent(dnsEvent(101), treeFor(101, "curl"))
+	ns.handleDnsEvent(dnsEvent(202), treeFor(202, "wget"))
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	require.Len(t, entity.Outbound, 2, "both processes' DNS queries must survive the batch")
+	for key, ev := range entity.Outbound {
+		require.NotNil(t, ev.ProcessRef)
+		assert.Equal(t, "evil.example.com./"+ev.ProcessRef.String(), key)
+		assert.Equal(t, "evil.example.com.", ev.DNSName, "the DNS name itself must not absorb the ref")
+	}
+}
 
 func TestNewNetworkStream(t *testing.T) {
 	tests := []struct {

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -413,3 +413,16 @@ func TestProcessRefFor_NoManager(t *testing.T) {
 	assert.Nil(t, ns.processRefFor(101), "no manager means nothing to attribute, not a panic")
 	assert.Nil(t, ns.processRefFor(0))
 }
+
+func TestCountConnections(t *testing.T) {
+	assert.Zero(t, countConnections(&armotypes.NetworkStream{}))
+
+	stream := &armotypes.NetworkStream{Entities: map[string]armotypes.NetworkStreamEntity{
+		"a": {
+			Inbound:  map[string]armotypes.NetworkStreamEvent{"i1": {}, "i2": {}},
+			Outbound: map[string]armotypes.NetworkStreamEvent{"o1": {}},
+		},
+		"b": {Outbound: map[string]armotypes.NetworkStreamEvent{"o2": {}, "o3": {}}},
+	}}
+	assert.Equal(t, 5, countConnections(stream), "inbound and outbound across every entity")
+}

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -305,15 +305,10 @@ func TestSnapshotNetworkStream_OwnsItsEventMaps(t *testing.T) {
 	}
 }
 
-// TestFlush_ChannelSnapshotSurvivesTheProducer pins the notification-channel
-// contract end to end. private-node-agent's host network sensor reads
-// outbound.ProcessTree off this channel, so what it receives must (a) still carry
-// trees and (b) be immune to everything the producer does after the send —
-// stripping trees, clearing entities, recording new events.
-//
-// Against the pre-attribution flush this fails deterministically: the channel
-// carried the live storage struct, so the strip nils the trees the consumer is
-// about to read and the clear empties its Outbound map.
+// TestFlush_ChannelSnapshotSurvivesTheProducer pins the channel contract end to end:
+// what the consumer receives must still carry trees AND be immune to everything the
+// producer does afterwards. Fails deterministically against the pre-attribution flush,
+// which handed over the live storage struct and then stripped and cleared it.
 func TestFlush_ChannelSnapshotSurvivesTheProducer(t *testing.T) {
 	mgr := processtree.NewProcessTreeManagerMock()
 	mgr.SetProcessBootTimeNs(101, 5_000_000_000)
@@ -351,12 +346,10 @@ func TestFlush_ChannelSnapshotSurvivesTheProducer(t *testing.T) {
 	}
 }
 
-// TestFlush_BlockedChannelSendHonoursShutdown: the channel send is deliberately
-// blocking, so a slow consumer applies backpressure rather than losing traffic.
-// That makes it a goroutine leak unless it also selects on context cancellation —
-// which the send could not do while it held eventsStorageMutex. Nothing else in
-// this suite enters the blocked path, because every other channel test buffers
-// specifically so the producer never blocks.
+// TestFlush_BlockedChannelSendHonoursShutdown: the send blocks deliberately, so a slow
+// consumer applies backpressure instead of losing traffic — which leaks the goroutine
+// unless it also selects on ctx. Nothing else here enters the blocked path, because the
+// other channel tests buffer so the producer never blocks.
 func TestFlush_BlockedChannelSendHonoursShutdown(t *testing.T) {
 	mgr := processtree.NewProcessTreeManagerMock()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -9,102 +9,51 @@ import (
 	"github.com/kubescape/go-logger/helpers"
 )
 
-// maxCmdlineBytes caps each process node's command line ON THE WIRE COPY ONLY.
-// cmdline is ~40% of a tree's bytes and unbounded, so it is the lever that keeps
-// the payload tail bounded: the worst observed message lands near 2 MB at p90
-// tree size against a 5 MiB limit (SUB-7850), and one pathological java or node
-// command line can exceed 100 KB on its own. 1024 bytes keeps >99% of real
-// command lines intact.
-//
-// The legacy alert paths and the notification-channel consumer keep the UNCAPPED
-// value — never apply this to a node they share.
+// Wire-format assembly for the HTTP payload. The reasoning behind every constant
+// here, with the production measurements it was calibrated against, is in
+// docs/features/network-stream-process-attribution.md.
+
+// maxCmdlineBytes caps a command line on the WIRE COPY ONLY. cmdline is unbounded
+// and ~40% of a tree's bytes. The alert paths and the notification-channel consumer
+// share these nodes and must keep the full value.
 const maxCmdlineBytes = 1024
 
-// cmdlineTruncationMarker makes a cut visible to a human reading the payload. It
-// is charged against the budget, so a capped value is never longer than
-// maxCmdlineBytes.
+// cmdlineTruncationMarker makes a cut visible, and is charged against the cap.
 const cmdlineTruncationMarker = "…"
 
-// maxTreeDepth bounds every recursive tree walk here. Real chains are ~10 nodes
-// deep; this exists so a malformed or cyclic tree costs a truncated payload
-// rather than the agent's stack.
+// maxTreeDepth bounds every recursive walk here, so a malformed or cyclic tree
+// costs a truncated payload rather than the stack. Real chains are ~10 nodes.
 const maxTreeDepth = 64
 
-// maxProcessTreeBytes budgets the process trees in one message.
+// maxProcessTreeBytes bounds the trees in one message, keeping it under the
+// broker's 5 MiB limit. Exceeding that limit is not graceful: the message is
+// rejected and dropped, so the node loses its whole interval of traffic rather
+// than some trees. A bound is needed because the process-aware batch key makes the
+// payload scale with distinct processes, which nothing else limits.
 //
-// This is the bound that keeps a message under the 5 MiB broker limit. It is
-// needed because attribution changed what sizes the payload: the batch key now
-// splits per process, so the message grows with the number of DISTINCT PROCESSES
-// that connected during the interval, and each one contributes a tree. The
-// original payload analysis (SUB-7850) modelled bytes per connection at a fixed
-// connection count of 283, which is exactly the quantity the key change stops
-// holding fixed. Without a bound, a node with heavy short-lived process churn —
-// a cron loop shelling out, a CI runner, exec-based probes — can exceed the limit,
-// and the whole message is then rejected and dropped: the node loses its entire
-// interval of traffic, not just some trees.
-//
-// A budget in BYTES rather than a tree count, because tree size is not uniform:
-// depth varies, the fields are variable-length, and JSON escaping inflates some
-// content ~6x (see escapedLen). No tree count bounds the payload.
-//
-// Calibrated against measured production traffic rather than guessed. In prod-eu a
-// network-stream message averages 29 KB on the topic, so ~22 KB of JSON before the
-// synchronizer envelope's base64; the reputation consumer's events_in divided by
-// the topic's message count puts a batch at ~42 connections (prod-us: ~32), which
-// makes a connection ~530 bytes of JSON without its tree. The largest batch ever
-// observed is 283 connections (SUB-7850).
-//
-// Measured against the worst case this budget exists for — EVERY connection from a
-// distinct process, so trees scale 1:1 with connections — using a fully-populated
-// 10-node chain, which estimates ~5.1 KB and marshals to ~4.3 KB:
-//
-//	 283 connections (the observed worst): all 283 trees ship, 1.77 MiB after base64
-//	 500 connections:                      all 500 ship,      3.13 MiB
-//	1000 connections:                      binds at 513 trees, 3.60 MiB
-//
-// So 2.5 MiB, which binds above ~513 such trees — 1.8x the observed worst batch,
-// keeping it a safety valve rather than a routine limiter that would degrade
-// attribution on the busiest nodes. A tighter 1.5 MiB was tried first and rejected:
-// it clips 70 of 283 trees, below the observed worst, while the payload there is
-// barely a third of the limit.
-//
-// Residual, deliberately not addressed here: with trees bounded, the connection
-// ENTRIES alone breach the limit at ~3,300 connections (11x the observed worst) —
-// measured 6.01 MiB at 4,000. The fix for that regime is splitting the message, as
-// the container profile does on HTTP 413, not dropping connections. The logging
-// below is what would tell us it is being approached.
+// Bytes rather than a tree count, because tree size varies too much for any count
+// to bound the payload. 2.5 MiB holds ~513 realistic trees — well above the largest
+// batch observed in production (283 connections), so it is a safety valve rather
+// than a routine limiter.
 const maxProcessTreeBytes = 2560 * 1024
 
-// processNodeOverheadBytes approximates the non-string JSON cost of one process
-// node — every field name, the numeric ids, the RFC-3339 start time (time.Time
-// ignores omitempty, so it is always serialised) and the childrenMap key, in which
-// a node's comm appears a second time.
-//
-// Measured against a fully-populated node as the tree builder produces them, which
-// is ~360 bytes with short strings. Deliberately generous: this feeds a budget, so
-// overestimating shrinks the payload while underestimating is what risks the limit.
+// processNodeOverheadBytes is one node's non-string JSON cost: field names, ids,
+// the always-serialised start time, and the childrenMap key. ~360 measured for a
+// fully-populated node; generous on purpose, since underestimating risks the limit.
 const processNodeOverheadBytes = 320
 
-// escapedByteBytes is the cost of one byte that JSON renders as an escape. The
-// worst form is \uXXXX; the short forms (\" \\ \n \r \t) cost 2, but they are
-// charged 6 as well, because over-charging shrinks the payload and under-charging
-// is what breaches the limit.
+// escapedByteBytes is what one JSON-escaped byte costs. \uXXXX is the worst form;
+// the short forms cost 2 but are charged 6 as well, erring toward a smaller payload.
 const escapedByteBytes = 6
 
-// buildWireStream derives the HTTP payload from the flush snapshot: per-event
-// trees move into the message-scoped Processes map — one capped copy per distinct
-// ProcessRef, because trees dominate the payload cost and the extra map entries
-// do not — events keep only their ref, and the attribution version marker is
-// stamped unconditionally, since an upgraded sensor with nothing to attribute
-// must stay distinguishable from a sensor that predates attribution.
+// buildWireStream derives the HTTP payload from the flush snapshot: each event's
+// tree moves into the message-scoped Processes map (one capped copy per distinct
+// ref), events keep only their ref, and the version marker is set unconditionally
+// so an upgraded sensor with nothing to attribute stays distinguishable from one
+// that predates attribution.
 //
-// The snapshot is NEVER mutated. The notification-channel consumer
-// (private-node-agent's host network sensor) holds it and reads
-// event.ProcessTree, and the trees themselves are shared with the process-tree
-// manager's cache and the legacy alert paths.
-//
-// Runs OUTSIDE eventsStorageMutex: this is the only expensive part of a flush,
-// and holding the lock across it would stall event recording.
+// Never mutates the snapshot: the notification-channel consumer holds it, and the
+// trees are shared with the process-tree cache and the alert paths.
 func buildWireStream(snapshot *armotypes.NetworkStream) *armotypes.NetworkStream {
 	wire := &armotypes.NetworkStream{
 		ProcessAttributionVersion: armotypes.NetworkStreamProcessAttributionV1,
@@ -138,11 +87,10 @@ type processCandidate struct {
 // collectTrees returns a copy of events with the per-event tree cleared, gathering
 // one candidate per distinct ref.
 //
-// On collision the DEEPER chain wins. The process-tree cache TTL (1 minute) is
-// shorter than the flush interval (2 minutes), so two lookups for one process
-// inside a single interval can legitimately return chains with different amounts
-// of ancestry resolved. First-wins would discard the richer chain and would make
-// the payload depend on Go's randomised map iteration order.
+// On collision the deeper chain wins: the tree cache TTL is shorter than the flush
+// interval, so two lookups for one process can return different amounts of resolved
+// ancestry, and first-wins would both discard the richer chain and make the payload
+// depend on map iteration order.
 func collectTrees(events map[string]armotypes.NetworkStreamEvent, candidates map[armotypes.ProcessRef]*processCandidate) map[string]armotypes.NetworkStreamEvent {
 	out := make(map[string]armotypes.NetworkStreamEvent, len(events))
 	for key, event := range events {
@@ -171,21 +119,13 @@ func collectTrees(events map[string]armotypes.NetworkStreamEvent, candidates map
 // selectProcessTrees copies the candidate trees that fit maxProcessTreeBytes,
 // returning nil when there are none so omitempty drops the field.
 //
-// Over budget, candidates are ranked SMALLEST TREE FIRST, ties broken on the ref.
-// That maximises the number of processes that keep an attributable tree, which is
-// the best available objective given that the sensor cannot know which process will
-// turn out to matter.
+// Over budget, ranking is smallest-tree-first, which maximises how many processes
+// keep a tree; ties break on the ref so the shipped set never depends on map
+// iteration order. (Ranking by connection count was rejected: a low-and-slow beacon
+// makes one connection per interval, so it would lose its tree first.)
 //
-// Ranking by connection count was tried and rejected: it sounds right, but a
-// low-and-slow beacon opens exactly ONE connection per interval, so it sorts last
-// and is the first tree dropped — the precise case reputation attribution exists to
-// catch. Tie-breaking on the ref keeps the payload independent of Go's randomised
-// map iteration order either way.
-//
-// Dropped candidates keep their refs on the connections — the pid identity
-// survives, and ProcessTreeFor is specified to return nil for a ref with no entry —
-// so the cost is degraded attribution for some processes rather than a rejected
-// message and the loss of every traffic row for the interval.
+// Connections are never dropped — only trees. Their refs stay put, so pid identity
+// survives and ProcessTreeFor returns nil for them as specified.
 func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) map[armotypes.ProcessRef]*armotypes.ProcessTree {
 	if len(candidates) == 0 {
 		return nil
@@ -231,10 +171,9 @@ func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) m
 		usedBytes += candidate.estBytes
 	}
 
-	// The whole point of the budget is that we find out whether it ever fires.
-	logger.L().Warning("NetworkStream - process tree budget exceeded, shipping refs without trees for the largest trees",
-		helpers.Int("processesWithTrees", len(candidates)), // processes with a ref but no tree are not candidates
-
+	// Logged so we learn whether this ever fires in production.
+	logger.L().Warning("NetworkStream - process tree budget exceeded, dropping the largest trees",
+		helpers.Int("processesWithTrees", len(candidates)),
 		helpers.Int("treesShipped", len(processes)),
 		helpers.Int("treesDropped", droppedTrees),
 		helpers.Int("connectionsWithoutTree", droppedConnections),
@@ -258,8 +197,7 @@ func estimateProcessBytes(node *armotypes.Process, budget int) int {
 		return 0
 	}
 
-	// The command line is counted as capTreeCopy will leave it. Slicing raw bytes
-	// mirrors capCmdline's budget; a cut mid-rune only makes escapedLen charge more.
+	// Counted as capTreeCopy will leave it; a cut mid-rune only costs more, not less.
 	cmdline := node.Cmdline
 	if len(cmdline) > maxCmdlineBytes {
 		cmdline = cmdline[:maxCmdlineBytes]
@@ -279,17 +217,11 @@ func estimateProcessBytes(node *armotypes.Process, budget int) int {
 	return total
 }
 
-// escapedLen returns at least the number of bytes encoding/json emits for s,
-// excluding the surrounding quotes.
-//
-// len(s) is NOT what reaches the wire, and the difference is what decides whether
-// the budget is a real bound. json escapes `"` and `\`, every control byte, and —
-// because Marshal enables HTML escaping — `<`, `>` and `&`, which real command
-// lines are full of (`sh -c 'cmd > /dev/null 2>&1'`). Invalid UTF-8 is replaced
-// byte-for-byte by �, and process argv is arbitrary kernel bytes, not
-// guaranteed UTF-8. Each such byte costs up to six where len() counts one, so
-// charging len() let a payload six times the estimate pass the budget and breach
-// the broker's message limit — losing the node's whole interval of traffic.
+// escapedLen returns at least the bytes encoding/json emits for s, excluding the
+// quotes. Never use len() here: json escapes `"`, `\`, control bytes and — Marshal
+// enables HTML escaping — `<`, `>`, `&`, which command lines are full of, and it
+// replaces each invalid UTF-8 byte (argv is raw kernel bytes) with \ufffd. Those
+// cost 6 bytes where len() counts 1, which is enough to void the budget entirely.
 func escapedLen(s string) int {
 	total := 0
 	for i := 0; i < len(s); {
@@ -316,10 +248,9 @@ func escapedLen(s string) int {
 	return total
 }
 
-// capTreeCopy returns an independent copy of a chain with every node's command
-// line capped. It must copy rather than cap in place: the nodes are shared with
-// the process-tree manager's LRU cache, the legacy alert paths, and the
-// notification-channel consumer, all of which keep the uncapped values.
+// capTreeCopy returns an independent copy of a chain with every command line capped.
+// It must copy rather than cap in place: these nodes are shared with the process-tree
+// cache, the alert paths and the channel consumer, which keep the uncapped values.
 func capTreeCopy(tree *armotypes.ProcessTree) *armotypes.ProcessTree {
 	if tree == nil {
 		return nil
@@ -328,27 +259,25 @@ func capTreeCopy(tree *armotypes.ProcessTree) *armotypes.ProcessTree {
 	if copied == nil {
 		return nil
 	}
-	// Copy the wrapper wholesale rather than field-listing it: a field list silently
-	// drops anything added to ProcessTree later, which is the exact trap the three
-	// existing process copiers fell into (see docs/features/process-start-time.md).
+	// Wholesale, not field-listed: a field list silently drops anything added to
+	// ProcessTree later. See docs/features/process-start-time.md for that trap.
 	dst := *tree
 	dst.ProcessTree = *copied
 	return &dst
 }
 
-// copyCappedProcess copies a node and its descendants, capping command lines as
-// it goes, and writes NOTHING to the source.
+// copyCappedProcess copies a node and its descendants, capping command lines, and
+// writes NOTHING to the source.
 //
-// armotypes.Process.DeepCopy cannot be used here: it calls MigrateToMap on its
-// receiver and on every child it recurses into, which allocates ChildrenMap and
-// nils Children on nodes other goroutines are reading. This function normalises
-// the deprecated Children slice on read instead.
+// Do not replace this with armotypes.Process.DeepCopy: that calls MigrateToMap on
+// its receiver and on every child it descends into, writing to nodes other
+// goroutines are reading. This normalises the deprecated Children slice on read.
 func copyCappedProcess(src *armotypes.Process, budget int) *armotypes.Process {
 	if src == nil || budget <= 0 {
 		return nil
 	}
 
-	dst := *src // scalar and string fields; strings are immutable, so sharing them is safe
+	dst := *src // strings are immutable, so sharing them is safe
 	dst.Cmdline = capCmdline(src.Cmdline)
 	dst.Uid = copyUint32Ptr(src.Uid)
 	dst.Gid = copyUint32Ptr(src.Gid)
@@ -391,9 +320,8 @@ func copyBoolPtr(p *bool) *bool {
 	return &v
 }
 
-// chainDepth returns the longest root-to-leaf node count, bounded by
-// maxTreeDepth. Read-only: unlike DeepCopy it does not normalise as it walks, so
-// it counts both child representations.
+// chainDepth returns the longest root-to-leaf node count, bounded by maxTreeDepth.
+// Read-only, so it counts both child representations rather than normalising.
 func chainDepth(node *armotypes.Process) int {
 	return chainDepthWithin(node, maxTreeDepth)
 }

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -1,0 +1,196 @@
+package networkstream
+
+import (
+	"unicode/utf8"
+
+	"github.com/armosec/armoapi-go/armotypes"
+)
+
+// maxCmdlineBytes caps each process node's command line ON THE WIRE COPY ONLY.
+// cmdline is ~40% of a tree's bytes and unbounded, so it is the lever that keeps
+// the payload tail bounded: the worst observed message lands near 2 MB at p90
+// tree size against a 5 MiB limit (SUB-7850), and one pathological java or node
+// command line can exceed 100 KB on its own. 1024 bytes keeps >99% of real
+// command lines intact.
+//
+// The legacy alert paths and the notification-channel consumer keep the UNCAPPED
+// value — never apply this to a node they share.
+const maxCmdlineBytes = 1024
+
+// cmdlineTruncationMarker makes a cut visible to a human reading the payload. It
+// is charged against the budget, so a capped value is never longer than
+// maxCmdlineBytes.
+const cmdlineTruncationMarker = "…"
+
+// maxTreeDepth bounds every recursive tree walk here. Real chains are ~10 nodes
+// deep; this exists so a malformed or cyclic tree costs a truncated payload
+// rather than the agent's stack.
+const maxTreeDepth = 64
+
+// buildWireStream derives the HTTP payload from the flush snapshot: per-event
+// trees move into the message-scoped Processes map — one capped copy per distinct
+// ProcessRef, because trees dominate the payload cost and the extra map entries
+// do not — events keep only their ref, and the attribution version marker is
+// stamped unconditionally, since an upgraded sensor with nothing to attribute
+// must stay distinguishable from a sensor that predates attribution.
+//
+// The snapshot is NEVER mutated. The notification-channel consumer
+// (private-node-agent's host network sensor) holds it and reads
+// event.ProcessTree, and the trees themselves are shared with the process-tree
+// manager's cache and the legacy alert paths.
+//
+// Runs OUTSIDE eventsStorageMutex: this is the only expensive part of a flush,
+// and holding the lock across it would stall event recording.
+func buildWireStream(snapshot *armotypes.NetworkStream) *armotypes.NetworkStream {
+	wire := &armotypes.NetworkStream{
+		ProcessAttributionVersion: armotypes.NetworkStreamProcessAttributionV1,
+	}
+	if snapshot == nil {
+		return wire
+	}
+
+	wire.Entities = make(map[string]armotypes.NetworkStreamEntity, len(snapshot.Entities))
+	wire.Processes = make(map[armotypes.ProcessRef]*armotypes.ProcessTree)
+	for entityID, entity := range snapshot.Entities {
+		e := entity
+		e.Inbound = moveTreesToProcessMap(entity.Inbound, wire.Processes)
+		e.Outbound = moveTreesToProcessMap(entity.Outbound, wire.Processes)
+		wire.Entities[entityID] = e
+	}
+	if len(wire.Processes) == 0 {
+		wire.Processes = nil // omitempty: don't ship an empty object
+	}
+	return wire
+}
+
+// moveTreesToProcessMap returns a copy of events with their trees lifted into
+// processes and the per-event tree cleared.
+//
+// On collision the DEEPER chain wins. The process-tree cache TTL (1 minute) is
+// shorter than the flush interval (2 minutes), so two lookups for one process
+// inside a single interval can legitimately return chains with different amounts
+// of ancestry resolved. First-wins would discard the richer chain and would make
+// the payload depend on Go's randomised map iteration order.
+func moveTreesToProcessMap(events map[string]armotypes.NetworkStreamEvent, processes map[armotypes.ProcessRef]*armotypes.ProcessTree) map[string]armotypes.NetworkStreamEvent {
+	out := make(map[string]armotypes.NetworkStreamEvent, len(events))
+	for key, event := range events {
+		// event is a copy of the map value, so clearing its tree below cannot
+		// reach the snapshot the channel consumer holds.
+		if event.ProcessRef != nil && event.ProcessTree != nil {
+			ref := *event.ProcessRef
+			existing, seen := processes[ref]
+			if !seen || chainDepth(&event.ProcessTree.ProcessTree) > chainDepth(&existing.ProcessTree) {
+				processes[ref] = capTreeCopy(event.ProcessTree)
+			}
+		}
+		event.ProcessTree = nil // the wire carries the ref; the tree lives in Processes
+		out[key] = event
+	}
+	return out
+}
+
+// capTreeCopy returns an independent copy of a chain with every node's command
+// line capped. It must copy rather than cap in place: the nodes are shared with
+// the process-tree manager's LRU cache, the legacy alert paths, and the
+// notification-channel consumer, all of which keep the uncapped values.
+func capTreeCopy(tree *armotypes.ProcessTree) *armotypes.ProcessTree {
+	if tree == nil {
+		return nil
+	}
+	copied := copyCappedProcess(&tree.ProcessTree, maxTreeDepth)
+	return &armotypes.ProcessTree{ContainerID: tree.ContainerID, ProcessTree: *copied}
+}
+
+// copyCappedProcess copies a node and its descendants, capping command lines as
+// it goes, and writes NOTHING to the source.
+//
+// armotypes.Process.DeepCopy cannot be used here: it calls MigrateToMap on its
+// receiver and on every child it recurses into, which allocates ChildrenMap and
+// nils Children on nodes other goroutines are reading. This function normalises
+// the deprecated Children slice on read instead.
+func copyCappedProcess(src *armotypes.Process, budget int) *armotypes.Process {
+	if src == nil || budget <= 0 {
+		return nil
+	}
+
+	dst := *src // scalar and string fields; strings are immutable, so sharing them is safe
+	dst.Cmdline = capCmdline(src.Cmdline)
+	dst.Uid = copyUint32Ptr(src.Uid)
+	dst.Gid = copyUint32Ptr(src.Gid)
+	dst.UpperLayer = copyBoolPtr(src.UpperLayer)
+	dst.Children = nil // normalised into ChildrenMap below
+	dst.ChildrenMap = nil
+
+	children := make(map[armotypes.CommPID]*armotypes.Process, len(src.ChildrenMap)+len(src.Children))
+	for key, child := range src.ChildrenMap {
+		if copiedChild := copyCappedProcess(child, budget-1); copiedChild != nil {
+			children[key] = copiedChild
+		}
+	}
+	for i := range src.Children {
+		copiedChild := copyCappedProcess(&src.Children[i], budget-1)
+		if copiedChild == nil {
+			continue
+		}
+		children[armotypes.CommPID{Comm: copiedChild.Comm, PID: copiedChild.PID}] = copiedChild
+	}
+	if len(children) > 0 {
+		dst.ChildrenMap = children
+	}
+	return &dst
+}
+
+func copyUint32Ptr(p *uint32) *uint32 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func copyBoolPtr(p *bool) *bool {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+// chainDepth returns the longest root-to-leaf node count, bounded by
+// maxTreeDepth. Read-only: unlike DeepCopy it does not normalise as it walks, so
+// it counts both child representations.
+func chainDepth(node *armotypes.Process) int {
+	return chainDepthWithin(node, maxTreeDepth)
+}
+
+func chainDepthWithin(node *armotypes.Process, budget int) int {
+	if node == nil || budget <= 0 {
+		return 0
+	}
+	deepest := 0
+	for _, child := range node.ChildrenMap {
+		if d := chainDepthWithin(child, budget-1); d > deepest {
+			deepest = d
+		}
+	}
+	for i := range node.Children {
+		if d := chainDepthWithin(&node.Children[i], budget-1); d > deepest {
+			deepest = d
+		}
+	}
+	return deepest + 1
+}
+
+// capCmdline truncates to maxCmdlineBytes including the marker, never splitting a
+// UTF-8 rune. Deterministic, so the backend's identity hash is stable for a given
+// sensor version.
+func capCmdline(cmdline string) string {
+	if len(cmdline) <= maxCmdlineBytes {
+		return cmdline
+	}
+	cut := maxCmdlineBytes - len(cmdlineTruncationMarker)
+	for cut > 0 && !utf8.RuneStart(cmdline[cut]) {
+		cut--
+	}
+	return cmdline[:cut] + cmdlineTruncationMarker
+}

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -43,17 +43,35 @@ const maxTreeDepth = 64
 // and the whole message is then rejected and dropped: the node loses its entire
 // interval of traffic, not just some trees.
 //
-// A budget in BYTES rather than a tree count, because tree size varies by ~2.5x
-// even with the command-line cap (~2 KB median, ~5 KB p90, ~12 KB for a deep chain
+// A budget in BYTES rather than a tree count, because tree size varies by ~3.5x
+// even with the command-line cap (~2 KB median, ~7 KB p90, ~12 KB for a deep chain
 // of capped command lines), so no count bounds the payload.
 //
-// 1.5 MiB of estimated tree bytes ≈ 2.1 MB once the synchronizer envelope's base64
-// costs x1.333, leaving room for the connection entries themselves and for the
-// 5 MiB ceiling. At p90 tree size that is ~300 trees, above the largest message
-// observed in production (283 connections, so at most 283 distinct processes), so
-// this is a safety valve rather than a routine limiter. Whether it ever fires is
-// deliberately observable: see the warning below.
-const maxProcessTreeBytes = 1536 * 1024
+// Calibrated against measured production traffic rather than guessed. In prod-eu a
+// network-stream message averages 29 KB on the topic, so ~22 KB of JSON before the
+// synchronizer envelope's base64; the reputation consumer's events_in divided by
+// the topic's message count puts a batch at ~42 connections (prod-us: ~32), which
+// makes a connection ~530 bytes of JSON without its tree. The largest batch ever
+// observed is 283 connections (SUB-7850).
+//
+// Taking the worst case this budget exists for — EVERY connection from a distinct
+// process, so trees scale 1:1 with connections:
+//
+//	283 connections x ~7 KB p90 tree ≈ 1.96 MiB of trees, + 146 KB of entries
+//	≈ 2.1 MiB JSON ≈ 2.8 MiB after base64 — 56% of the 5 MiB limit.
+//
+// So 2.5 MiB. It binds above ~360 distinct processes at p90 tree size and ~1280 at
+// median, i.e. above anything yet observed, which keeps it a safety valve instead
+// of a routine limiter that would degrade attribution on the busiest nodes. A
+// tighter 1.5 MiB was tried first and rejected: it binds at 216-301 trees, *below*
+// the observed worst batch, while the payload there is only half the limit.
+//
+// Residual, deliberately not addressed here: with trees bounded, the connection
+// entries alone would breach the limit at ~2,500 connections — 9x the observed
+// worst. The fix for that regime is splitting the message (as the container
+// profile does on HTTP 413), not dropping connections. The logging below is what
+// would tell us it is being approached.
+const maxProcessTreeBytes = 2560 * 1024
 
 // processNodeOverheadBytes approximates the non-string JSON cost of one process
 // node — field names, the numeric ids, the RFC-3339 start time and the child map

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -1,9 +1,12 @@
 package networkstream
 
 import (
+	"sort"
 	"unicode/utf8"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 )
 
 // maxCmdlineBytes caps each process node's command line ON THE WIRE COPY ONLY.
@@ -26,6 +29,37 @@ const cmdlineTruncationMarker = "…"
 // deep; this exists so a malformed or cyclic tree costs a truncated payload
 // rather than the agent's stack.
 const maxTreeDepth = 64
+
+// maxProcessTreeBytes budgets the process trees in one message.
+//
+// This is the bound that keeps a message under the 5 MiB broker limit. It is
+// needed because attribution changed what sizes the payload: the batch key now
+// splits per process, so the message grows with the number of DISTINCT PROCESSES
+// that connected during the interval, and each one contributes a tree. The
+// original payload analysis (SUB-7850) modelled bytes per connection at a fixed
+// connection count of 283, which is exactly the quantity the key change stops
+// holding fixed. Without a bound, a node with heavy short-lived process churn —
+// a cron loop shelling out, a CI runner, exec-based probes — can exceed the limit,
+// and the whole message is then rejected and dropped: the node loses its entire
+// interval of traffic, not just some trees.
+//
+// A budget in BYTES rather than a tree count, because tree size varies by ~2.5x
+// even with the command-line cap (~2 KB median, ~5 KB p90, ~12 KB for a deep chain
+// of capped command lines), so no count bounds the payload.
+//
+// 1.5 MiB of estimated tree bytes ≈ 2.1 MB once the synchronizer envelope's base64
+// costs x1.333, leaving room for the connection entries themselves and for the
+// 5 MiB ceiling. At p90 tree size that is ~300 trees, above the largest message
+// observed in production (283 connections, so at most 283 distinct processes), so
+// this is a safety valve rather than a routine limiter. Whether it ever fires is
+// deliberately observable: see the warning below.
+const maxProcessTreeBytes = 1536 * 1024
+
+// processNodeOverheadBytes approximates the non-string JSON cost of one process
+// node — field names, the numeric ids, the RFC-3339 start time and the child map
+// key. Deliberately generous: this feeds a budget, so overestimating shrinks the
+// payload and underestimating is what risks the limit.
+const processNodeOverheadBytes = 200
 
 // buildWireStream derives the HTTP payload from the flush snapshot: per-event
 // trees move into the message-scoped Processes map — one capped copy per distinct
@@ -50,43 +84,152 @@ func buildWireStream(snapshot *armotypes.NetworkStream) *armotypes.NetworkStream
 	}
 
 	wire.Entities = make(map[string]armotypes.NetworkStreamEntity, len(snapshot.Entities))
-	wire.Processes = make(map[armotypes.ProcessRef]*armotypes.ProcessTree)
+	candidates := make(map[armotypes.ProcessRef]*processCandidate)
 	for entityID, entity := range snapshot.Entities {
 		e := entity
-		e.Inbound = moveTreesToProcessMap(entity.Inbound, wire.Processes)
-		e.Outbound = moveTreesToProcessMap(entity.Outbound, wire.Processes)
+		e.Inbound = collectTrees(entity.Inbound, candidates)
+		e.Outbound = collectTrees(entity.Outbound, candidates)
 		wire.Entities[entityID] = e
 	}
-	if len(wire.Processes) == 0 {
-		wire.Processes = nil // omitempty: don't ship an empty object
-	}
+	wire.Processes = selectProcessTrees(candidates) // nil when empty: omitempty
 	return wire
 }
 
-// moveTreesToProcessMap returns a copy of events with their trees lifted into
-// processes and the per-event tree cleared.
+// processCandidate is one distinct process seen in a flush, with the best tree
+// found for it and what it would cost to ship.
+type processCandidate struct {
+	ref         armotypes.ProcessRef
+	tree        *armotypes.ProcessTree // the SOURCE tree; copied only if selected
+	depth       int
+	connections int
+	estBytes    int
+}
+
+// collectTrees returns a copy of events with the per-event tree cleared, gathering
+// one candidate per distinct ref.
 //
 // On collision the DEEPER chain wins. The process-tree cache TTL (1 minute) is
 // shorter than the flush interval (2 minutes), so two lookups for one process
 // inside a single interval can legitimately return chains with different amounts
 // of ancestry resolved. First-wins would discard the richer chain and would make
 // the payload depend on Go's randomised map iteration order.
-func moveTreesToProcessMap(events map[string]armotypes.NetworkStreamEvent, processes map[armotypes.ProcessRef]*armotypes.ProcessTree) map[string]armotypes.NetworkStreamEvent {
+func collectTrees(events map[string]armotypes.NetworkStreamEvent, candidates map[armotypes.ProcessRef]*processCandidate) map[string]armotypes.NetworkStreamEvent {
 	out := make(map[string]armotypes.NetworkStreamEvent, len(events))
 	for key, event := range events {
 		// event is a copy of the map value, so clearing its tree below cannot
 		// reach the snapshot the channel consumer holds.
 		if event.ProcessRef != nil && event.ProcessTree != nil {
 			ref := *event.ProcessRef
-			existing, seen := processes[ref]
-			if !seen || chainDepth(&event.ProcessTree.ProcessTree) > chainDepth(&existing.ProcessTree) {
-				processes[ref] = capTreeCopy(event.ProcessTree)
+			candidate, seen := candidates[ref]
+			if !seen {
+				candidate = &processCandidate{ref: ref}
+				candidates[ref] = candidate
+			}
+			candidate.connections++
+			if depth := chainDepth(&event.ProcessTree.ProcessTree); !seen || depth > candidate.depth {
+				candidate.tree = event.ProcessTree
+				candidate.depth = depth
+				candidate.estBytes = estimateTreeBytes(event.ProcessTree)
 			}
 		}
 		event.ProcessTree = nil // the wire carries the ref; the tree lives in Processes
 		out[key] = event
 	}
 	return out
+}
+
+// selectProcessTrees copies the candidate trees that fit maxProcessTreeBytes,
+// returning nil when there are none so omitempty drops the field.
+//
+// Over budget, candidates are ranked by connection count first: a process that
+// reached many endpoints is both the most expensive attribution to lose and the
+// shape reputation cares about most (beacon-style fan-out). Ties break on the ref
+// so the payload never depends on map iteration order. Dropped candidates keep
+// their refs on the connections — the pid identity survives, and ProcessTreeFor is
+// specified to return nil for a ref with no entry — so the cost is degraded
+// attribution for the least-connected processes rather than a rejected message and
+// the loss of every traffic row for the interval.
+func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) map[armotypes.ProcessRef]*armotypes.ProcessTree {
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	totalBytes := 0
+	for _, candidate := range candidates {
+		totalBytes += candidate.estBytes
+	}
+
+	processes := make(map[armotypes.ProcessRef]*armotypes.ProcessTree, len(candidates))
+	if totalBytes <= maxProcessTreeBytes {
+		for ref, candidate := range candidates {
+			processes[ref] = capTreeCopy(candidate.tree)
+		}
+		return processes
+	}
+
+	ordered := make([]*processCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		ordered = append(ordered, candidate)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		a, b := ordered[i], ordered[j]
+		if a.connections != b.connections {
+			return a.connections > b.connections
+		}
+		if a.ref.PID != b.ref.PID {
+			return a.ref.PID < b.ref.PID
+		}
+		return a.ref.StartTimeNs < b.ref.StartTimeNs
+	})
+
+	usedBytes, droppedTrees, droppedConnections := 0, 0, 0
+	for _, candidate := range ordered {
+		// Skip rather than stop, so a small tree still ships after an oversized one.
+		if usedBytes+candidate.estBytes > maxProcessTreeBytes {
+			droppedTrees++
+			droppedConnections += candidate.connections
+			continue
+		}
+		processes[candidate.ref] = capTreeCopy(candidate.tree)
+		usedBytes += candidate.estBytes
+	}
+
+	// The whole point of the budget is that we find out whether it ever fires.
+	logger.L().Warning("NetworkStream - process tree budget exceeded, shipping refs without trees for the least-connected processes",
+		helpers.Int("distinctProcesses", len(candidates)),
+		helpers.Int("treesShipped", len(processes)),
+		helpers.Int("treesDropped", droppedTrees),
+		helpers.Int("connectionsWithoutTree", droppedConnections),
+		helpers.Int("estimatedTreeBytes", totalBytes),
+		helpers.Int("budgetBytes", maxProcessTreeBytes))
+
+	return processes
+}
+
+// estimateTreeBytes approximates a tree's serialised size, counting the command
+// line as it will be AFTER capping. Read-only, and bounded by maxTreeDepth.
+func estimateTreeBytes(tree *armotypes.ProcessTree) int {
+	if tree == nil {
+		return 0
+	}
+	return len(tree.ContainerID) + estimateProcessBytes(&tree.ProcessTree, maxTreeDepth)
+}
+
+func estimateProcessBytes(node *armotypes.Process, budget int) int {
+	if node == nil || budget <= 0 {
+		return 0
+	}
+	total := processNodeOverheadBytes +
+		min(len(node.Cmdline), maxCmdlineBytes) +
+		len(node.Comm) + len(node.Pcomm) + len(node.Path) + len(node.Cwd) +
+		len(node.Hardlink) + len(node.UserName) + len(node.GroupName)
+	for _, child := range node.ChildrenMap {
+		total += estimateProcessBytes(child, budget-1)
+	}
+	for i := range node.Children {
+		total += estimateProcessBytes(&node.Children[i], budget-1)
+	}
+	return total
 }
 
 // capTreeCopy returns an independent copy of a chain with every node's command

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -32,15 +32,21 @@ const maxTreeDepth = 64
 // payload scale with distinct processes, which nothing else limits.
 //
 // Bytes rather than a tree count, because tree size varies too much for any count
-// to bound the payload. 2.5 MiB holds ~513 realistic trees — well above the largest
+// to bound the payload. 2.5 MiB holds ~461 realistic trees — well above the largest
 // batch observed in production (283 connections), so it is a safety valve rather
 // than a routine limiter.
 const maxProcessTreeBytes = 2560 * 1024
 
-// processNodeOverheadBytes is one node's non-string JSON cost: field names, ids,
-// the always-serialised start time, and the childrenMap key. ~360 measured for a
-// fully-populated node; generous on purpose, since underestimating risks the limit.
+// processNodeOverheadBytes is one node's non-string JSON cost: field names, the
+// numeric ids, the always-serialised start time and the childrenMap wrapper. ~360
+// measured for a fully-populated node; generous on purpose, since underestimating
+// risks the limit. Per-entry map keys are charged explicitly, not from this slack.
 const processNodeOverheadBytes = 320
+
+// processMapKeyOverheadBytes is a childrenMap entry key's cost apart from the comm:
+// two quotes, the separator CommPID.MarshalText writes (U+241F, three UTF-8 bytes),
+// up to ten digits of pid, and the colon and comma around the entry.
+const processMapKeyOverheadBytes = 2 + 3 + 10 + 2
 
 // escapedByteBytes is what one JSON-escaped byte costs. \uXXXX is the worst form;
 // the short forms cost 2 but are charged 6 as well, erring toward a smaller payload.
@@ -189,7 +195,8 @@ func estimateTreeBytes(tree *armotypes.ProcessTree) int {
 	if tree == nil {
 		return 0
 	}
-	return len(tree.ContainerID) + estimateProcessBytes(&tree.ProcessTree, maxTreeDepth)
+	return processNodeOverheadBytes + escapedLen(tree.ContainerID) +
+		estimateProcessBytes(&tree.ProcessTree, maxTreeDepth)
 }
 
 func estimateProcessBytes(node *armotypes.Process, budget int) int {
@@ -208,11 +215,20 @@ func estimateProcessBytes(node *armotypes.Process, budget int) int {
 		escapedLen(node.Comm) + escapedLen(node.Pcomm) + escapedLen(node.Path) +
 		escapedLen(node.Cwd) + escapedLen(node.Hardlink) +
 		escapedLen(node.UserName) + escapedLen(node.GroupName)
+	// A child's comm is emitted TWICE: as its own field, and again in this node's
+	// childrenMap key. Charging it once let the estimate undercount whenever a comm
+	// was escape-heavy enough to outgrow the per-node slack.
 	for _, child := range node.ChildrenMap {
-		total += estimateProcessBytes(child, budget-1)
+		if child == nil {
+			continue
+		}
+		total += processMapKeyOverheadBytes + escapedLen(child.Comm) +
+			estimateProcessBytes(child, budget-1)
 	}
 	for i := range node.Children {
-		total += estimateProcessBytes(&node.Children[i], budget-1)
+		child := &node.Children[i]
+		total += processMapKeyOverheadBytes + escapedLen(child.Comm) +
+			estimateProcessBytes(child, budget-1)
 	}
 	return total
 }

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -43,9 +43,9 @@ const maxTreeDepth = 64
 // and the whole message is then rejected and dropped: the node loses its entire
 // interval of traffic, not just some trees.
 //
-// A budget in BYTES rather than a tree count, because tree size varies by ~3.5x
-// even with the command-line cap (~2 KB median, ~7 KB p90, ~12 KB for a deep chain
-// of capped command lines), so no count bounds the payload.
+// A budget in BYTES rather than a tree count, because tree size is not uniform:
+// depth varies, the fields are variable-length, and JSON escaping inflates some
+// content ~6x (see escapedLen). No tree count bounds the payload.
 //
 // Calibrated against measured production traffic rather than guessed. In prod-eu a
 // network-stream message averages 29 KB on the topic, so ~22 KB of JSON before the
@@ -54,30 +54,42 @@ const maxTreeDepth = 64
 // makes a connection ~530 bytes of JSON without its tree. The largest batch ever
 // observed is 283 connections (SUB-7850).
 //
-// Taking the worst case this budget exists for — EVERY connection from a distinct
-// process, so trees scale 1:1 with connections:
+// Measured against the worst case this budget exists for — EVERY connection from a
+// distinct process, so trees scale 1:1 with connections — using a fully-populated
+// 10-node chain, which estimates ~5.1 KB and marshals to ~4.3 KB:
 //
-//	283 connections x ~7 KB p90 tree ≈ 1.96 MiB of trees, + 146 KB of entries
-//	≈ 2.1 MiB JSON ≈ 2.8 MiB after base64 — 56% of the 5 MiB limit.
+//	 283 connections (the observed worst): all 283 trees ship, 1.77 MiB after base64
+//	 500 connections:                      all 500 ship,      3.13 MiB
+//	1000 connections:                      binds at 513 trees, 3.60 MiB
 //
-// So 2.5 MiB. It binds above ~360 distinct processes at p90 tree size and ~1280 at
-// median, i.e. above anything yet observed, which keeps it a safety valve instead
-// of a routine limiter that would degrade attribution on the busiest nodes. A
-// tighter 1.5 MiB was tried first and rejected: it binds at 216-301 trees, *below*
-// the observed worst batch, while the payload there is only half the limit.
+// So 2.5 MiB, which binds above ~513 such trees — 1.8x the observed worst batch,
+// keeping it a safety valve rather than a routine limiter that would degrade
+// attribution on the busiest nodes. A tighter 1.5 MiB was tried first and rejected:
+// it clips 70 of 283 trees, below the observed worst, while the payload there is
+// barely a third of the limit.
 //
 // Residual, deliberately not addressed here: with trees bounded, the connection
-// entries alone would breach the limit at ~2,500 connections — 9x the observed
-// worst. The fix for that regime is splitting the message (as the container
-// profile does on HTTP 413), not dropping connections. The logging below is what
-// would tell us it is being approached.
+// ENTRIES alone breach the limit at ~3,300 connections (11x the observed worst) —
+// measured 6.01 MiB at 4,000. The fix for that regime is splitting the message, as
+// the container profile does on HTTP 413, not dropping connections. The logging
+// below is what would tell us it is being approached.
 const maxProcessTreeBytes = 2560 * 1024
 
 // processNodeOverheadBytes approximates the non-string JSON cost of one process
-// node — field names, the numeric ids, the RFC-3339 start time and the child map
-// key. Deliberately generous: this feeds a budget, so overestimating shrinks the
-// payload and underestimating is what risks the limit.
-const processNodeOverheadBytes = 200
+// node — every field name, the numeric ids, the RFC-3339 start time (time.Time
+// ignores omitempty, so it is always serialised) and the childrenMap key, in which
+// a node's comm appears a second time.
+//
+// Measured against a fully-populated node as the tree builder produces them, which
+// is ~360 bytes with short strings. Deliberately generous: this feeds a budget, so
+// overestimating shrinks the payload while underestimating is what risks the limit.
+const processNodeOverheadBytes = 320
+
+// escapedByteBytes is the cost of one byte that JSON renders as an escape. The
+// worst form is \uXXXX; the short forms (\" \\ \n \r \t) cost 2, but they are
+// charged 6 as well, because over-charging shrinks the payload and under-charging
+// is what breaches the limit.
+const escapedByteBytes = 6
 
 // buildWireStream derives the HTTP payload from the flush snapshot: per-event
 // trees move into the message-scoped Processes map — one capped copy per distinct
@@ -159,14 +171,21 @@ func collectTrees(events map[string]armotypes.NetworkStreamEvent, candidates map
 // selectProcessTrees copies the candidate trees that fit maxProcessTreeBytes,
 // returning nil when there are none so omitempty drops the field.
 //
-// Over budget, candidates are ranked by connection count first: a process that
-// reached many endpoints is both the most expensive attribution to lose and the
-// shape reputation cares about most (beacon-style fan-out). Ties break on the ref
-// so the payload never depends on map iteration order. Dropped candidates keep
-// their refs on the connections — the pid identity survives, and ProcessTreeFor is
-// specified to return nil for a ref with no entry — so the cost is degraded
-// attribution for the least-connected processes rather than a rejected message and
-// the loss of every traffic row for the interval.
+// Over budget, candidates are ranked SMALLEST TREE FIRST, ties broken on the ref.
+// That maximises the number of processes that keep an attributable tree, which is
+// the best available objective given that the sensor cannot know which process will
+// turn out to matter.
+//
+// Ranking by connection count was tried and rejected: it sounds right, but a
+// low-and-slow beacon opens exactly ONE connection per interval, so it sorts last
+// and is the first tree dropped — the precise case reputation attribution exists to
+// catch. Tie-breaking on the ref keeps the payload independent of Go's randomised
+// map iteration order either way.
+//
+// Dropped candidates keep their refs on the connections — the pid identity
+// survives, and ProcessTreeFor is specified to return nil for a ref with no entry —
+// so the cost is degraded attribution for some processes rather than a rejected
+// message and the loss of every traffic row for the interval.
 func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) map[armotypes.ProcessRef]*armotypes.ProcessTree {
 	if len(candidates) == 0 {
 		return nil
@@ -191,8 +210,8 @@ func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) m
 	}
 	sort.Slice(ordered, func(i, j int) bool {
 		a, b := ordered[i], ordered[j]
-		if a.connections != b.connections {
-			return a.connections > b.connections
+		if a.estBytes != b.estBytes {
+			return a.estBytes < b.estBytes
 		}
 		if a.ref.PID != b.ref.PID {
 			return a.ref.PID < b.ref.PID
@@ -213,8 +232,9 @@ func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) m
 	}
 
 	// The whole point of the budget is that we find out whether it ever fires.
-	logger.L().Warning("NetworkStream - process tree budget exceeded, shipping refs without trees for the least-connected processes",
-		helpers.Int("distinctProcesses", len(candidates)),
+	logger.L().Warning("NetworkStream - process tree budget exceeded, shipping refs without trees for the largest trees",
+		helpers.Int("processesWithTrees", len(candidates)), // processes with a ref but no tree are not candidates
+
 		helpers.Int("treesShipped", len(processes)),
 		helpers.Int("treesDropped", droppedTrees),
 		helpers.Int("connectionsWithoutTree", droppedConnections),
@@ -237,15 +257,61 @@ func estimateProcessBytes(node *armotypes.Process, budget int) int {
 	if node == nil || budget <= 0 {
 		return 0
 	}
-	total := processNodeOverheadBytes +
-		min(len(node.Cmdline), maxCmdlineBytes) +
-		len(node.Comm) + len(node.Pcomm) + len(node.Path) + len(node.Cwd) +
-		len(node.Hardlink) + len(node.UserName) + len(node.GroupName)
+
+	// The command line is counted as capTreeCopy will leave it. Slicing raw bytes
+	// mirrors capCmdline's budget; a cut mid-rune only makes escapedLen charge more.
+	cmdline := node.Cmdline
+	if len(cmdline) > maxCmdlineBytes {
+		cmdline = cmdline[:maxCmdlineBytes]
+	}
+
+	total := processNodeOverheadBytes + len(cmdlineTruncationMarker) +
+		escapedLen(cmdline) +
+		escapedLen(node.Comm) + escapedLen(node.Pcomm) + escapedLen(node.Path) +
+		escapedLen(node.Cwd) + escapedLen(node.Hardlink) +
+		escapedLen(node.UserName) + escapedLen(node.GroupName)
 	for _, child := range node.ChildrenMap {
 		total += estimateProcessBytes(child, budget-1)
 	}
 	for i := range node.Children {
 		total += estimateProcessBytes(&node.Children[i], budget-1)
+	}
+	return total
+}
+
+// escapedLen returns at least the number of bytes encoding/json emits for s,
+// excluding the surrounding quotes.
+//
+// len(s) is NOT what reaches the wire, and the difference is what decides whether
+// the budget is a real bound. json escapes `"` and `\`, every control byte, and —
+// because Marshal enables HTML escaping — `<`, `>` and `&`, which real command
+// lines are full of (`sh -c 'cmd > /dev/null 2>&1'`). Invalid UTF-8 is replaced
+// byte-for-byte by �, and process argv is arbitrary kernel bytes, not
+// guaranteed UTF-8. Each such byte costs up to six where len() counts one, so
+// charging len() let a payload six times the estimate pass the budget and breach
+// the broker's message limit — losing the node's whole interval of traffic.
+func escapedLen(s string) int {
+	total := 0
+	for i := 0; i < len(s); {
+		if c := s[i]; c < utf8.RuneSelf {
+			if c >= 0x20 && c != '"' && c != '\\' && c != '<' && c != '>' && c != '&' {
+				total++
+			} else {
+				total += escapedByteBytes
+			}
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		switch {
+		case r == utf8.RuneError && size == 1:
+			total += escapedByteBytes // one invalid byte -> the 6-byte \ufffd
+		case r == '\u2028' || r == '\u2029': // JSON escapes the line/paragraph separators
+			total += escapedByteBytes
+		default:
+			total += size
+		}
+		i += size
 	}
 	return total
 }

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -38,9 +38,13 @@ const maxTreeDepth = 64
 const maxProcessTreeBytes = 2560 * 1024
 
 // processNodeOverheadBytes is one node's non-string JSON cost: field names, the
-// numeric ids, the always-serialised start time and the childrenMap wrapper. ~360
-// measured for a fully-populated node; generous on purpose, since underestimating
-// risks the limit. Per-entry map keys are charged explicitly, not from this slack.
+// numeric ids, the always-serialised start time and the childrenMap wrapper.
+//
+// Measured at ~149 bytes (133 for a node with every numeric at max and strings
+// empty, plus ~16 for the childrenMap wrapper). 320 is therefore deliberate
+// headroom, not a measurement: it absorbs the fields not modelled individually,
+// such as ProcessTree.UniqueID, and anything added to the type later. Per-entry map
+// keys are charged explicitly rather than from this slack.
 const processNodeOverheadBytes = 320
 
 // processMapKeyOverheadBytes is a childrenMap entry key's cost apart from the comm:
@@ -133,22 +137,54 @@ func collectTrees(events map[string]armotypes.NetworkStreamEvent, candidates map
 // Connections are never dropped — only trees. Their refs stay put, so pid identity
 // survives and ProcessTreeFor returns nil for them as specified.
 func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) map[armotypes.ProcessRef]*armotypes.ProcessTree {
+	processes, stats := selectWithinBudget(candidates)
+	if stats.exceeded {
+		// Logged so we learn whether this ever fires in production; these counts are
+		// the decision input for raising the budget or making it configurable.
+		logger.L().Warning("NetworkStream - process tree budget exceeded, dropping the largest trees",
+			helpers.Int("processesWithTrees", stats.candidates),
+			helpers.Int("treesShipped", stats.treesShipped),
+			helpers.Int("treesDropped", stats.treesDropped),
+			helpers.Int("connectionsWithoutTree", stats.connectionsWithoutTree),
+			helpers.Int("estimatedTreeBytes", stats.estimatedBytes),
+			helpers.Int("budgetBytes", maxProcessTreeBytes))
+	}
+	return processes
+}
+
+// budgetStats reports what a selection did. The drop figures are DERIVED from the
+// result rather than accumulated inside the packing loop, so they stay correct
+// however that loop is later restructured.
+type budgetStats struct {
+	candidates             int
+	treesShipped           int
+	treesDropped           int
+	connectionsWithoutTree int
+	estimatedBytes         int
+	exceeded               bool
+}
+
+func selectWithinBudget(candidates map[armotypes.ProcessRef]*processCandidate) (map[armotypes.ProcessRef]*armotypes.ProcessTree, budgetStats) {
+	stats := budgetStats{candidates: len(candidates)}
 	if len(candidates) == 0 {
-		return nil
+		return nil, stats
 	}
 
-	totalBytes := 0
+	totalConnections := 0
 	for _, candidate := range candidates {
-		totalBytes += candidate.estBytes
+		stats.estimatedBytes += candidate.estBytes
+		totalConnections += candidate.connections
 	}
 
 	processes := make(map[armotypes.ProcessRef]*armotypes.ProcessTree, len(candidates))
-	if totalBytes <= maxProcessTreeBytes {
+	if stats.estimatedBytes <= maxProcessTreeBytes {
 		for ref, candidate := range candidates {
 			processes[ref] = capTreeCopy(candidate.tree)
 		}
-		return processes
+		stats.treesShipped = len(processes)
+		return processes, stats
 	}
+	stats.exceeded = true
 
 	ordered := make([]*processCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
@@ -165,28 +201,23 @@ func selectProcessTrees(candidates map[armotypes.ProcessRef]*processCandidate) m
 		return a.ref.StartTimeNs < b.ref.StartTimeNs
 	})
 
-	usedBytes, droppedTrees, droppedConnections := 0, 0, 0
+	usedBytes, shippedConnections := 0, 0
 	for _, candidate := range ordered {
-		// Skip rather than stop, so a small tree still ships after an oversized one.
+		// Defensive only: the ascending sort means nothing after the first miss can
+		// fit either, so this is equivalent to breaking. It costs one comparison and
+		// survives a future change to the ordering.
 		if usedBytes+candidate.estBytes > maxProcessTreeBytes {
-			droppedTrees++
-			droppedConnections += candidate.connections
 			continue
 		}
 		processes[candidate.ref] = capTreeCopy(candidate.tree)
 		usedBytes += candidate.estBytes
+		shippedConnections += candidate.connections
 	}
 
-	// Logged so we learn whether this ever fires in production.
-	logger.L().Warning("NetworkStream - process tree budget exceeded, dropping the largest trees",
-		helpers.Int("processesWithTrees", len(candidates)),
-		helpers.Int("treesShipped", len(processes)),
-		helpers.Int("treesDropped", droppedTrees),
-		helpers.Int("connectionsWithoutTree", droppedConnections),
-		helpers.Int("estimatedTreeBytes", totalBytes),
-		helpers.Int("budgetBytes", maxProcessTreeBytes))
-
-	return processes
+	stats.treesShipped = len(processes)
+	stats.treesDropped = len(candidates) - len(processes)
+	stats.connectionsWithoutTree = totalConnections - shippedConnections
+	return processes, stats
 }
 
 // estimateTreeBytes approximates a tree's serialised size, counting the command

--- a/pkg/networkstream/v1/wire.go
+++ b/pkg/networkstream/v1/wire.go
@@ -98,7 +98,15 @@ func capTreeCopy(tree *armotypes.ProcessTree) *armotypes.ProcessTree {
 		return nil
 	}
 	copied := copyCappedProcess(&tree.ProcessTree, maxTreeDepth)
-	return &armotypes.ProcessTree{ContainerID: tree.ContainerID, ProcessTree: *copied}
+	if copied == nil {
+		return nil
+	}
+	// Copy the wrapper wholesale rather than field-listing it: a field list silently
+	// drops anything added to ProcessTree later, which is the exact trap the three
+	// existing process copiers fell into (see docs/features/process-start-time.md).
+	dst := *tree
+	dst.ProcessTree = *copied
+	return &dst
 }
 
 // copyCappedProcess copies a node and its descendants, capping command lines as

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -2,6 +2,7 @@ package networkstream
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -297,4 +298,111 @@ func TestCapCmdline(t *testing.T) {
 	capped := capCmdline(multibyte)
 	assert.LessOrEqual(t, len(capped), maxCmdlineBytes)
 	assert.True(t, utf8.ValidString(capped), "a cut mid-rune would emit invalid UTF-8")
+}
+
+// bigTree builds a tree whose estimated size is roughly sizeBytes, using the
+// command line (which is what actually dominates a real tree's bytes).
+func bigTree(pid uint32, sizeBytes int) *armotypes.ProcessTree {
+	cmdlineLen := sizeBytes - processNodeOverheadBytes
+	if cmdlineLen < 1 {
+		cmdlineLen = 1
+	}
+	return treeOf("c1", &armotypes.Process{PID: pid, Comm: "p", Cmdline: strings.Repeat("a", cmdlineLen)})
+}
+
+// TestBuildWireStream_UnderBudgetShipsEveryTree: the budget is a safety valve, so
+// ordinary messages must be untouched by it.
+func TestBuildWireStream_UnderBudgetShipsEveryTree(t *testing.T) {
+	events := map[string]armotypes.NetworkStreamEvent{}
+	for pid := uint32(1); pid <= 200; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("1.2.3.%d/443/TCP/%d/10000000", pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 2048)}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	assert.Len(t, wire.Processes, 200, "200 x ~2 KB is well inside the budget")
+}
+
+// TestBuildWireStream_OverBudgetDropsTreesNotConnections pins the failure mode the
+// budget exists to prevent. Before it, a node with heavy process churn produced a
+// message over the broker's 5 MiB limit, which is rejected and dropped — losing the
+// node's ENTIRE interval of traffic. Now the connections all still ship; only the
+// least-connected processes lose their trees.
+func TestBuildWireStream_OverBudgetDropsTreesNotConnections(t *testing.T) {
+	events := map[string]armotypes.NetworkStreamEvent{}
+	const processes = 4000
+	for pid := uint32(1); pid <= processes; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("10.0.%d.%d/443/TCP/%d/10000000", pid/256, pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 2048)}
+	}
+	snapshot := outboundOnly("c1", events)
+
+	wire := buildWireStream(snapshot)
+
+	// Every connection survives, with its ref.
+	require.Len(t, wire.Entities["c1"].Outbound, processes, "connections must never be dropped — that is the data loss this whole change fixes")
+	for _, ev := range wire.Entities["c1"].Outbound {
+		require.NotNil(t, ev.ProcessRef, "the pid identity survives even when the tree does not")
+	}
+
+	// Trees are bounded.
+	assert.Less(t, len(wire.Processes), processes, "the budget must actually drop trees")
+	assert.NotEmpty(t, wire.Processes, "it must not drop everything either")
+	shipped := 0
+	for _, tree := range wire.Processes {
+		shipped += estimateTreeBytes(tree)
+	}
+	assert.LessOrEqual(t, shipped, maxProcessTreeBytes, "shipped trees must fit the budget")
+
+	// A dropped ref resolves to nil rather than panicking.
+	for _, ev := range wire.Entities["c1"].Outbound {
+		_ = wire.ProcessTreeFor(&ev)
+	}
+
+	// And the payload stays under the broker limit even after the base64 envelope.
+	payload, err := json.Marshal(wire)
+	require.NoError(t, err)
+	encoded := len(payload) * 4 / 3
+	assert.Less(t, encoded, 5<<20, "the whole point: %d bytes JSON -> ~%d base64, under 5 MiB", len(payload), encoded)
+}
+
+// TestSelectProcessTrees_PrefersFanOutDeterministically: over budget, the process
+// that reached the most endpoints keeps its tree, and the outcome must not depend
+// on Go's randomised map iteration order.
+func TestSelectProcessTrees_PrefersFanOutDeterministically(t *testing.T) {
+	chatty := armotypes.ProcessRef{PID: 900, StartTimeNs: 10_000_000}
+	for i := 0; i < 16; i++ {
+		events := map[string]armotypes.NetworkStreamEvent{}
+		// One process with many connections...
+		for c := 0; c < 40; c++ {
+			ref := chatty
+			events[fmt.Sprintf("10.1.1.%d/443/TCP/900/10000000", c)] =
+				armotypes.NetworkStreamEvent{ProcessRef: &ref, ProcessTree: bigTree(900, 4096)}
+		}
+		// ...and many single-connection processes that together blow the budget.
+		for pid := uint32(1); pid <= 2000; pid++ {
+			ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+			events[fmt.Sprintf("10.2.%d.%d/443/TCP/%d/10000000", pid/256, pid%256, pid)] =
+				armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 4096)}
+		}
+
+		wire := buildWireStream(outboundOnly("c1", events))
+
+		require.NotNil(t, wire.Processes[chatty], "the highest-fan-out process must keep its tree on every run")
+	}
+}
+
+func TestEstimateTreeBytes_CountsCappedCmdline(t *testing.T) {
+	assert.Zero(t, estimateTreeBytes(nil))
+
+	short := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh", Cmdline: "sh -c true"})
+	assert.Greater(t, estimateTreeBytes(short), processNodeOverheadBytes)
+
+	// A 200 KB command line must be counted as its capped size, not its raw size —
+	// otherwise the budget would reject trees that are actually small on the wire.
+	huge := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh", Cmdline: strings.Repeat("a", 200_000)})
+	assert.Less(t, estimateTreeBytes(huge), processNodeOverheadBytes+maxCmdlineBytes+64)
 }

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -108,12 +108,10 @@ func TestBuildWireStream_RefWithoutTree(t *testing.T) {
 	assert.Nil(t, wire.ProcessTreeFor(ev), "a dangling ref resolves to nil, not a panic")
 }
 
-// TestBuildWireStream_DeeperChainWins: the process-tree cache TTL (1 min) is
-// shorter than the flush interval (2 min), so two lookups for one process inside
-// a single interval can legitimately return chains with different amounts of
-// ancestry resolved. First-wins would discard the richer chain and would make the
-// payload depend on Go's map iteration order; preferring the deeper chain is
-// deterministic.
+// TestBuildWireStream_DeeperChainWins: the tree cache TTL is shorter than the flush
+// interval, so two lookups for one process can return different amounts of resolved
+// ancestry. First-wins would discard the richer chain and make the payload depend on
+// map iteration order.
 func TestBuildWireStream_DeeperChainWins(t *testing.T) {
 	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
 	shallow := treeOf("c1", chain(50, 101))
@@ -152,15 +150,10 @@ func TestBuildWireStream_InboundIsAttributedToo(t *testing.T) {
 	}
 }
 
-// TestBuildWireStream_DoesNotMutateSharedTree pins the constraint that makes
-// sharing tree pointers into the flush snapshot safe: the wire copy must not
-// write to the source nodes. They are shared with the process-tree manager's LRU
-// cache, the legacy alert paths, and the notification-channel consumer.
-//
-// armotypes.Process.DeepCopy is NOT usable for this: it calls MigrateToMap on its
-// receiver and on every child it recurses into, which allocates ChildrenMap and
-// nils Children on the SHARED nodes. This test fails if the copy ever regresses
-// to it.
+// TestBuildWireStream_DoesNotMutateSharedTree pins what makes sharing tree pointers
+// into the snapshot safe: the wire copy must not write to the source nodes, which are
+// shared with the process-tree cache, the alert paths and the channel consumer. Fails
+// if the copy ever regresses to armotypes.Process.DeepCopy, which mutates as it walks.
 func TestBuildWireStream_DoesNotMutateSharedTree(t *testing.T) {
 	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
 	// Deliberately in the legacy shape: nil ChildrenMap, ancestry in Children.
@@ -216,14 +209,10 @@ func TestBuildWireStream_SerializationContract(t *testing.T) {
 	assert.Equal(t, "curl", resolved.ProcessTree.Comm)
 }
 
-// TestNoTickScaling guards the one silent failure mode of this feature: a
-// StartTimeNs division would still join correctly inside a single message — the key
-// and the ref share a producer — while breaking identity across messages by seven
-// orders of magnitude.
-//
-// It must run the WHOLE producer path, starting at processRefFor where the value
-// enters, because that is where a scaling bug would be introduced. Asserting only
-// that buildWireStream does not rewrite an already-correct literal is a tautology.
+// TestNoTickScaling guards this feature's one silent failure mode: a StartTimeNs
+// division still joins correctly inside a message while breaking identity across
+// messages. It must run the WHOLE producer path from processRefFor, where the value
+// enters — asserting that buildWireStream preserves a correct literal is a tautology.
 func TestNoTickScaling(t *testing.T) {
 	const startTimeNs = uint64(5_000_000_000) // procfs values are exact multiples of 10^7
 	mgr := processtree.NewProcessTreeManagerMock()
@@ -468,11 +457,9 @@ func TestSelectProcessTrees_PrefersSmallestTrees(t *testing.T) {
 }
 
 // TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes: the packing loop skips
-// rather than stops, so one tree larger than the whole budget cannot starve the rest.
-//
-// Note such a tree has to be WIDE, not deep: maxTreeDepth caps a chain at 64 nodes,
-// so the deepest possible chain is a few hundred KB. Real network-stream trees are
-// chains, which is why this case is defensive rather than expected.
+// rather than stops, so one oversized tree cannot starve the rest. Such a tree must be
+// WIDE — maxTreeDepth caps a chain at 64 nodes — so this is defensive: real trees are
+// chains.
 func TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes(t *testing.T) {
 	huge := armotypes.ProcessRef{PID: 1, StartTimeNs: 10_000_000}
 	oversized := &armotypes.Process{PID: 1, Comm: "p", ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
@@ -535,18 +522,11 @@ func TestEstimateTreeBytes_CountsCappedCmdline(t *testing.T) {
 	assert.Less(t, estimateTreeBytes(huge), processNodeOverheadBytes+maxCmdlineBytes+64)
 }
 
-// TestBuildWireStream_ObservedWorstCaseFitsBudget pins the CALIBRATION, not just
-// the mechanism. The budget must not bind on traffic that production actually
-// produces, or it degrades attribution on exactly the busiest nodes.
-//
-// The scenario is the worst case the budget exists for, at the largest batch ever
-// observed: 283 connections (SUB-7850), every one from a DISTINCT process, each
-// carrying a p90-sized (~7 KB) tree. Measured production inputs: a batch averages
-// ~42 connections at ~530 bytes of JSON each (prod-eu, reputation events_in over
-// topic message count, against a 29 KB mean message).
-//
-// A 1.5 MiB budget fails this test — it binds at 216 trees — which is why the
-// budget is 2.5 MiB.
+// TestBuildWireStream_ObservedWorstCaseFitsBudget pins the CALIBRATION, not the
+// mechanism: the budget must not bind on traffic production actually produces, or it
+// degrades attribution on the busiest nodes. The scenario is the largest batch ever
+// observed (283 connections, SUB-7850) with every connection from a distinct process.
+// A 1.5 MiB budget fails this, which is why it is 2.5 MiB.
 func TestBuildWireStream_ObservedWorstCaseFitsBudget(t *testing.T) {
 	const (
 		observedWorstConnections = 283
@@ -586,16 +566,10 @@ func realisticNode(pid uint32, cmdline string) *armotypes.Process {
 	}
 }
 
-// TestEstimateTreeBytes_NeverUnderestimates is the guard the process-tree budget
-// rests on. estimateTreeBytes feeds maxProcessTreeBytes, so if it can undercount
-// the real marshalled size, the budget is not a bound and an oversized message is
-// silently produced — the broker rejects it and the node loses its ENTIRE interval
-// of traffic, with nothing logged.
-//
-// The subtle case is JSON escaping. len(s) is not what reaches the wire: json
-// escapes quotes, backslashes, control bytes, and — because Marshal enables HTML
-// escaping — `<`, `>` and `&`, which real command lines are full of. Process argv
-// is arbitrary kernel bytes, so invalid UTF-8 is routine and costs 6 bytes each.
+// TestEstimateTreeBytes_NeverUnderestimates is the guard the budget rests on: if the
+// estimate can undercount the marshalled size, maxProcessTreeBytes is not a bound and
+// an oversized message ships silently. The subtle case is JSON escaping — see
+// escapedLen.
 func TestEstimateTreeBytes_NeverUnderestimates(t *testing.T) {
 	deepChain := func(nodes int, cmdline string) *armotypes.Process {
 		var root, prev *armotypes.Process

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -3,8 +3,10 @@ package networkstream
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/armosec/armoapi-go/armotypes"
@@ -401,30 +403,123 @@ func TestBuildWireStream_OverBudgetDropsTreesNotConnections(t *testing.T) {
 	assert.Less(t, encoded, 5<<20, "the whole point: %d bytes JSON -> ~%d base64, under 5 MiB", len(payload), encoded)
 }
 
-// TestSelectProcessTrees_PrefersFanOutDeterministically: over budget, the process
-// that reached the most endpoints keeps its tree, and the outcome must not depend
-// on Go's randomised map iteration order.
-func TestSelectProcessTrees_PrefersFanOutDeterministically(t *testing.T) {
-	chatty := armotypes.ProcessRef{PID: 900, StartTimeNs: 10_000_000}
-	for i := 0; i < 16; i++ {
+// TestSelectProcessTrees_IsDeterministic pins the stated contract that the shipped
+// SET never depends on Go's randomised map iteration order. Asserting only that one
+// particular process survived is not enough: with the ref tie-breaks removed, every
+// equal-cost candidate ties, sort.Slice's output becomes iteration-dependent, and
+// the set silently varies run to run.
+func TestSelectProcessTrees_IsDeterministic(t *testing.T) {
+	build := func() map[armotypes.ProcessRef]*armotypes.ProcessTree {
 		events := map[string]armotypes.NetworkStreamEvent{}
-		// One process with many connections...
-		for c := 0; c < 40; c++ {
-			ref := chatty
-			events[fmt.Sprintf("10.1.1.%d/443/TCP/900/10000000", c)] =
-				armotypes.NetworkStreamEvent{ProcessRef: &ref, ProcessTree: bigTree(900, 4096)}
-		}
-		// ...and many single-connection processes that together blow the budget.
 		for pid := uint32(1); pid <= 2000; pid++ {
 			ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
 			events[fmt.Sprintf("10.2.%d.%d/443/TCP/%d/10000000", pid/256, pid%256, pid)] =
 				armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 4096)}
 		}
-
-		wire := buildWireStream(outboundOnly("c1", events))
-
-		require.NotNil(t, wire.Processes[chatty], "the highest-fan-out process must keep its tree on every run")
+		return buildWireStream(outboundOnly("c1", events)).Processes
 	}
+
+	first := build()
+	require.NotEmpty(t, first)
+	require.Less(t, len(first), 2000, "this case must actually exceed the budget")
+
+	firstRefs := make([]string, 0, len(first))
+	for ref := range first {
+		firstRefs = append(firstRefs, ref.String())
+	}
+	sort.Strings(firstRefs)
+
+	for i := 0; i < 12; i++ {
+		again := build()
+		refs := make([]string, 0, len(again))
+		for ref := range again {
+			refs = append(refs, ref.String())
+		}
+		sort.Strings(refs)
+		require.Equal(t, firstRefs, refs, "the shipped set must be identical on every run")
+	}
+}
+
+// TestSelectProcessTrees_PrefersSmallestTrees: over budget, ranking is smallest-tree
+// first, so the number of processes keeping attribution is maximised. Ranking by
+// connection count was rejected — a low-and-slow beacon makes one connection, so it
+// would sort last and lose its tree first.
+func TestSelectProcessTrees_PrefersSmallestTrees(t *testing.T) {
+	small := armotypes.ProcessRef{PID: 1, StartTimeNs: 10_000_000}
+	events := map[string]armotypes.NetworkStreamEvent{
+		// One connection, tiny tree: the low-and-slow shape. Must survive.
+		"10.9.9.9/443/TCP/1/10000000": {ProcessRef: &small, ProcessTree: bigTree(1, 1024)},
+	}
+	// Chatty processes with large trees that together blow the budget.
+	for pid := uint32(100); pid < 1100; pid++ {
+		for c := 0; c < 5; c++ {
+			ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+			events[fmt.Sprintf("10.3.%d.%d/%d/TCP/%d/10000000", pid/256, pid%256, c, pid)] =
+				armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 12288)}
+		}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	require.Less(t, len(wire.Processes), 1001, "this case must exceed the budget")
+	assert.NotNil(t, wire.Processes[small],
+		"the single-connection process with the smallest tree must keep it — that is the beacon shape")
+}
+
+// TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes: the packing loop skips
+// rather than stops, so one tree larger than the whole budget cannot starve the rest.
+//
+// Note such a tree has to be WIDE, not deep: maxTreeDepth caps a chain at 64 nodes,
+// so the deepest possible chain is a few hundred KB. Real network-stream trees are
+// chains, which is why this case is defensive rather than expected.
+func TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes(t *testing.T) {
+	huge := armotypes.ProcessRef{PID: 1, StartTimeNs: 10_000_000}
+	oversized := &armotypes.Process{PID: 1, Comm: "p", ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
+	for i := 0; i < 4000; i++ {
+		child := &armotypes.Process{PID: uint32(10_000 + i), Comm: "p",
+			Cmdline: strings.Repeat("a", maxCmdlineBytes), ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
+		oversized.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
+	}
+	require.Greater(t, estimateTreeBytes(treeOf("c1", oversized)), maxProcessTreeBytes,
+		"this tree must exceed the whole budget on its own")
+
+	events := map[string]armotypes.NetworkStreamEvent{
+		"10.9.9.9/443/TCP/1/10000000": {ProcessRef: &huge, ProcessTree: treeOf("c1", oversized)},
+	}
+	for pid := uint32(2); pid <= 6; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("10.4.0.%d/443/TCP/%d/10000000", pid, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, 2048)}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	assert.Nil(t, wire.Processes[huge], "a tree larger than the whole budget cannot ship")
+	assert.Len(t, wire.Processes, 5, "the small trees after it must still ship")
+}
+
+// TestEstimateTreeBytes_CountsLegacyChildren: the deprecated Children slice reaches
+// the wire (capTreeCopy normalises it into ChildrenMap), so the estimator must charge
+// for it. If it did not, a Children-shaped tree would be free against the budget.
+func TestEstimateTreeBytes_CountsLegacyChildren(t *testing.T) {
+	childless := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh"})
+	withLegacyChild := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh",
+		Children: []armotypes.Process{{PID: 2, Comm: "curl", Cmdline: strings.Repeat("a", 500)}}})
+
+	assert.Greater(t, estimateTreeBytes(withLegacyChild), estimateTreeBytes(childless)+500,
+		"a Children-shaped descendant must be charged, not free")
+}
+
+// TestCapTreeCopy_PreservesWrapperFields: the wrapper is copied wholesale rather than
+// field-listed, so a field added to ProcessTree later cannot be silently dropped.
+func TestCapTreeCopy_PreservesWrapperFields(t *testing.T) {
+	src := &armotypes.ProcessTree{ContainerID: "c1", UniqueID: 4242,
+		ProcessTree: armotypes.Process{PID: 1, Comm: "sh"}}
+
+	capped := capTreeCopy(src)
+
+	assert.Equal(t, "c1", capped.ContainerID)
+	assert.Equal(t, uint32(4242), capped.UniqueID, "field-listing the wrapper would drop this")
 }
 
 func TestEstimateTreeBytes_CountsCappedCmdline(t *testing.T) {
@@ -474,4 +569,112 @@ func TestBuildWireStream_ObservedWorstCaseFitsBudget(t *testing.T) {
 	require.NoError(t, err)
 	encoded := (len(payload) + observedWorstConnections*bytesPerConnection) * 4 / 3
 	assert.Less(t, encoded, 4<<20, "~%d B encoded should stay well clear of the 5 MiB limit", encoded)
+}
+
+// realisticNode is a process node shaped the way the tree builder actually
+// produces them: every field populated. Sparse nodes are a test artefact.
+func realisticNode(pid uint32, cmdline string) *armotypes.Process {
+	uid, gid := uint32(1000), uint32(1000)
+	upper := true
+	return &armotypes.Process{
+		PID: pid, PPID: pid - 1, Comm: "some-process", Pcomm: "parent-process",
+		Cmdline: cmdline, Path: "/usr/local/bin/some-process", Cwd: "/var/lib/some-process",
+		Hardlink: "/usr/local/bin/some-process", UserName: "serviceaccount", GroupName: "serviceaccount",
+		Uid: &uid, Gid: &gid, UpperLayer: &upper, StartTime: time.Unix(1754290000, 994619533),
+		ChildrenMap: map[armotypes.CommPID]*armotypes.Process{},
+	}
+}
+
+// TestEstimateTreeBytes_NeverUnderestimates is the guard the process-tree budget
+// rests on. estimateTreeBytes feeds maxProcessTreeBytes, so if it can undercount
+// the real marshalled size, the budget is not a bound and an oversized message is
+// silently produced — the broker rejects it and the node loses its ENTIRE interval
+// of traffic, with nothing logged.
+//
+// The subtle case is JSON escaping. len(s) is not what reaches the wire: json
+// escapes quotes, backslashes, control bytes, and — because Marshal enables HTML
+// escaping — `<`, `>` and `&`, which real command lines are full of. Process argv
+// is arbitrary kernel bytes, so invalid UTF-8 is routine and costs 6 bytes each.
+func TestEstimateTreeBytes_NeverUnderestimates(t *testing.T) {
+	deepChain := func(nodes int, cmdline string) *armotypes.Process {
+		var root, prev *armotypes.Process
+		for i := 0; i < nodes; i++ {
+			node := realisticNode(uint32(100+i), cmdline)
+			if prev == nil {
+				root = node
+			} else {
+				prev.ChildrenMap[armotypes.CommPID{Comm: node.Comm, PID: node.PID}] = node
+			}
+			prev = node
+		}
+		return root
+	}
+	wide := realisticNode(1, "sh")
+	for i := 0; i < 50; i++ {
+		child := realisticNode(uint32(1000+i), "worker --shard=<n> & echo \"done\"")
+		wide.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
+	}
+
+	cases := []struct {
+		name string
+		tree *armotypes.ProcessTree
+	}{
+		{"bare", treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh"})},
+		{"realistic single node", treeOf("c1", realisticNode(1, "/usr/bin/curl https://example.com/api?a=1"))},
+		{"realistic 10-node chain", treeOf("c1", deepChain(10, "/usr/bin/curl https://example.com"))},
+		{"realistic 64-node chain", treeOf("c1", deepChain(64, "/usr/bin/curl https://example.com"))},
+		{"over-deep chain (truncated)", treeOf("c1", deepChain(120, "sh -c true"))},
+		{"wide fan-out", treeOf("c1", wide)},
+		// Shell redirects and job control: every < > & costs 6 bytes, not 1.
+		{"html-escaped shell cmdline", treeOf("c1", realisticNode(1, strings.Repeat("sh -c 'a > b 2>&1 && c < d' ", 40)))},
+		{"all quotes", treeOf("c1", realisticNode(1, strings.Repeat(`"`, 900)))},
+		{"all backslashes", treeOf("c1", realisticNode(1, strings.Repeat(`\`, 900)))},
+		{"control bytes", treeOf("c1", realisticNode(1, strings.Repeat("\x01\x02\x1f", 300)))},
+		// Non-UTF-8 argv: each invalid byte becomes the 6-byte �.
+		{"invalid utf-8 argv", treeOf("c1", realisticNode(1, strings.Repeat("\x80", 1024)))},
+		{"invalid utf-8 over the cap", treeOf("c1", realisticNode(1, strings.Repeat("\xff", 8000)))},
+		{"line separators", treeOf("c1", realisticNode(1, strings.Repeat("a b ", 300)))},
+		{"uncapped path field", treeOf("c1", &armotypes.Process{PID: 1, Comm: "x",
+			Path: strings.Repeat("\x80", 20_000), Cwd: strings.Repeat("&", 20_000)})},
+		{"legacy Children shape", treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh",
+			Children: []armotypes.Process{*realisticNode(2, strings.Repeat("<&>", 400))}})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Compare against what actually goes on the wire: the capped copy.
+			capped := capTreeCopy(tc.tree)
+			payload, err := json.Marshal(capped)
+			require.NoError(t, err)
+			est := estimateTreeBytes(tc.tree)
+
+			assert.GreaterOrEqual(t, est, len(payload),
+				"estimate %d < marshalled %d: the budget would not bound the payload", est, len(payload))
+		})
+	}
+}
+
+// TestBuildWireStream_EscapeHeavyPayloadStaysUnderLimit is the end-to-end version:
+// many processes whose command lines are non-UTF-8 kernel bytes, which inflate 6x
+// through JSON. Before escaping was accounted for, 629 such processes estimated at
+// 29% of the budget and produced 5.37 MB after base64 — over the broker limit, with
+// nothing dropped and nothing logged.
+func TestBuildWireStream_EscapeHeavyPayloadStaysUnderLimit(t *testing.T) {
+	events := map[string]armotypes.NetworkStreamEvent{}
+	for pid := uint32(1); pid <= 800; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("10.%d.%d.%d/443/TCP/%d/10000000", pid/65536, pid/256%256, pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref,
+				ProcessTree: treeOf("c1", realisticNode(pid, strings.Repeat("\x80", maxCmdlineBytes)))}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	payload, err := json.Marshal(wire)
+	require.NoError(t, err)
+	encoded := len(payload) * 4 / 3
+	assert.Less(t, encoded, 5<<20,
+		"%d processes -> %d B JSON -> ~%d B base64, must stay under the 5 MiB broker limit",
+		len(wire.Processes), len(payload), encoded)
+	require.Len(t, wire.Entities["c1"].Outbound, 800, "connections are never dropped")
 }

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/node-agent/pkg/processtree"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -212,21 +213,31 @@ func TestBuildWireStream_SerializationContract(t *testing.T) {
 }
 
 // TestNoTickScaling guards the one silent failure mode of this feature: a
-// StartTimeNs division would still join correctly inside a single message while
-// breaking identity across messages by seven orders of magnitude.
+// StartTimeNs division would still join correctly inside a single message — the key
+// and the ref share a producer — while breaking identity across messages by seven
+// orders of magnitude.
+//
+// It must run the WHOLE producer path, starting at processRefFor where the value
+// enters, because that is where a scaling bug would be introduced. Asserting only
+// that buildWireStream does not rewrite an already-correct literal is a tautology.
 func TestNoTickScaling(t *testing.T) {
-	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
-	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
-		"1.2.3.4/443/TCP/101/5000000000": {ProcessRef: ref, ProcessTree: treeOf("c1", chain(101))},
-	})
+	const startTimeNs = uint64(5_000_000_000) // procfs values are exact multiples of 10^7
+	mgr := processtree.NewProcessTreeManagerMock()
+	mgr.SetProcessBootTimeNs(101, startTimeNs)
+	ns := newTestStream(t, mgr)
 
-	wire := buildWireStream(snapshot)
+	ns.handleNetworkEvent(outboundEvent(101, "1.2.3.4", 443), treeFor(101, "curl"))
+	wire := buildWireStream(snapshotNetworkStream(&ns.networkEventsStorage))
 
-	for _, ev := range wire.Entities["c1"].Outbound {
-		assert.Equal(t, uint64(5_000_000_000), ev.ProcessRef.StartTimeNs, "emitted verbatim, never rescaled")
+	require.Len(t, wire.Entities[testNodeName].Outbound, 1)
+	for key, ev := range wire.Entities[testNodeName].Outbound {
+		require.NotNil(t, ev.ProcessRef)
+		assert.Equal(t, startTimeNs, ev.ProcessRef.StartTimeNs, "emitted verbatim, never rescaled")
+		assert.Equal(t, "1.2.3.4/443/TCP/101/5000000000", key, "the batch key carries the unscaled value too")
 	}
+	require.Len(t, wire.Processes, 1)
 	for gotRef := range wire.Processes {
-		assert.Equal(t, uint64(5_000_000_000), gotRef.StartTimeNs, "the map key must match the event's ref exactly")
+		assert.Equal(t, startTimeNs, gotRef.StartTimeNs, "the map key must match the event's ref exactly")
 	}
 }
 

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -460,11 +460,12 @@ func TestSelectProcessTrees_PrefersSmallestTrees(t *testing.T) {
 		"the single-connection process with the smallest tree must keep it — that is the beacon shape")
 }
 
-// TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes: the packing loop skips
-// rather than stops, so one oversized tree cannot starve the rest. Such a tree must be
-// WIDE — maxTreeDepth caps a chain at 64 nodes — so this is defensive: real trees are
-// chains.
-func TestSelectProcessTrees_OversizedTreeDoesNotBlockSmallOnes(t *testing.T) {
+// TestSelectProcessTrees_OversizedTreeIsExcluded: a tree larger than the whole budget
+// must be dropped while the rest still ship. Note what this does NOT prove: it passes
+// under either loop shape, because the ascending sort puts the small trees first — the
+// skip-vs-break branch is unreachable, not load-bearing. Such a tree also has to be
+// WIDE, since maxTreeDepth caps a chain at 64 nodes, so real chains never hit this.
+func TestSelectProcessTrees_OversizedTreeIsExcluded(t *testing.T) {
 	huge := armotypes.ProcessRef{PID: 1, StartTimeNs: 10_000_000}
 	oversized := &armotypes.Process{PID: 1, Comm: "p", ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
 	for i := 0; i < 4000; i++ {
@@ -813,4 +814,91 @@ func escapeHeavyBytes(rng *rand.Rand, n int) string {
 		b[i] = []byte{'<', '>', '&', '"', '\\', 0x01, 0x1f, 0x80, 0xff}[rng.Intn(9)]
 	}
 	return string(b)
+}
+
+// TestSelectProcessTrees_MaximisesTreesKept pins the ranking ORDER, which
+// TestSelectProcessTrees_PrefersSmallestTrees does not: every tree there is the same
+// size, so ordering only decides which equal-sized trees ship. Mixing two size
+// populations makes the shipped COUNT depend on the order, which is the property
+// smallest-first exists for.
+func TestSelectProcessTrees_MaximisesTreesKept(t *testing.T) {
+	const smallBytes, largeBytes = 20_000, 80_000
+	smallEst := estimateTreeBytes(bigTree(1, smallBytes))
+	require.Greater(t, estimateTreeBytes(bigTree(1, largeBytes)), smallEst*3,
+		"the two populations must be far enough apart to discriminate")
+
+	events := map[string]armotypes.NetworkStreamEvent{}
+	smallRefs := map[armotypes.ProcessRef]bool{}
+	for pid := uint32(1); pid <= 200; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		smallRefs[*ref] = true
+		events[fmt.Sprintf("10.1.0.%d/443/TCP/%d/10000000", pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, smallBytes)}
+	}
+	for pid := uint32(1000); pid < 1100; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("10.2.0.%d/443/TCP/%d/10000000", pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, largeBytes)}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	// Greedy-smallest is optimal for "most processes keep a tree", so the expected
+	// count is computable rather than a magic number.
+	want := min(maxProcessTreeBytes/smallEst, 200)
+	assert.Equal(t, want, len(wire.Processes), "ranking must maximise how many processes keep a tree")
+	for ref := range wire.Processes {
+		assert.True(t, smallRefs[ref], "a large tree displaced a small one: ranking is not smallest-first")
+	}
+}
+
+// TestSelectWithinBudget_StatsAreDerived pins the counters the budget warning reports.
+// They are the decision input for whether the budget needs raising, so they must be
+// consistent by construction rather than by an accumulator that a future change to the
+// packing loop could silently desynchronise.
+func TestSelectWithinBudget_StatsAreDerived(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		processes, stats := selectWithinBudget(nil)
+		assert.Nil(t, processes, "nil so omitempty drops the field")
+		assert.False(t, stats.exceeded)
+		assert.Zero(t, stats.candidates)
+	})
+
+	build := func(count, sizeBytes, connsEach int) map[armotypes.ProcessRef]*processCandidate {
+		candidates := map[armotypes.ProcessRef]*processCandidate{}
+		for pid := uint32(1); pid <= uint32(count); pid++ {
+			ref := armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+			tree := bigTree(pid, sizeBytes)
+			candidates[ref] = &processCandidate{
+				ref: ref, tree: tree, connections: connsEach, estBytes: estimateTreeBytes(tree),
+			}
+		}
+		return candidates
+	}
+
+	t.Run("under budget", func(t *testing.T) {
+		candidates := build(20, 2048, 3)
+		processes, stats := selectWithinBudget(candidates)
+		assert.False(t, stats.exceeded)
+		assert.Len(t, processes, 20)
+		assert.Equal(t, 20, stats.treesShipped)
+		assert.Zero(t, stats.treesDropped)
+		assert.Zero(t, stats.connectionsWithoutTree)
+	})
+
+	t.Run("over budget", func(t *testing.T) {
+		const count, connsEach = 1000, 4
+		candidates := build(count, 12288, connsEach)
+		processes, stats := selectWithinBudget(candidates)
+
+		require.True(t, stats.exceeded, "this case must exceed the budget")
+		assert.Equal(t, count, stats.candidates)
+		assert.Equal(t, len(processes), stats.treesShipped)
+		// The identities that hold however the loop is written.
+		assert.Equal(t, count, stats.treesShipped+stats.treesDropped,
+			"every candidate is either shipped or counted as dropped")
+		assert.Equal(t, stats.treesDropped*connsEach, stats.connectionsWithoutTree,
+			"connections without a tree must follow from the trees actually dropped")
+		assert.Greater(t, stats.estimatedBytes, maxProcessTreeBytes)
+	})
 }

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -3,6 +3,7 @@ package networkstream
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"testing"
@@ -677,4 +678,51 @@ func TestBuildWireStream_EscapeHeavyPayloadStaysUnderLimit(t *testing.T) {
 		"%d processes -> %d B JSON -> ~%d B base64, must stay under the 5 MiB broker limit",
 		len(wire.Processes), len(payload), encoded)
 	require.Len(t, wire.Entities["c1"].Outbound, 800, "connections are never dropped")
+}
+
+// TestEstimateTreeBytes_NeverUnderestimatesRandom is the generalisation of the
+// table above: the budget's soundness depends on a property that must hold for
+// ALL inputs, and process argv is arbitrary kernel bytes. Deterministic seed, so a
+// failure is reproducible.
+func TestEstimateTreeBytes_NeverUnderestimatesRandom(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260804))
+	randomBytes := func(n int) string {
+		b := make([]byte, n)
+		for i := range b {
+			switch rng.Intn(5) {
+			case 0: // the bytes JSON escapes to 6 chars
+				b[i] = []byte{'<', '>', '&', 0x00, 0x1f}[rng.Intn(5)]
+			case 1: // the short escapes
+				b[i] = []byte{'"', '\\', '\n', '\r', '\t'}[rng.Intn(5)]
+			case 2: // high bytes: mostly invalid UTF-8
+				b[i] = byte(0x80 + rng.Intn(0x80))
+			default: // plain ASCII
+				b[i] = byte(0x20 + rng.Intn(0x5f))
+			}
+		}
+		return string(b)
+	}
+
+	for i := 0; i < 400; i++ {
+		node := &armotypes.Process{
+			PID: uint32(rng.Intn(1 << 20)), PPID: uint32(rng.Intn(1 << 20)),
+			Comm: randomBytes(rng.Intn(24)), Pcomm: randomBytes(rng.Intn(24)),
+			Cmdline: randomBytes(rng.Intn(3000)), Path: randomBytes(rng.Intn(300)),
+			Cwd: randomBytes(rng.Intn(300)), Hardlink: randomBytes(rng.Intn(60)),
+			UserName: randomBytes(rng.Intn(30)), GroupName: randomBytes(rng.Intn(30)),
+			ChildrenMap: map[armotypes.CommPID]*armotypes.Process{},
+		}
+		for c := 0; c < rng.Intn(4); c++ {
+			child := &armotypes.Process{PID: uint32(rng.Intn(1 << 20)), Comm: randomBytes(rng.Intn(20)),
+				Cmdline: randomBytes(rng.Intn(2000)), Path: randomBytes(rng.Intn(200))}
+			node.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
+		}
+		tree := treeOf(randomBytes(rng.Intn(40)), node)
+
+		payload, err := json.Marshal(capTreeCopy(tree))
+		require.NoError(t, err)
+		est := estimateTreeBytes(tree)
+		require.GreaterOrEqual(t, est, len(payload),
+			"iteration %d: estimate %d < marshalled %d — the budget would not bound the payload", i, est, len(payload))
+	}
 }

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -300,14 +300,46 @@ func TestCapCmdline(t *testing.T) {
 	assert.True(t, utf8.ValidString(capped), "a cut mid-rune would emit invalid UTF-8")
 }
 
-// bigTree builds a tree whose estimated size is roughly sizeBytes, using the
-// command line (which is what actually dominates a real tree's bytes).
+// bigTree builds a chain whose estimated size is at least sizeBytes, the way a real
+// tree gets big: across ~10 ancestor nodes, not one giant command line. A single
+// node cannot exceed processNodeOverheadBytes + maxCmdlineBytes, because the cap
+// truncates it — so a helper that piles all the bytes into one cmdline silently
+// produces a ~1.2 KB tree however large a size it is asked for.
 func bigTree(pid uint32, sizeBytes int) *armotypes.ProcessTree {
-	cmdlineLen := sizeBytes - processNodeOverheadBytes
-	if cmdlineLen < 1 {
-		cmdlineLen = 1
+	const perNode = processNodeOverheadBytes + maxCmdlineBytes
+	nodes := (sizeBytes + perNode - 1) / perNode
+	if nodes < 1 {
+		nodes = 1
 	}
-	return treeOf("c1", &armotypes.Process{PID: pid, Comm: "p", Cmdline: strings.Repeat("a", cmdlineLen)})
+	cmdline := strings.Repeat("a", maxCmdlineBytes)
+
+	var root, prev *armotypes.Process
+	for i := 0; i < nodes; i++ {
+		// The leaf carries the process's own pid; ancestors get synthetic ones.
+		nodePID := pid
+		if i < nodes-1 {
+			nodePID = pid + uint32((i+1)*1_000_000)
+		}
+		node := &armotypes.Process{PID: nodePID, Comm: "p", Cmdline: cmdline,
+			ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
+		if prev == nil {
+			root = node
+		} else {
+			prev.ChildrenMap[armotypes.CommPID{Comm: node.Comm, PID: node.PID}] = node
+		}
+		prev = node
+	}
+	return treeOf("c1", root)
+}
+
+// TestBigTree_ReachesRequestedSize keeps the helper honest: every budget test below
+// is meaningless if the trees it builds are smaller than they claim.
+func TestBigTree_ReachesRequestedSize(t *testing.T) {
+	for _, want := range []int{2048, 5222, 7270, 12288} {
+		got := estimateTreeBytes(bigTree(1, want))
+		assert.GreaterOrEqual(t, got, want, "bigTree(%d) estimated only %d bytes", want, got)
+		assert.Less(t, got, want+processNodeOverheadBytes+maxCmdlineBytes, "bigTree(%d) overshot at %d", want, got)
+	}
 }
 
 // TestBuildWireStream_UnderBudgetShipsEveryTree: the budget is a safety valve, so
@@ -405,4 +437,41 @@ func TestEstimateTreeBytes_CountsCappedCmdline(t *testing.T) {
 	// otherwise the budget would reject trees that are actually small on the wire.
 	huge := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh", Cmdline: strings.Repeat("a", 200_000)})
 	assert.Less(t, estimateTreeBytes(huge), processNodeOverheadBytes+maxCmdlineBytes+64)
+}
+
+// TestBuildWireStream_ObservedWorstCaseFitsBudget pins the CALIBRATION, not just
+// the mechanism. The budget must not bind on traffic that production actually
+// produces, or it degrades attribution on exactly the busiest nodes.
+//
+// The scenario is the worst case the budget exists for, at the largest batch ever
+// observed: 283 connections (SUB-7850), every one from a DISTINCT process, each
+// carrying a p90-sized (~7 KB) tree. Measured production inputs: a batch averages
+// ~42 connections at ~530 bytes of JSON each (prod-eu, reputation events_in over
+// topic message count, against a 29 KB mean message).
+//
+// A 1.5 MiB budget fails this test — it binds at 216 trees — which is why the
+// budget is 2.5 MiB.
+func TestBuildWireStream_ObservedWorstCaseFitsBudget(t *testing.T) {
+	const (
+		observedWorstConnections = 283
+		p90TreeBytes             = 7270
+		bytesPerConnection       = 530
+	)
+	events := map[string]armotypes.NetworkStreamEvent{}
+	for pid := uint32(1); pid <= observedWorstConnections; pid++ {
+		ref := &armotypes.ProcessRef{PID: pid, StartTimeNs: 10_000_000}
+		events[fmt.Sprintf("10.0.%d.%d/443/TCP/%d/10000000", pid/256, pid%256, pid)] =
+			armotypes.NetworkStreamEvent{ProcessRef: ref, ProcessTree: bigTree(pid, p90TreeBytes)}
+	}
+
+	wire := buildWireStream(outboundOnly("c1", events))
+
+	require.Len(t, wire.Processes, observedWorstConnections,
+		"the budget must not bind on the largest batch observed in production")
+
+	// And that case must sit well under the broker limit once base64 applies.
+	payload, err := json.Marshal(wire)
+	require.NoError(t, err)
+	encoded := (len(payload) + observedWorstConnections*bytesPerConnection) * 4 / 3
+	assert.Less(t, encoded, 4<<20, "~%d B encoded should stay well clear of the 5 MiB limit", encoded)
 }

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -1,0 +1,289 @@
+package networkstream
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chain builds a root->...->leaf process chain, the shape buildBranchToShim
+// produces: one child per node, ChildrenMap always allocated.
+func chain(pids ...uint32) *armotypes.Process {
+	var root, prev *armotypes.Process
+	for _, pid := range pids {
+		node := &armotypes.Process{PID: pid, Comm: "p" + string(rune('0'+pid%10)), ChildrenMap: map[armotypes.CommPID]*armotypes.Process{}}
+		if prev == nil {
+			root = node
+		} else {
+			prev.ChildrenMap[armotypes.CommPID{Comm: node.Comm, PID: node.PID}] = node
+		}
+		prev = node
+	}
+	return root
+}
+
+func treeOf(containerID string, root *armotypes.Process) *armotypes.ProcessTree {
+	return &armotypes.ProcessTree{ContainerID: containerID, ProcessTree: *root}
+}
+
+func outboundOnly(entityID string, events map[string]armotypes.NetworkStreamEvent) *armotypes.NetworkStream {
+	return &armotypes.NetworkStream{Entities: map[string]armotypes.NetworkStreamEntity{
+		entityID: {Outbound: events, Inbound: map[string]armotypes.NetworkStreamEvent{}},
+	}}
+}
+
+// eventPtr returns the address of a map-held event, which ProcessTreeFor needs.
+func eventPtr(nsw *armotypes.NetworkStream, entityID, key string) *armotypes.NetworkStreamEvent {
+	ev := nsw.Entities[entityID].Outbound[key]
+	return &ev
+}
+
+func TestBuildWireStream_TreesShipOncePerProcess(t *testing.T) {
+	ref101 := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
+	tree101 := treeOf("c1", &armotypes.Process{PID: 101, Comm: "curl", Cmdline: "curl https://x"})
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"1.2.3.4/443/TCP/101/5000000000": {IPAddress: "1.2.3.4", Port: 443, ProcessRef: ref101, ProcessTree: tree101},
+		"9.9.9.9/53/UDP/101/5000000000":  {IPAddress: "9.9.9.9", Port: 53, ProcessRef: ref101, ProcessTree: tree101},
+	})
+
+	wire := buildWireStream(snapshot)
+
+	assert.Equal(t, armotypes.NetworkStreamProcessAttributionV1, wire.ProcessAttributionVersion)
+	require.Len(t, wire.Processes, 1, "one tree per process, not per connection — trees dominate the payload")
+
+	got := wire.ProcessTreeFor(eventPtr(wire, "c1", "1.2.3.4/443/TCP/101/5000000000"))
+	require.NotNil(t, got, "the supported join must resolve")
+	assert.Equal(t, "curl", got.ProcessTree.Comm)
+	assert.Equal(t, "c1", got.ContainerID)
+
+	for key, ev := range wire.Entities["c1"].Outbound {
+		assert.Nil(t, ev.ProcessTree, "wire events must not inline trees (%s)", key)
+		assert.NotNil(t, ev.ProcessRef, "the ref is what the consumer joins on (%s)", key)
+	}
+
+	// The snapshot is the channel consumer's view and must be untouched.
+	for _, ev := range snapshot.Entities["c1"].Outbound {
+		assert.NotNil(t, ev.ProcessTree, "the channel snapshot keeps its trees")
+	}
+	assert.NotSame(t, tree101, wire.Processes[*ref101], "the map value is a copy, not the shared chain")
+}
+
+func TestBuildWireStream_LegacyEventsPassThrough(t *testing.T) {
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"1.2.3.4/443/TCP": {IPAddress: "1.2.3.4", Port: 443}, // no ref, no tree
+	})
+
+	wire := buildWireStream(snapshot)
+
+	assert.Empty(t, wire.Processes, "omitempty: never ship an empty processes object")
+	assert.Equal(t, armotypes.NetworkStreamProcessAttributionV1, wire.ProcessAttributionVersion,
+		"the marker is a capability signal, set even when nothing was attributable")
+	require.Len(t, wire.Entities["c1"].Outbound, 1, "unattributed connections still ship")
+}
+
+// TestBuildWireStream_RefWithoutTree: a ref whose tree never resolved still ships.
+// It dangles, and ProcessTreeFor is specified to return nil for that — losing the
+// ref instead would lose the pid too.
+func TestBuildWireStream_RefWithoutTree(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 303}
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"5.6.7.8/80/TCP/303/0": {IPAddress: "5.6.7.8", Port: 80, ProcessRef: ref},
+	})
+
+	wire := buildWireStream(snapshot)
+
+	assert.Empty(t, wire.Processes)
+	ev := eventPtr(wire, "c1", "5.6.7.8/80/TCP/303/0")
+	require.NotNil(t, ev.ProcessRef)
+	assert.Nil(t, wire.ProcessTreeFor(ev), "a dangling ref resolves to nil, not a panic")
+}
+
+// TestBuildWireStream_DeeperChainWins: the process-tree cache TTL (1 min) is
+// shorter than the flush interval (2 min), so two lookups for one process inside
+// a single interval can legitimately return chains with different amounts of
+// ancestry resolved. First-wins would discard the richer chain and would make the
+// payload depend on Go's map iteration order; preferring the deeper chain is
+// deterministic.
+func TestBuildWireStream_DeeperChainWins(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
+	shallow := treeOf("c1", chain(50, 101))
+	deep := treeOf("c1", chain(1, 50, 101))
+
+	// Repeated because map iteration order is randomised per range: the outcome
+	// must not depend on which entry is visited first.
+	for i := 0; i < 32; i++ {
+		snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+			"1.2.3.4/443/TCP/101/5000000000": {ProcessRef: ref, ProcessTree: shallow},
+			"9.9.9.9/53/UDP/101/5000000000":  {ProcessRef: ref, ProcessTree: deep},
+		})
+		wire := buildWireStream(snapshot)
+		require.Len(t, wire.Processes, 1)
+		assert.Equal(t, uint32(1), wire.Processes[*ref].ProcessTree.PID, "the deeper chain's root must win")
+	}
+}
+
+func TestBuildWireStream_InboundIsAttributedToo(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 77, StartTimeNs: 1_000_000_000}
+	snapshot := &armotypes.NetworkStream{Entities: map[string]armotypes.NetworkStreamEntity{
+		"c1": {
+			Inbound: map[string]armotypes.NetworkStreamEvent{
+				"1.2.3.4/8080/TCP/77/1000000000": {ProcessRef: ref, ProcessTree: treeOf("c1", chain(77))},
+			},
+			Outbound: map[string]armotypes.NetworkStreamEvent{},
+		},
+	}}
+
+	wire := buildWireStream(snapshot)
+
+	require.Len(t, wire.Processes, 1)
+	for _, ev := range wire.Entities["c1"].Inbound {
+		assert.Nil(t, ev.ProcessTree)
+		assert.NotNil(t, ev.ProcessRef)
+	}
+}
+
+// TestBuildWireStream_DoesNotMutateSharedTree pins the constraint that makes
+// sharing tree pointers into the flush snapshot safe: the wire copy must not
+// write to the source nodes. They are shared with the process-tree manager's LRU
+// cache, the legacy alert paths, and the notification-channel consumer.
+//
+// armotypes.Process.DeepCopy is NOT usable for this: it calls MigrateToMap on its
+// receiver and on every child it recurses into, which allocates ChildrenMap and
+// nils Children on the SHARED nodes. This test fails if the copy ever regresses
+// to it.
+func TestBuildWireStream_DoesNotMutateSharedTree(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
+	// Deliberately in the legacy shape: nil ChildrenMap, ancestry in Children.
+	shared := &armotypes.ProcessTree{ContainerID: "c1", ProcessTree: armotypes.Process{
+		PID: 50, Comm: "sh",
+		Children: []armotypes.Process{{PID: 101, Comm: "curl", Cmdline: "curl https://x"}},
+	}}
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"1.2.3.4/443/TCP/101/5000000000": {ProcessRef: ref, ProcessTree: shared},
+	})
+
+	wire := buildWireStream(snapshot)
+
+	assert.Nil(t, shared.ProcessTree.ChildrenMap, "the source's ChildrenMap must not be allocated behind its back")
+	require.Len(t, shared.ProcessTree.Children, 1, "the source's Children slice must not be emptied")
+	assert.Equal(t, uint32(101), shared.ProcessTree.Children[0].PID)
+
+	// ...and the legacy child must still reach the wire, normalised on read.
+	copied := wire.Processes[*ref]
+	require.NotNil(t, copied)
+	require.Len(t, copied.ProcessTree.ChildrenMap, 1, "a Children-shaped source is normalised into the copy")
+	for _, child := range copied.ProcessTree.ChildrenMap {
+		assert.Equal(t, uint32(101), child.PID)
+	}
+}
+
+// TestBuildWireStream_SerializationContract pins the exact cross-repo wire form
+// the backend joins on. A sensor-side refactor must not drift from it silently.
+func TestBuildWireStream_SerializationContract(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"1.2.3.4/443/TCP/101/5000000000": {
+			IPAddress: "1.2.3.4", Port: 443, Protocol: armotypes.NetworkStreamEventProtocolTCP,
+			ProcessRef: ref, ProcessTree: treeOf("c1", &armotypes.Process{PID: 101, Comm: "curl"}),
+		},
+	})
+
+	payload, err := json.Marshal(buildWireStream(snapshot))
+	require.NoError(t, err)
+	got := string(payload)
+
+	assert.Contains(t, got, `"processRef":"101/5000000000"`, "per-event reference, text-marshalled")
+	assert.Contains(t, got, `"processAttributionVersion":1`)
+	assert.Contains(t, got, `"processes":{"101/5000000000":`, "message-scoped map keyed by the same text form")
+
+	// Round-trip through the consumer's own join.
+	var decoded armotypes.NetworkStream
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	ev := decoded.Entities["c1"].Outbound["1.2.3.4/443/TCP/101/5000000000"]
+	assert.Nil(t, ev.ProcessTree, "trees ship once in processes, never inline per event")
+	resolved := decoded.ProcessTreeFor(&ev)
+	require.NotNil(t, resolved, "the ref must resolve after a full marshal/unmarshal round trip")
+	assert.Equal(t, "curl", resolved.ProcessTree.Comm)
+}
+
+// TestNoTickScaling guards the one silent failure mode of this feature: a
+// StartTimeNs division would still join correctly inside a single message while
+// breaking identity across messages by seven orders of magnitude.
+func TestNoTickScaling(t *testing.T) {
+	ref := &armotypes.ProcessRef{PID: 101, StartTimeNs: 5_000_000_000}
+	snapshot := outboundOnly("c1", map[string]armotypes.NetworkStreamEvent{
+		"1.2.3.4/443/TCP/101/5000000000": {ProcessRef: ref, ProcessTree: treeOf("c1", chain(101))},
+	})
+
+	wire := buildWireStream(snapshot)
+
+	for _, ev := range wire.Entities["c1"].Outbound {
+		assert.Equal(t, uint64(5_000_000_000), ev.ProcessRef.StartTimeNs, "emitted verbatim, never rescaled")
+	}
+	for gotRef := range wire.Processes {
+		assert.Equal(t, uint64(5_000_000_000), gotRef.StartTimeNs, "the map key must match the event's ref exactly")
+	}
+}
+
+func TestCapTreeCopy_CmdlineCapped(t *testing.T) {
+	long := strings.Repeat("a", 5000)
+	src := &armotypes.ProcessTree{ContainerID: "c1", ProcessTree: armotypes.Process{
+		PID: 1, Comm: "sh", Cmdline: long,
+		ChildrenMap: map[armotypes.CommPID]*armotypes.Process{
+			{PID: 2, Comm: "java"}: {PID: 2, Comm: "java", Cmdline: long,
+				ChildrenMap: map[armotypes.CommPID]*armotypes.Process{
+					{PID: 3, Comm: "sh"}: {PID: 3, Comm: "sh", Cmdline: long},
+				}},
+		},
+	}}
+
+	capped := capTreeCopy(src)
+
+	assert.LessOrEqual(t, len(capped.ProcessTree.Cmdline), maxCmdlineBytes)
+	assert.True(t, strings.HasSuffix(capped.ProcessTree.Cmdline, cmdlineTruncationMarker), "truncation must be visible")
+	// Every node in the chain, not just the root.
+	var walk func(*armotypes.Process, int)
+	seen := 0
+	walk = func(node *armotypes.Process, depth int) {
+		seen++
+		assert.LessOrEqual(t, len(node.Cmdline), maxCmdlineBytes, "node at depth %d", depth)
+		for _, child := range node.ChildrenMap {
+			walk(child, depth+1)
+		}
+	}
+	walk(&capped.ProcessTree, 0)
+	assert.Equal(t, 3, seen, "the whole chain is copied, not just the root")
+
+	// The SOURCE is untouched: it is shared with the legacy alert paths and the
+	// notification-channel consumer, which keep the uncapped values.
+	assert.Len(t, src.ProcessTree.Cmdline, 5000)
+	for _, child := range src.ProcessTree.ChildrenMap {
+		assert.Len(t, child.Cmdline, 5000)
+		for _, grandchild := range child.ChildrenMap {
+			assert.Len(t, grandchild.Cmdline, 5000)
+		}
+	}
+}
+
+func TestCapCmdline(t *testing.T) {
+	assert.Equal(t, "curl https://x", capCmdline("curl https://x"), "short command lines pass through unmarked")
+	assert.Equal(t, "", capCmdline(""))
+
+	exact := strings.Repeat("a", maxCmdlineBytes)
+	assert.Equal(t, exact, capCmdline(exact), "exactly at the cap is not truncated")
+
+	over := strings.Repeat("a", maxCmdlineBytes+1)
+	assert.LessOrEqual(t, len(capCmdline(over)), maxCmdlineBytes, "the marker is inside the budget")
+	assert.True(t, strings.HasSuffix(capCmdline(over), cmdlineTruncationMarker))
+
+	// Truncation never splits a rune.
+	multibyte := strings.Repeat("é", maxCmdlineBytes) // 2 bytes per rune
+	capped := capCmdline(multibyte)
+	assert.LessOrEqual(t, len(capped), maxCmdlineBytes)
+	assert.True(t, utf8.ValidString(capped), "a cut mid-rune would emit invalid UTF-8")
+}

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -776,7 +776,12 @@ func TestEstimateTreeBytes_NeverUnderestimatesRandom(t *testing.T) {
 		// fields per child, which left the per-node slack untouched and could never
 		// reach the deficit region where the childrenMap key made the estimate
 		// undercount — 200k trees found nothing.
-		for c := 0; c < rng.Intn(6); c++ {
+		//
+		// Draw the child count ONCE: in the loop condition it is redrawn per iteration,
+		// which skews the distribution badly (5 children becomes ~1.5% likely instead of
+		// ~16.7%) and starves the high-fan-out cases this generator exists to reach.
+		children := rng.Intn(6)
+		for c := 0; c < children; c++ {
 			uid, gid := uint32(rng.Intn(70000)), uint32(rng.Intn(70000))
 			upper := rng.Intn(2) == 0
 			child := &armotypes.Process{

--- a/pkg/networkstream/v1/wire_test.go
+++ b/pkg/networkstream/v1/wire_test.go
@@ -330,7 +330,11 @@ func TestBigTree_ReachesRequestedSize(t *testing.T) {
 	for _, want := range []int{2048, 5222, 7270, 12288} {
 		got := estimateTreeBytes(bigTree(1, want))
 		assert.GreaterOrEqual(t, got, want, "bigTree(%d) estimated only %d bytes", want, got)
-		assert.Less(t, got, want+processNodeOverheadBytes+maxCmdlineBytes, "bigTree(%d) overshot at %d", want, got)
+		// A proportional ceiling: the point is that the helper lands near the size it
+		// was asked for, not that it matches an exact byte count that shifts whenever
+		// per-node accounting changes.
+		assert.Less(t, got, want*5/4+processNodeOverheadBytes+maxCmdlineBytes,
+			"bigTree(%d) overshot at %d", want, got)
 	}
 }
 
@@ -516,10 +520,14 @@ func TestEstimateTreeBytes_CountsCappedCmdline(t *testing.T) {
 	short := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh", Cmdline: "sh -c true"})
 	assert.Greater(t, estimateTreeBytes(short), processNodeOverheadBytes)
 
-	// A 200 KB command line must be counted as its capped size, not its raw size —
-	// otherwise the budget would reject trees that are actually small on the wire.
+	// A 200 KB command line must be counted at its CAPPED size, not its raw size —
+	// otherwise the budget would reject trees that are small on the wire. Asserted
+	// against the raw length rather than a tight constant, so the bound states the
+	// intent and does not have to be retuned whenever per-node accounting changes.
 	huge := treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh", Cmdline: strings.Repeat("a", 200_000)})
-	assert.Less(t, estimateTreeBytes(huge), processNodeOverheadBytes+maxCmdlineBytes+64)
+	estimate := estimateTreeBytes(huge)
+	assert.Greater(t, estimate, maxCmdlineBytes, "the capped command line is still counted")
+	assert.Less(t, estimate, 4*maxCmdlineBytes, "but nothing close to the 200 KB raw length")
 }
 
 // TestBuildWireStream_ObservedWorstCaseFitsBudget pins the CALIBRATION, not the
@@ -564,6 +572,65 @@ func realisticNode(pid uint32, cmdline string) *armotypes.Process {
 		Uid: &uid, Gid: &gid, UpperLayer: &upper, StartTime: time.Unix(1754290000, 994619533),
 		ChildrenMap: map[armotypes.CommPID]*armotypes.Process{},
 	}
+}
+
+// escapeHeavyComm is 15 bytes — the kernel's TASK_COMM_LEN bound — of a character
+// JSON expands to 6 bytes, so escapedLen is 90 against a len of 15.
+const escapeHeavyComm = "<<<<<<<<<<<<<<<"
+
+func escapeHeavyCommTree(children int) *armotypes.ProcessTree {
+	root := realisticNode(1, "sh")
+	for i := 0; i < children; i++ {
+		child := realisticNode(uint32(1000+i), "/usr/bin/curl https://example.com")
+		child.Comm = escapeHeavyComm
+		root.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
+	}
+	return treeOf("c1", root)
+}
+
+func escapeHeavyCommLegacyTree(children int) *armotypes.ProcessTree {
+	root := realisticNode(1, "sh")
+	for i := 0; i < children; i++ {
+		child := realisticNode(uint32(1000+i), "/usr/bin/curl https://example.com")
+		child.Comm = escapeHeavyComm
+		root.Children = append(root.Children, *child)
+	}
+	return treeOf("c1", root)
+}
+
+func unboundedCommTree(children, commBytes int) *armotypes.ProcessTree {
+	root := realisticNode(1, "sh")
+	for i := 0; i < children; i++ {
+		child := realisticNode(uint32(1000+i), "/usr/bin/curl https://example.com")
+		child.Comm = strings.Repeat("<", commBytes)
+		root.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
+	}
+	return treeOf("c1", root)
+}
+
+func unboundedCommLegacyTree(children, commBytes int) *armotypes.ProcessTree {
+	root := realisticNode(1, "sh")
+	for i := 0; i < children; i++ {
+		child := realisticNode(uint32(1000+i), "/usr/bin/curl https://example.com")
+		child.Comm = strings.Repeat("<", commBytes)
+		root.Children = append(root.Children, *child)
+	}
+	return treeOf("c1", root)
+}
+
+func escapeHeavyCommChain(nodes int) *armotypes.ProcessTree {
+	var root, prev *armotypes.Process
+	for i := 0; i < nodes; i++ {
+		node := realisticNode(uint32(100+i), "/usr/bin/curl https://example.com")
+		node.Comm = escapeHeavyComm
+		if prev == nil {
+			root = node
+		} else {
+			prev.ChildrenMap[armotypes.CommPID{Comm: node.Comm, PID: node.PID}] = node
+		}
+		prev = node
+	}
+	return treeOf("c1", root)
 }
 
 // TestEstimateTreeBytes_NeverUnderestimates is the guard the budget rests on: if the
@@ -613,6 +680,23 @@ func TestEstimateTreeBytes_NeverUnderestimates(t *testing.T) {
 			Path: strings.Repeat("\x80", 20_000), Cwd: strings.Repeat("&", 20_000)})},
 		{"legacy Children shape", treeOf("c1", &armotypes.Process{PID: 1, Comm: "sh",
 			Children: []armotypes.Process{*realisticNode(2, strings.Repeat("<&>", 400))}})},
+		// A child's comm is emitted TWICE — as its own field and inside the parent's
+		// childrenMap key — so it must be charged twice. At the kernel's 15-byte comm
+		// bound the per-node slack happens to absorb the difference, so these cases
+		// are regression cover for the near-break-even region...
+		{"escape-heavy child comm, fan-out 5", escapeHeavyCommTree(5)},
+		{"escape-heavy child comm, fan-out 200", escapeHeavyCommTree(200)},
+		{"escape-heavy child comm, legacy Children", escapeHeavyCommLegacyTree(50)},
+		{"escape-heavy child comm, 64-node chain", escapeHeavyCommChain(64)},
+		// ...and these are the cases that actually discriminate. Nothing in this repo
+		// enforces a comm length — it is only ever 15 bytes because every source is a
+		// kernel TASK_COMM_LEN buffer. The estimate must not depend on that: with an
+		// unbounded comm the old accounting ran ~48% under, and a bound that rests on
+		// an unenforced external invariant is not a bound.
+		{"unbounded child comm, fan-out 200", unboundedCommTree(200, 1024)},
+		{"unbounded child comm, legacy Children", unboundedCommLegacyTree(200, 1024)},
+		// containerID lives on the wrapper and is escaped like any other string.
+		{"escape-heavy containerID", treeOf(strings.Repeat("<", 64), realisticNode(1, "sh"))},
 	}
 
 	for _, tc := range cases {
@@ -686,9 +770,24 @@ func TestEstimateTreeBytes_NeverUnderestimatesRandom(t *testing.T) {
 			UserName: randomBytes(rng.Intn(30)), GroupName: randomBytes(rng.Intn(30)),
 			ChildrenMap: map[armotypes.CommPID]*armotypes.Process{},
 		}
-		for c := 0; c < rng.Intn(4); c++ {
-			child := &armotypes.Process{PID: uint32(rng.Intn(1 << 20)), Comm: randomBytes(rng.Intn(20)),
-				Cmdline: randomBytes(rng.Intn(2000)), Path: randomBytes(rng.Intn(200))}
+		// Children are FULLY populated, and comms are drawn at the kernel's 15-byte
+		// bound from the escape-heavy alphabet. A previous generator set only four
+		// fields per child, which left the per-node slack untouched and could never
+		// reach the deficit region where the childrenMap key made the estimate
+		// undercount — 200k trees found nothing.
+		for c := 0; c < rng.Intn(6); c++ {
+			uid, gid := uint32(rng.Intn(70000)), uint32(rng.Intn(70000))
+			upper := rng.Intn(2) == 0
+			child := &armotypes.Process{
+				PID: uint32(rng.Intn(1 << 20)), PPID: uint32(rng.Intn(1 << 20)),
+				Comm: escapeHeavyBytes(rng, 15), Pcomm: escapeHeavyBytes(rng, 15),
+				Cmdline: randomBytes(rng.Intn(2000)), Path: randomBytes(rng.Intn(200)),
+				Cwd: randomBytes(rng.Intn(200)), Hardlink: randomBytes(rng.Intn(60)),
+				UserName: randomBytes(rng.Intn(30)), GroupName: randomBytes(rng.Intn(30)),
+				Uid: &uid, Gid: &gid, UpperLayer: &upper,
+				StartTime:   time.Unix(int64(1754290000+rng.Intn(1000)), int64(rng.Intn(1e9))),
+				ChildrenMap: map[armotypes.CommPID]*armotypes.Process{},
+			}
 			node.ChildrenMap[armotypes.CommPID{Comm: child.Comm, PID: child.PID}] = child
 		}
 		tree := treeOf(randomBytes(rng.Intn(40)), node)
@@ -699,4 +798,19 @@ func TestEstimateTreeBytes_NeverUnderestimatesRandom(t *testing.T) {
 		require.GreaterOrEqual(t, est, len(payload),
 			"iteration %d: estimate %d < marshalled %d — the budget would not bound the payload", i, est, len(payload))
 	}
+}
+
+// escapeHeavyBytes builds a string of n bytes weighted heavily toward characters
+// JSON expands to six bytes, which is the region where a len()-based estimate
+// undercounts the marshalled size.
+func escapeHeavyBytes(rng *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		if rng.Intn(4) == 0 {
+			b[i] = byte(0x20 + rng.Intn(0x5f)) // plain ASCII
+			continue
+		}
+		b[i] = []byte{'<', '>', '&', '"', '\\', 0x01, 0x1f, 0x80, 0xff}[rng.Intn(9)]
+	}
+	return string(b)
 }


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Puts process identity on the network-stream wire, so a malicious-endpoint finding can
aggregate onto the same incident as the exec, file and other findings from the same
process chain. Until now the stream carried no process data at all on the wire: the
sensor captured a process tree per connection and then stripped it before sending.

**This also fixes silent data loss.** The per-batch connection key was
`address/port/protocol` with first-writer-wins, so when two processes in one container
reached the same endpoint inside a flush interval, the second connection was **discarded
entirely** — it never reached the wire under any identity. The same held for two processes
resolving one domain. `TestHandleNetworkEvent_TwoProcessesSameEndpoint` pins that: before
the fix the batch holds one entry, not two.

### What changed

- **`processRef` per connection**, plus `processAttributionVersion` per message
  (`NetworkStreamProcessAttributionV1 = 1`, set unconditionally — an empty `processes`
  map is not a capability signal).
- **The batch key gained the ref**, appended and never reordered: an unattributed key
  stays byte-identical to the old format. For IP connections the forms cannot collide
  (address/port/protocol are structured, so an attributed key carries exactly two more
  components); for DNS the name is unstructured, so a contrived name ending in
  `/<pid>/<startTimeNs>` can collide, costing one record — documented in the feature doc.
  First-writer-wins is retained per process.
- **Trees ship once per process** in the message-scoped `processes` map, not once per
  connection — trees dominate the payload, the duplicated ref bytes do not. On collision
  the deeper chain wins, because the tree cache TTL (1 min) is shorter than the flush
  interval (2 min) and first-wins would both discard the richer chain and make the
  payload depend on map iteration order.
- **Command lines capped at 1024 bytes on the wire copy only**, with a visible `…`,
  never splitting a rune. `cmdline` is ~40% of a tree's bytes and unbounded, so this is
  what bounds the payload tail rather than an optimisation.
- **The flush snapshot is now independent of the live storage**, which deletes a race
  rather than papering over it (below).
- **A per-message budget on the process trees**, because attribution changed what
  sizes the payload (below).
- `go.mod`: `armoapi-go` v0.0.696 → **v0.0.742**, the exact tag carrying the schema.
  v0.0.741 does not contain it, so a newer tag is not evidence.
- New feature doc: `docs/features/network-stream-process-attribution.md`.

### The flush race, and lock discipline

The flush used to hand the notification channel the **live** storage struct, then — still
holding `eventsStorageMutex` — sleep 100 ms and strip every process tree from the maps
the consumer was reading. The sleep was the only thing standing between
`private-node-agent`'s host network sensor and having its data erased mid-read. A test
showed worse: a connection recorded 300 ms *after* the flush appeared inside the
already-delivered snapshot, because the clear loop and the consumer shared the same maps.

`snapshotNetworkStream` now allocates its own event maps, so the delivered value is
immune to everything the producer does next. The 100 ms sleep is **deleted rather than
shortened** — there is no shared state left to race on.

This file has a prior mutex-stall fix in its history, so the bound on lock-held work is
part of the design:

| | Inside `eventsStorageMutex` | Outside |
|---|---|---|
| Work | Allocate the snapshot's maps; copy each event by value; clear the live storage | Both sends; the wire copy's tree copies and command-line caps |
| Bound | O(entities + connections) small struct copies — a few hundred at the largest observed message (109 entities, 283 connections) | one capped tree copy per *selected* process — transient memory is bounded by the tree budget (2.5 MiB), not by the connection count, and freed after the send |

Tree **pointers** are copied into the snapshot, never walked. That is safe because a tree
is immutable once attached: `buildBranchToShim` allocates fresh nodes per branch, so
event trees are not shared with the process tree's live map — only with its 1-minute LRU
entry, which nothing writes to after construction. The ref is also computed *before*
`eventsStorageMutex` is taken, so no storage→tree lock-order edge is added.

### Payload budget — a gap in the approved plan, not only in the code

Attribution changed **what sizes the payload**. The old batch key collapsed every
process reaching one endpoint into a single entry carrying no tree, so size tracked
*distinct endpoints*. The new key splits per process and each distinct process
contributes a tree, so size tracks **distinct processes that connected** — and nothing
bounded that. SUB-7850's analysis modelled bytes per *connection* at a fixed count of
283 connections, which is exactly the quantity the key change stops holding fixed, so
the multiplier on connection count was never budgeted.

Breaching the broker's 5 MiB limit is not graceful: `sendNetworkEvent` gets a non-2xx,
`Start()` logs it and drops the snapshot — **the node loses its entire interval of
traffic**, no retry, no split. A node with heavy short-lived process churn (a cron loop
shelling out, a CI runner, exec-based probes) can reach that.

`maxProcessTreeBytes` bounds it at **2.5 MiB of estimated tree bytes**, calibrated
against measured production traffic rather than guessed:

| Input | Value | Source |
|---|---|---|
| Mean message on topic | 29 KB (prod-us 32 KB) | `pulsar_average_msg_size` on `network-stream-v1` |
| Mean connections per batch | ~42 (prod-us ~32) | `network_reputation_events_in_total` ÷ topic message count |
| ⇒ bytes per connection, no tree | ~530 B JSON | derived |
| Largest batch ever observed | 283 connections | SUB-7850 |

Measured end to end against the worst case the budget exists for — *every* connection
from a distinct process, so trees scale 1:1 — with production-weight entries included:

| Connections (all distinct) | Trees shipped | JSON | after base64 |
|---|---|---|---|
| 42 (the mean) | all 42 | 0.20 MiB | 0.26 MiB |
| **283 (observed worst)** | **all 283** | 1.33 MiB | **1.77 MiB — 35% of limit** |
| 500 | all 500 | 2.35 MiB | 3.13 MiB |
| 1000 | 513 (budget binds) | 2.70 MiB | 3.60 MiB |
| 4000 | 513 | 4.50 MiB | **6.01 MiB — over, on entries alone** |

Design points:

- **A byte budget, not a tree count** — tree size is not uniform (depth varies, fields
  are variable-length, JSON escaping inflates some content ~6×), so no count bounds the
  payload. The estimator overestimates realistic trees by ~19%, and two tests enforce
  that it never goes the other way (see below).
- **Connections are never dropped** — that is the data loss this PR fixes. Only trees
  are, and the refs stay on the connections, so pid identity survives and
  `ProcessTreeFor` returns nil for them as specified.
- **Ranked smallest-tree-first**, ties broken on the ref, which maximises the number of
  processes keeping a tree. Connection-count ranking was tried and rejected: a
  low-and-slow beacon opens exactly *one* connection per interval, so it sorted last and
  lost its tree first — the precise case reputation exists to catch.
- **It must not bind on real traffic**, or it degrades attribution on exactly the
  busiest nodes. A tighter 1.5 MiB was tried first and rejected — it clips 70 of 283
  trees while the payload there is barely a third of the limit.
  `TestBuildWireStream_ObservedWorstCaseFitsBudget` pins this and fails at 1.5 MiB.

#### The budget only became a real bound after a review caught this

The first version charged `len(s)` per string. That is **not** what `encoding/json`
emits: it escapes `"` and `\`, every control byte, and — because `Marshal` enables HTML
escaping — `<`, `>` and `&`, which real command lines are full of
(`sh -c 'cmd > /dev/null 2>&1'`). Invalid UTF-8 becomes the 6-byte `\ufffd`, and process
argv is arbitrary kernel bytes. Each such byte costs up to **six** where `len()` counted
one.

Measured: 629 processes with 1 KB of non-UTF-8 argv each estimated at **29% of the
budget**, so nothing was dropped and nothing logged, while the real message was
**5.37 MB after base64** — rejected by the broker, node loses its whole interval. It also
undercounted *ordinary* traffic (a realistic node: 372 estimated vs 395 marshalled).
Reachable deliberately by anyone able to exec in a container on the node, which made it
a detection-evasion primitive with a wider blast radius than the bug this PR fixes.

`escapedLen` now charges the true escaped cost, and the direction is enforced rather than
asserted: `TestEstimateTreeBytes_NeverUnderestimates` over 15 adversarial shapes (fails
on 10 of them with the old estimator) plus a 400-case randomised version checked against
real `json.Marshal` output.

**How often this binds in reality is not knowable from current data**, because today's
sensor strips trees and emits no process identity — distinct-processes-per-batch exists
in no message. So two log lines make it answerable after rollout: `process tree budget
exceeded` (with `processesWithTrees`, `treesShipped`, `treesDropped`,
`connectionsWithoutTree`) and `large payload` above 2 MiB (size, entity, connection and
tree counts). Quiet at the ~30 KB fleet mean. If the first fires routinely, the budget
should become configurable rather than being raised blind.

**Residual, deliberately not fixed here:** with trees bounded, the connection *entries*
alone breach the limit at roughly **3,300 connections** (11× the observed worst; measured
6.01 MiB at 4,000). No tree budget can help there — the fix for that regime is splitting
the message, as `docs/features/container-profile-split-on-413.md` does on HTTP 413, not
dropping connections.

### Not `Process.DeepCopy()`

`armotypes.Process.DeepCopy` **mutates its receiver**: it calls `MigrateToMap`, which
allocates `ChildrenMap` and nils `Children`, and it does so on every child it recurses
into. Those nodes are shared with the process-tree manager's LRU cache, the legacy alert
paths and the channel consumer, so calling it from the flush goroutine would be a data
race that also strips the uncapped command lines those consumers rely on.
`copyCappedProcess` is read-only instead, normalising the deprecated `Children` slice
into the copy without touching the source. `TestBuildWireStream_DoesNotMutateSharedTree`
pins this so a future refactor cannot regress to `DeepCopy`. Every recursive walk is
depth-bounded (64).

### `StartTimeNs` is boot-relative nanoseconds, emitted verbatim

Converted once on the way in from `/proc` (SUB-7845); **nothing here rescales it**. A
division would still join correctly *within* one message — key and ref share a producer —
while silently breaking identity across messages by seven orders of magnitude.
`StartTimeNs` appears in exactly one non-test statement in this diff and in no arithmetic
expression. Zero is legal and means unknown; the ref is emitted anyway, degrading to
pid-only identity. See `docs/features/process-start-time.md`.

## Handoff for the host/ECS workstream

`cmd/host`, `cmd/ecs`, the KubernetesMode streaming gate and `pkg/hostnetworksensor` are
untouched. Inheriting from this change:

- The tree strip is gone, and with it **the shared-map race the host sensor's 100 ms
  sleep existed to survive**. The channel now delivers an independent snapshot, still
  with trees.
- The batch key gained a process suffix (format above).
- The channel send is still blocking (backpressure, not data loss) but now selects on
  context cancellation.
- Outside Kubernetes mode the HTTP export is disabled entirely, so that in-process
  channel is the only consumer today.
- In Kubernetes mode, pre-existing host (non-container) processes carry no start time.

## Testing

`pkg/networkstream` cannot be built or tested on macOS (`inspektor-gadget/pkg/utils/host`
excludes darwin, imported transitively). Everything below ran in a Linux container:

```bash
docker run --rm -v "$PWD":/src -v "$(go env GOMODCACHE)":/go/pkg/mod -w /src \
  -e GOFLAGS=-mod=mod -e CGO_ENABLED=1 golang:1.25 \
  sh -c 'go build ./... && go vet ./pkg/networkstream/... && go test -race ./pkg/networkstream/... -count=1'
```

`pkg/networkstream/v1` had two test functions before this change, so it brings its own
coverage. `go test ./pkg/...` shows the **same** pass/fail set as `main`: the only
failures are pre-existing and unrelated (`pkg/containerwatcher/v2/tracers` needs a
`tracers.tar` build artifact; `pkg/validator` `TestCheckPrerequisites`).

## Two plan amendments this work implies

Neither is a code change; both are for the plan owner:

1. **§2.3's payload paragraph reads as though the `cmdline` cap were the only lever.**
   It is not — the connection-count multiplier introduced by the key change was never
   analysed, which is what the budget above addresses.
2. **The two plan documents disagree on p90 tree size:** the implementation plan says
   5.1 KB, while the epic plan's "~2 MB at 283 connections" implies ~7 KB. This work
   calibrated against 7 KB (the pessimistic figure).

## CI note

`build-and-push-image` will fail on missing Quay secrets. That is structural for a
cross-fork PR — the job gets no secrets — not a defect in this change.

## AI Review

Two independent fresh-context reviews by **Claude Opus 5**, each in a clean subagent
following `armosec-shared-rules:code-review-standards`, each with its own probe tests and
mutation passes.

**Round 1** (commits through `ad55206c`) — **no must-fix.** It independently confirmed the
four highest-risk properties: no `StartTimeNs` scaling anywhere, no lock-order hazard, no
data race under `-race` with concurrent producers/flushers over a shared tree graph, and
that trees really are immutable once attached (so sharing pointers into the snapshot is
safe). It also confirmed the `DeepCopy` deviation is justified by reading the armoapi-go
source. Six should-fix/nit items were addressed in `82ba0dd2`, including **two of my own
tests that did not pin what they claimed** — `TestNoTickScaling` passed with a
`/10_000_000` injected into `processRefFor`, and the shutdown `select` was covered by
nothing because every channel test buffers so the producer never blocks. Both now fail
against those mutations.

**Round 2** (the budget commits, which round 1 never saw) — **one must-fix, now fixed.**
The tree budget was not a bound: the estimator charged `len(s)` while `encoding/json`
escapes, so 629 processes with non-UTF-8 argv estimated at 29% of budget and produced a
5.37 MB message that the broker rejects, costing the node its whole interval — see the
section above. Fixed in `1e978ede` with `escapedLen`, a raised per-node overhead, a
15-shape property test and a 400-case randomised one, both checked against real
`json.Marshal` output. The review also found the determinism contract, skip-vs-break
packing, the estimator's legacy-`Children` branch and the wrapper-field copy were all
unpinned (mutations survived the suite) — closed in the same commit — and that my
connection-count ranking rationale was backwards for the beacon case it named, which is
why ranking is now smallest-tree-first.

**Verdict: approved after fixes.** Everything else in both rounds was verified correct.
Round 2's closing note: *"the test suite is unusually load-bearing: 5 of 13 mutations were
killed by named assertions."*

## Ticket

SUB-7786

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network and DNS events now include process attribution with process-reference deduplication and connection counting.
  - Stream payloads retain process references while selecting deduplicated process-trees under a deterministic byte budget, with UTF-8 command-line truncation and warnings for dropped trees.

- **Bug Fixes**
  - Improved flush behavior with snapshot isolation, safer shutdown-aware notifications/backpressure, and more consistent event/payload handling.

- **Documentation**
  - Added detailed documentation on network-stream process attribution semantics and testing notes.

- **Tests**
  - Expanded coverage for attribution, snapshot/flush guarantees, budgeting statistics, and shutdown/cancellation scenarios.

- **Chores**
  - Updated the ArmoAPI Go dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->