### PR TITLE
testing a fix for the scramble of the path opens

### DIFF
--- a/pkg/utils/datasource_event.go
+++ b/pkg/utils/datasource_event.go
@@ -520,7 +520,15 @@ func (e *DatasourceEvent) GetFlagsRaw() uint32 {
 
 func (e *DatasourceEvent) GetFullPath() string {
 	path, _ := e.getFieldAccessor("fpath").String(e.Data)
-	if path == "" {
+	// Discard a full path the gadget could not actually resolve. A non-absolute
+	// value is stale scratch-buffer content, not this event's path -- see
+	// IsResolvedFullPath. Without this guard NormalizePath prefixes "/" and
+	// turns the fragment into a well-formed absolute path, which then enters
+	// the learned profile as its own root-level segment. Enough distinct
+	// fragments cross OpenDynamicThreshold and collapse the profile's root
+	// position to a wildcard, which stops the profile matching anything
+	// meaningfully.
+	if !IsResolvedFullPath(path) {
 		path, _ = e.getFieldAccessor("fname").String(e.Data)
 	}
 	return NormalizePath(path)

--- a/pkg/utils/path.go
+++ b/pkg/utils/path.go
@@ -18,6 +18,30 @@ import (
 // another /proc/<pid> entry is observed leaking.
 var headlessProcRegex = regexp.MustCompile(`^/\d+/(task|fd|setgroups|gid_map|uid_map|status|stat|cgroup|mountinfo|maps|environ|comm|cmdline|ns)(/|$)`)
 
+// IsResolvedFullPath reports whether p is usable as a gadget-resolved full
+// path (the "fpath" field of an open event).
+//
+// The gadget builds that field by walking the dentry chain backwards into a
+// per-CPU scratch buffer which is never cleared between events. When the walk
+// contributes nothing, the buffer's previous contents are returned instead,
+// so the field can carry a fragment of an unrelated event's path — including
+// one belonging to a different container on the same node.
+//
+// A successful walk always emits a leading slash before returning, so a
+// non-empty value that is not absolute cannot have come from one. That makes
+// the leading slash a reliable boundary check for the fragment case.
+//
+// Callers must NOT apply this to "fname": that field is the raw syscall
+// argument and is legitimately relative when openat is used with a dirfd.
+//
+// This does not catch every stale value. When the returned pointer happens to
+// land on the start of a previous complete path the result is absolute and
+// indistinguishable by shape; that case can only be fixed in the gadget, by
+// returning NULL for an empty walk and by clearing the scratch buffer.
+func IsResolvedFullPath(p string) bool {
+	return p != "" && strings.HasPrefix(p, "/")
+}
+
 // NormalizePath normalizes a path by:
 // 1. Prepending "/proc" to "headless" proc paths (e.g. /46/task/46/fd -> /proc/46/task/46/fd)
 // 2. Ensuring it starts with "/" if it's not empty

--- a/pkg/utils/resolved_full_path_test.go
+++ b/pkg/utils/resolved_full_path_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import "testing"
+
+// TestIsResolvedFullPath pins the boundary check on the gadget's "fpath"
+// field. The non-absolute cases are real values captured from node-agent on a
+// 2-node k3s cluster; each is a fragment of an unrelated event's path left in
+// the gadget's per-CPU scratch buffer.
+func TestIsResolvedFullPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Stale scratch-buffer fragments -- must be rejected.
+		{"observed fragment ocal.sh", "ocal.sh", false},
+		{"observed fragment local.sh", "local.sh", false},
+		{"observed fragment cal.sh", "cal.sh", false},
+		{"observed fragment cksource", "cksource", false},
+		{"empty", "", false},
+		{"bare relative name", "passwd", false},
+		{"relative with separator", "appendonlydir/appendonly.aof.1.incr.aof", false},
+		{"dot", ".", false},
+
+		// Legitimate resolved paths -- must be accepted.
+		{"absolute file", "/etc/passwd", true},
+		{"resolved symlink target", "/usr/lib/libtinfo.so.6.6", true},
+		{"atomic writer target", "/health/..2026_08_03_16_47_11.8011833/ping_readiness_local.sh", true},
+		{"headless proc, re-rooted later by NormalizePath", "/23240/setgroups", true},
+		{"root", "/", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsResolvedFullPath(tt.path); got != tt.want {
+				t.Errorf("IsResolvedFullPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizePathLaundersFragments documents the behaviour that made this
+// defect invisible: NormalizePath turns a stale fragment into a well-formed
+// absolute path. It is why the guard must run before NormalizePath, not
+// inside it -- NormalizePath is also applied to "fname", which is
+// legitimately relative for openat with a dirfd.
+func TestNormalizePathLaundersFragments(t *testing.T) {
+	for _, frag := range []string{"ocal.sh", "local.sh", "cksource"} {
+		got := NormalizePath(frag)
+		if got != "/"+frag {
+			t.Fatalf("NormalizePath(%q) = %q, expected it to prefix a slash", frag, got)
+		}
+		if IsResolvedFullPath(frag) {
+			t.Errorf("fragment %q must be rejected before NormalizePath sees it", frag)
+		}
+	}
+}


### PR DESCRIPTION
Looks like it could be as simple as this, currently testing for various side effects as tag= `sbob-rc5s-osp` -> Edit: its only half the rent, there is more to the story. This current patch does help, but I havnt had time to check where those `scrambled` lookups were introduced.
More info can be found here:
https://github.com/k8sstormcenter/bob/issues/183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling when full paths are unresolved or contain stale relative fragments.
  * Prevented invalid path fragments from being treated as valid absolute paths.
  * Added fallback behavior to use the available filename when a resolved full path is unavailable.

* **Tests**
  * Added coverage for relative, absolute, root, and process-related path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->