### PR TITLE
fix(sbom): classify sidecar oversized images as TooLarge

### DIFF
--- a/pkg/sbommanager/v1/sbom_manager.go
+++ b/pkg/sbommanager/v1/sbom_manager.go
@@ -509,6 +509,23 @@ func (s *SbomManager) processContainerWithMetadata(notif containercollection.Pub
 				s.handleScannerCrash(sbomName, notif, scanErr, imageTag, imageID, wipSbomHadContent)
 				return
 			}
+			if errors.Is(scanErr, sbomscanner.ErrImageTooLarge) {
+				s.metrics.ReportSBOMScan("error")
+				s.metrics.ObserveSBOMScanDuration("error", scanDuration)
+				logger.L().Ctx(s.ctx).Error("SbomManager - sidecar image too large",
+					helpers.Error(scanErr),
+					helpers.String("namespace", notif.Container.K8s.Namespace),
+					helpers.String("pod", notif.Container.K8s.PodName),
+					helpers.String("container", notif.Container.K8s.ContainerName),
+					helpers.String("sbomName", sbomName))
+				if wipSbomHadContent {
+					s.handleGenericFailure(sbomName)
+				} else {
+					s.markSBOMStatus(sbomName, helpersv1.TooLarge, nil)
+				}
+				s.reportFailure(notif, imageTag, imageID, scanfailure.ReasonImageTooLarge, scanErr)
+				return
+			}
 			s.metrics.ReportSBOMScan("error")
 			s.metrics.ObserveSBOMScanDuration("error", scanDuration)
 			logger.L().Ctx(s.ctx).Error("SbomManager - sidecar scan failed",

--- a/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
+++ b/pkg/sbommanager/v1/sbom_manager_reprocessing_test.go
@@ -469,6 +469,56 @@ func Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediately(t *tes
 	assert.Equal(t, 1, fake.patchCalls, "a fresh reservation must mark TooLarge on the first occurrence, with no retry budget")
 }
 
+// Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediatelyViaSidecar is the
+// sidecar counterpart to Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediately:
+// a fresh reservation whose sidecar returns sbomscanner.ErrImageTooLarge must still be marked
+// TooLarge immediately, with no retry budget.
+func Test_processContainerWithMetadata_MarksFreshImageTooLargeImmediatelyViaSidecar(t *testing.T) {
+	fake := newFakeSbomClient()
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	mgr := newTestManagerWithScannerErr(fake, "v2.0.0", sbomscanner.ErrImageTooLarge)
+	mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+
+	stored := fake.get(sbomName)
+	assert.Equal(t, helpersv1.TooLarge, stored.Annotations[helpersv1.StatusMetadataKey])
+	assert.Equal(t, 1, fake.patchCalls, "sidecar ErrImageTooLarge must mark TooLarge on the first attempt")
+	_, stillBudgeted := mgr.failureRetries.Get(sbomName)
+	assert.False(t, stillBudgeted, "sidecar ErrImageTooLarge must not consume the generic retry budget")
+}
+
+// Test_processContainerWithMetadata_PreservesContentOnSidecarTooLarge is the sidecar
+// counterpart to Test_processContainerWithMetadata_PreservesContentOnTooLarge: TooLarge is a
+// storage-layer one-way door, so a content-bearing SBOM must fall back to generic Incomplete
+// pinning instead.
+func Test_processContainerWithMetadata_PreservesContentOnSidecarTooLarge(t *testing.T) {
+	fake := newFakeSbomClient()
+	notif, imageStatus, imageTag, imageID := testNotifAndImageStatus()
+	sbomName, err := names.ImageInfoToSlug(imageTag, imageID)
+	assert.NoError(t, err)
+
+	good := &v1beta1.SBOMSyft{}
+	good.Name = sbomName
+	good.Annotations = map[string]string{
+		helpersv1.StatusMetadataKey:      helpersv1.Learning,
+		helpersv1.ToolVersionMetadataKey: "v1.0.0",
+	}
+	good.Spec.Syft.Artifacts = make([]v1beta1.SyftPackage, 2)
+	fake.sboms[sbomName] = good
+
+	mgr := newTestManagerWithScannerErr(fake, "v2.0.0", sbomscanner.ErrImageTooLarge)
+	for range maxScanRetries + 2 {
+		mgr.processContainerWithMetadata(notif, nil, imageStatus, imageTag, imageID)
+	}
+
+	raw := fake.get(sbomName)
+	assert.Len(t, raw.Spec.Syft.Artifacts, 2, "existing SBOM content must survive an annotation-only status update")
+	assert.Equal(t, helpersv1.Incomplete, raw.Annotations[helpersv1.StatusMetadataKey], "content-bearing SBOMs must never be pinned TooLarge via sidecar")
+	assert.Equal(t, 1, fake.patchCalls, "only the maxScanRetries-th consecutive failure marks Incomplete")
+}
+
 // genericThenCrashScannerClient returns a generic error on its first two calls, then
 // sbomscanner.ErrScannerCrashed on the third -- used to reproduce the exact mixed-failure
 // sequence from the review finding on PR #857 (2 generic failures + 1 crash).

--- a/pkg/sbomscanner/v1/client.go
+++ b/pkg/sbomscanner/v1/client.go
@@ -92,6 +92,9 @@ func (c *sbomScannerClient) CreateSBOM(ctx context.Context, req ScanRequest) (*S
 		if ok && (st.Code() == codes.Unavailable || st.Code() == codes.Aborted) {
 			return nil, fmt.Errorf("%w: %v", ErrScannerCrashed, err)
 		}
+		if ok && st.Code() == codes.FailedPrecondition {
+			return nil, fmt.Errorf("%w: %v", ErrImageTooLarge, err)
+		}
 		return nil, err
 	}
 

--- a/pkg/sbomscanner/v1/integration_test.go
+++ b/pkg/sbomscanner/v1/integration_test.go
@@ -12,9 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1"
 	_ "modernc.org/sqlite"
 )
@@ -130,9 +128,7 @@ func TestIntegration_ImageTooLarge(t *testing.T) {
 		MaxImageSize: 1,
 	})
 	require.Error(t, err)
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.ErrorIs(t, err, ErrImageTooLarge)
 }
 
 func TestIntegration_ReadyCheck(t *testing.T) {

--- a/pkg/sbomscanner/v1/server.go
+++ b/pkg/sbomscanner/v1/server.go
@@ -57,7 +57,7 @@ func (s *scannerServer) CreateSBOM(ctx context.Context, req *pb.CreateSBOMReques
 	src, err := syftutil.NewSource(req.ImageTag, req.ImageId, req.ImageId, &imageStatus, req.LayerPaths, req.MaxImageSize)
 	if err != nil {
 		if errors.Is(err, syftutil.ErrImageTooLarge) {
-			return nil, status.Error(codes.FailedPrecondition, "image size exceeds maximum allowed size")
+			return nil, status.Error(codes.FailedPrecondition, ErrImageTooLarge.Error())
 		}
 		return nil, status.Errorf(codes.Internal, "failed to create image source: %v", err)
 	}

--- a/pkg/sbomscanner/v1/types.go
+++ b/pkg/sbomscanner/v1/types.go
@@ -11,6 +11,7 @@ import (
 var (
 	ErrScannerCrashed  = errors.New("SBOM scanner sidecar crashed during scan")
 	ErrScannerNotReady = errors.New("SBOM scanner sidecar not ready")
+	ErrImageTooLarge = errors.New("image size exceeds maximum allowed size")
 )
 
 type ScanRequest struct {


### PR DESCRIPTION
## Overview

Fix the sidecar SBOM path to classify oversized images the same way as the in-process path. This change maps gRPC `FailedPrecondition` to `ErrImageTooLarge` and updates SBOM handling to mark fresh SBOMs as `TooLarge` while preserving content-bearing SBOMs on the generic `Incomplete` path.

## How to Test

```bash
go test ./pkg/sbomscanner/v1/ -run 'TestIntegration_ImageTooLarge|TestCreateSBOM_ImageTooLarge' -count=1
go test ./pkg/sbommanager/v1/ -run 'TooLargeImmediatelyViaSidecar|PreservesContentOnSidecarTooLarge' -count=1
```

## Related issues/PRs

* Resolved #877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images exceeding the maximum allowed size are now explicitly flagged as too large without consuming retry attempts.

* **Bug Fixes**
  * Enhanced error handling to distinguish image size limit violations from other failure conditions, preserving existing SBOM content when applicable.

* **Tests**
  * Added test coverage for oversized image handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->