### PR TITLE
feat(otel): add pod-level memory metric, harden cgroup scope resolution

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,7 +201,10 @@ func main() {
 	// when OTEL_METRICS_EXPORTER=prometheus; OTLP push when OTEL_EXPORTER_OTLP_ENDPOINT set).
 	// MUST be constructed after otelsetup.InitProviders() so the global MeterProvider is set.
 	// Always use the OTEL impl — the SDK's own no-op providers handle the "no endpoint" case.
-	metricsProvider := otelmetrics.NewOTELMetricsManager(resolveOwnContainerID(ctx, k8sClient))
+	ownContainerID, ownPodUID := resolveOwnContainerID(ctx, k8sClient)
+	// true: this entrypoint (the Kubernetes DaemonSet) bind-mounts the HOST's
+	// /sys/fs/cgroup over its own — see NewOTELMetricsManager's doc comment.
+	metricsProvider := otelmetrics.NewOTELMetricsManager(ownContainerID, ownPodUID, true)
 
 	// Create watchers
 	dWatcher := dynamicwatcher.NewWatchHandler(k8sClient, storageClient.GetStorageClient(), cfg.SkipNamespace)
@@ -546,11 +549,13 @@ func resolveOwnContainerID(ctx context.Context, k8sClient *k8sinterface.Kubernet
 	const containerName = "node-agent"
 	podName, namespace := os.Getenv("POD_NAME"), os.Getenv("NAMESPACE_NAME")
 	if podName == "" || namespace == "" {
+		logger.L().Warning("resolveOwnContainerID - POD_NAME or NAMESPACE_NAME unset, cgroup memory gauges will report 0",
+			helpers.String("pod", podName), helpers.String("namespace", namespace))
 		return "", ""
 	}
 	pod, err := k8sClient.GetKubernetesClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		logger.L().Warning("resolveOwnContainerID - failed to get own pod, cgroup memory gauges will fall back",
+		logger.L().Warning("resolveOwnContainerID - failed to get own pod, cgroup memory gauges will report 0",
 			helpers.Error(err), helpers.String("pod", podName), helpers.String("namespace", namespace))
 		return "", ""
 	}
@@ -563,5 +568,11 @@ func resolveOwnContainerID(ctx context.Context, k8sClient *k8sinterface.Kubernet
 			return cs.ContainerID, string(pod.UID)
 		}
 	}
+	// No ContainerStatuses entry named "node-agent" yet — most likely a
+	// startup race (this pod's own status hasn't propagated yet). This result
+	// is cached for the process lifetime by the caller, so it's worth logging:
+	// otherwise it's silently indistinguishable from a genuine misconfiguration.
+	logger.L().Warning("resolveOwnContainerID - no ContainerStatuses entry named \"node-agent\" yet, cgroup memory gauges will report 0",
+		helpers.String("pod", podName), helpers.String("namespace", namespace))
 	return "", ""
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -535,31 +535,33 @@ func main() {
 	// Return normally so deferred OTEL shutdown flushes traces/metrics/logs.
 }
 
-// resolveOwnContainerID returns node-agent's own container ID via the k8s API
-// (using the Downward-API POD_NAME / NAMESPACE_NAME env), or "" if it cannot be
-// determined. The cgroup memory gauges use it to locate the correct container
-// scope in the host-mounted cgroup tree; "" makes them fall back to /proc-based
-// resolution. Best-effort: a failure here only degrades those gauges.
-func resolveOwnContainerID(ctx context.Context, k8sClient *k8sinterface.KubernetesApi) string {
+// resolveOwnContainerID returns node-agent's own container ID and pod UID via
+// the k8s API (using the Downward-API POD_NAME / NAMESPACE_NAME env), or "", ""
+// if they cannot be determined. The cgroup memory gauges use the container ID
+// to locate the correct container scope in the host-mounted cgroup tree ("" makes
+// them fall back to /proc-based resolution) and the pod UID to verify the parent
+// pod slice the pod-level gauges read from. Best-effort: a failure here only
+// degrades those gauges.
+func resolveOwnContainerID(ctx context.Context, k8sClient *k8sinterface.KubernetesApi) (containerID, podUID string) {
 	const containerName = "node-agent"
 	podName, namespace := os.Getenv("POD_NAME"), os.Getenv("NAMESPACE_NAME")
 	if podName == "" || namespace == "" {
-		return ""
+		return "", ""
 	}
 	pod, err := k8sClient.GetKubernetesClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		logger.L().Warning("resolveOwnContainerID - failed to get own pod, cgroup memory gauges will fall back",
 			helpers.Error(err), helpers.String("pod", podName), helpers.String("namespace", namespace))
-		return ""
+		return "", ""
 	}
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == containerName {
 			// ContainerID is "<runtime>://<id>", e.g. "containerd://9103ee5f..."
 			if i := strings.LastIndex(cs.ContainerID, "/"); i >= 0 {
-				return cs.ContainerID[i+1:]
+				return cs.ContainerID[i+1:], string(pod.UID)
 			}
-			return cs.ContainerID
+			return cs.ContainerID, string(pod.UID)
 		}
 	}
-	return ""
+	return "", ""
 }

--- a/docs/metrics-migration.md
+++ b/docs/metrics-migration.md
@@ -110,7 +110,7 @@ previously missing event types (`exit`, `fork`).
 ### Cgroup Scope Resolution Hardening (accuracy fix, no name change)
 
 `node_agent_process_memory_cgroup_bytes` / `..._cgroup_limit_bytes` (and the new pod-level
-metrics above) are read via `findCgroupScopeDir` / `resolveCgroupMemoryPaths`, which had three
+metrics above) are read via `findCgroupScopeDir` / `resolveCgroupMemoryPaths`, which had several
 defects fixed alongside the pod-level metric addition — no metric was renamed, but
 previously-silent or previously-wrong readings on affected hosts will now report correctly:
 
@@ -123,19 +123,33 @@ previously-silent or previously-wrong readings on affected hosts will now report
   the process lifetime. The resolver now keeps walking until it finds a directory that actually
   has one (`memory.current` on v2, `memory.usage_in_bytes` on v1), and reads the correct
   filename pair for whichever it found — so v1 hosts get correctly *container-scoped* numbers
-  instead of `0`, not just a `0` that's harder to trigger.
-- **A caller with a known container ID never falls through to the unscoped resolution
-  strategies.** Those strategies read from the cgroup root itself, which is only a valid proxy
-  for "this container's memory" when the caller mounts its own namespaced cgroup root (the
-  sbom-scanner sidecar topology, `ownContainerID == ""`). For the main agent, which bind-mounts
-  the *host's* cgroup tree, that same root is the whole node — an earlier version of this fix
-  did fall through in that case, which would have silently reported node-wide memory as this
-  container's own on any host where the scoped lookup failed. Fixed before merge; a container
-  ID that can't be scope-resolved now reports `0`, never a plausible-looking wrong number.
+  instead of `0`, not just a `0` that's harder to trigger. This applies to both the container-
+  and pod-level resolvers.
+- **A host-mounted caller never falls through to the unscoped resolution strategies.** Those
+  strategies read from the cgroup root itself, which is only a valid proxy for "this container's
+  memory" when the caller mounts its own namespaced cgroup root (the sbom-scanner sidecar, and
+  any entrypoint that isn't the Kubernetes DaemonSet). For the DaemonSet, which bind-mounts the
+  *host's* cgroup tree, that same root is the whole node. This is a property of the deployment
+  topology (`hostCgroupMounted`, passed explicitly by each entrypoint), not of whether a
+  container ID happens to be known for a given call — an earlier version of this fix inferred
+  it from `ownContainerID == ""` instead, which left the same node-wide misattribution reachable
+  through a different door: an empty container ID on the host-mounted DaemonSet (e.g. a
+  permanently-cached early-startup race, before this pod's own `ContainerStatuses` entry
+  exists) still bind-mounts the host tree, so falling through in that case was exactly as wrong
+  as falling through after a failed scoped lookup. Both doors are closed now; a host-mounted
+  caller that can't verify a container-scoped directory always reports `0`, never a
+  plausible-looking wrong number, regardless of why the container ID wasn't known.
 - Scoped to the **systemd** cgroup driver; hosts on the cgroupfs driver still read `0` for
   both the container- and pod-level cgroup metrics (pre-existing, unchanged by this PR —
   tracked as a follow-up, since `findCgroupScopeDir` requires a `.scope`-suffixed name that
-  cgroupfs layouts never produce).
+  cgroupfs layouts never produce). This is the only remaining declared non-goal; cgroup v1 is
+  now fully supported at both the container and pod level.
+- The two currently-silent `resolveOwnContainerID` failure paths (missing `POD_NAME`/
+  `NAMESPACE_NAME`, and no `ContainerStatuses` entry named `node-agent` yet) now log a
+  `Warning`, as does an unresolved container ID on the DaemonSet reaching
+  `RegisterPodMemoryMetrics`. Combined with the resolver's own rejection log (also raised to
+  `Warning`), the empty-container-ID and cgroup-v1 populations should both become directly
+  observable in logs post-deploy.
 
 **On the production data cited during development:** per-pod SigNoz telemetry showed 35% of
 live pods reporting `cgroup_bytes == 0` while `rss_bytes > 0`, and 2% showing a smaller genuine

--- a/docs/metrics-migration.md
+++ b/docs/metrics-migration.md
@@ -110,22 +110,47 @@ previously missing event types (`exit`, `fork`).
 ### Cgroup Scope Resolution Hardening (accuracy fix, no name change)
 
 `node_agent_process_memory_cgroup_bytes` / `..._cgroup_limit_bytes` (and the new pod-level
-metrics above) are read via `findCgroupScopeDir`, which had two defects fixed alongside the
-pod-level metric addition — no metric was renamed, but previously-silent `0` readings on
-affected hosts will now report real values:
+metrics above) are read via `findCgroupScopeDir` / `resolveCgroupMemoryPaths`, which had three
+defects fixed alongside the pod-level metric addition — no metric was renamed, but
+previously-silent or previously-wrong readings on affected hosts will now report correctly:
 
 - Container-ID matching was an unanchored substring (`strings.Contains`), which could in
   principle select the wrong container's cgroup. Now a delimited-segment match.
 - The first name-matching `.scope` directory was accepted without checking it actually
-  contained `memory.current`. On cgroup-v1/hybrid hosts, `filepath.WalkDir` can reach an
-  unrelated controller subtree (e.g. `blkio`, `cpu`) before `memory`, so the resolver would
-  lock onto a directory with no `memory.current` and silently cache a `0` read for the
-  process lifetime. Per-pod production telemetry showed this affecting **35% of live pods**
-  (`cgroup_bytes == 0` while `rss_bytes > 0`) before this fix.
+  contained a memory-accounting file at all. On cgroup-v1/hybrid hosts, `filepath.WalkDir` can
+  reach an unrelated controller subtree (e.g. `blkio`, `cpu`) before `memory`, so the resolver
+  could lock onto a directory with no memory-accounting file and silently cache a `0` read for
+  the process lifetime. The resolver now keeps walking until it finds a directory that actually
+  has one (`memory.current` on v2, `memory.usage_in_bytes` on v1), and reads the correct
+  filename pair for whichever it found — so v1 hosts get correctly *container-scoped* numbers
+  instead of `0`, not just a `0` that's harder to trigger.
+- **A caller with a known container ID never falls through to the unscoped resolution
+  strategies.** Those strategies read from the cgroup root itself, which is only a valid proxy
+  for "this container's memory" when the caller mounts its own namespaced cgroup root (the
+  sbom-scanner sidecar topology, `ownContainerID == ""`). For the main agent, which bind-mounts
+  the *host's* cgroup tree, that same root is the whole node — an earlier version of this fix
+  did fall through in that case, which would have silently reported node-wide memory as this
+  container's own on any host where the scoped lookup failed. Fixed before merge; a container
+  ID that can't be scope-resolved now reports `0`, never a plausible-looking wrong number.
 - Scoped to the **systemd** cgroup driver; hosts on the cgroupfs driver still read `0` for
   both the container- and pod-level cgroup metrics (pre-existing, unchanged by this PR —
   tracked as a follow-up, since `findCgroupScopeDir` requires a `.scope`-suffixed name that
   cgroupfs layouts never produce).
+
+**On the production data cited during development:** per-pod SigNoz telemetry showed 35% of
+live pods reporting `cgroup_bytes == 0` while `rss_bytes > 0`, and 2% showing a smaller genuine
+`0 < cgroup_bytes < rss_bytes` inversion. At the time, this was attributed mainly to the
+wrong-controller-subtree defect above (cgroup-v1/hybrid hosts). On review, that attribution
+isn't fully confirmed: a simpler, v2-compatible explanation — `ownContainerID` resolving to
+empty on a permanently-cached early-startup race — is equally consistent with the same observed
+zeros, and the true v1-vs-v2 split of the affected 35% couldn't be determined from SigNoz data
+alone (no cgroup-version attribute exists in the current telemetry, and live per-node inspection
+wasn't available at the time). This PR fixes both failure modes it found either way, but the
+35% figure should be read as "pods currently reporting a silent `cgroup_bytes == 0`," not as
+confirmed evidence for any one specific mechanism. Because this fix makes cgroup-v1 hosts report
+real (non-zero) container-scoped numbers instead of `0`, and raises the pod-level resolver's
+rejection log from `Debug` to `Warning`, the actual v1-vs-empty-container-ID split will become
+directly observable post-deploy rather than inferred.
 
 ### Removed Metrics (not migrated)
 

--- a/docs/metrics-migration.md
+++ b/docs/metrics-migration.md
@@ -104,6 +104,28 @@ previously missing event types (`exit`, `fork`).
 | New OTEL name | Description |
 |---|---|
 | `node_agent_ebpf_events_dropped_total{reason}` | eBPF events dropped due to backpressure (`reason=worker_channel_full`) or profile drops |
+| `node_agent_pod_memory_cgroup_bytes` | Pod-level memory usage, read from the parent `kubepods-*-pod<UID>.slice` cgroup (one level above the container `.scope`). Covers every container in the pod, including third-party sidecars with no OTEL instrumentation of their own (e.g. `clamav`, gated behind `capabilities.malwareDetection`). Additive alongside `node_agent_process_memory_cgroup_bytes`, which stays container-scoped and unchanged. |
+| `node_agent_pod_memory_cgroup_limit_bytes` | Pod-level memory limit, paired with `node_agent_pod_memory_cgroup_bytes` (0 = unlimited/unresolved). |
+
+### Cgroup Scope Resolution Hardening (accuracy fix, no name change)
+
+`node_agent_process_memory_cgroup_bytes` / `..._cgroup_limit_bytes` (and the new pod-level
+metrics above) are read via `findCgroupScopeDir`, which had two defects fixed alongside the
+pod-level metric addition — no metric was renamed, but previously-silent `0` readings on
+affected hosts will now report real values:
+
+- Container-ID matching was an unanchored substring (`strings.Contains`), which could in
+  principle select the wrong container's cgroup. Now a delimited-segment match.
+- The first name-matching `.scope` directory was accepted without checking it actually
+  contained `memory.current`. On cgroup-v1/hybrid hosts, `filepath.WalkDir` can reach an
+  unrelated controller subtree (e.g. `blkio`, `cpu`) before `memory`, so the resolver would
+  lock onto a directory with no `memory.current` and silently cache a `0` read for the
+  process lifetime. Per-pod production telemetry showed this affecting **35% of live pods**
+  (`cgroup_bytes == 0` while `rss_bytes > 0`) before this fix.
+- Scoped to the **systemd** cgroup driver; hosts on the cgroupfs driver still read `0` for
+  both the container- and pod-level cgroup metrics (pre-existing, unchanged by this PR —
+  tracked as a follow-up, since `findCgroupScopeDir` requires a `.scope`-suffixed name that
+  cgroupfs layouts never produce).
 
 ### Removed Metrics (not migrated)
 

--- a/pkg/metricsmanager/otel/bench_test.go
+++ b/pkg/metricsmanager/otel/bench_test.go
@@ -27,7 +27,7 @@ func setupBenchmarkMeterProvider() {
 // ns/op ≤ 1.1× Prometheus impl (run with -benchmem to verify).
 func BenchmarkReportRuleEvaluationTime(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("")
+	m := NewOTELMetricsManager("", "")
 
 	// Warm the cache for the key under test so the benchmark measures the
 	// cached fast path, not the first-call allocation.
@@ -44,7 +44,7 @@ func BenchmarkReportRuleEvaluationTime(b *testing.B) {
 // eBPF events counter with a cached event_type attribute set.
 func BenchmarkReportEvent(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("")
+	m := NewOTELMetricsManager("", "")
 	m.ReportEvent(utils.ExecveEventType) // warm cache
 
 	b.ResetTimer()
@@ -58,7 +58,7 @@ func BenchmarkReportEvent(b *testing.B) {
 // counter with a cached rule_id attribute set.
 func BenchmarkReportRuleAlert(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("")
+	m := NewOTELMetricsManager("", "")
 	m.ReportRuleAlert("R1001") // warm cache
 
 	b.ResetTimer()

--- a/pkg/metricsmanager/otel/bench_test.go
+++ b/pkg/metricsmanager/otel/bench_test.go
@@ -27,7 +27,7 @@ func setupBenchmarkMeterProvider() {
 // ns/op ≤ 1.1× Prometheus impl (run with -benchmem to verify).
 func BenchmarkReportRuleEvaluationTime(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("", "")
+	m := NewOTELMetricsManager("", "", false)
 
 	// Warm the cache for the key under test so the benchmark measures the
 	// cached fast path, not the first-call allocation.
@@ -44,7 +44,7 @@ func BenchmarkReportRuleEvaluationTime(b *testing.B) {
 // eBPF events counter with a cached event_type attribute set.
 func BenchmarkReportEvent(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("", "")
+	m := NewOTELMetricsManager("", "", false)
 	m.ReportEvent(utils.ExecveEventType) // warm cache
 
 	b.ResetTimer()
@@ -58,7 +58,7 @@ func BenchmarkReportEvent(b *testing.B) {
 // counter with a cached rule_id attribute set.
 func BenchmarkReportRuleAlert(b *testing.B) {
 	setupBenchmarkMeterProvider()
-	m := NewOTELMetricsManager("", "")
+	m := NewOTELMetricsManager("", "", false)
 	m.ReportRuleAlert("R1001") // warm cache
 
 	b.ResetTimer()

--- a/pkg/metricsmanager/otel/otel_metrics_manager.go
+++ b/pkg/metricsmanager/otel/otel_metrics_manager.go
@@ -98,14 +98,24 @@ type OTELMetricsManager struct {
 // returns the real MeterProvider, not the SDK no-op.
 //
 // ownContainerID is this agent's own container ID (from the k8s API); it lets
-// the cgroup memory gauges resolve the correct container scope under the
-// host-mounted cgroup tree. Pass "" when unknown — the gauges then fall back to
-// /proc-based resolution and report 0 if that fails.
+// the cgroup memory gauges resolve the correct container scope. Pass "" when
+// unknown.
 //
 // ownPodUID is this agent's own pod UID (from the same k8s API call); it
 // verifies the pod-level cgroup slice the pod memory gauges read from. Pass ""
 // when unknown — the pod slice is then accepted on its name shape alone.
-func NewOTELMetricsManager(ownContainerID, ownPodUID string) *OTELMetricsManager {
+//
+// hostCgroupMounted MUST be true only for the caller that bind-mounts the
+// HOST's /sys/fs/cgroup over its own (the Kubernetes DaemonSet). It MUST be
+// false for every other caller — the sbom-scanner sidecar, or any entrypoint
+// (cmd/host, cmd/ecs) that mounts its own namespaced /sys/fs/cgroup —
+// regardless of whether ownContainerID is known for that call. Getting this
+// wrong on a host-mounted caller with an unresolved container ID would
+// silently report the whole node's memory as this container's own; see
+// resolveCgroupMemoryPathsUnder's doc comment for the full reasoning. When
+// hostCgroupMounted is false, a resolution failure simply falls back to
+// /proc-based resolution and reports 0 if that also fails.
+func NewOTELMetricsManager(ownContainerID, ownPodUID string, hostCgroupMounted bool) *OTELMetricsManager {
 	meter := otelsetup.Meter()
 	m := &OTELMetricsManager{
 		undeclaredRulesSet: make(map[string]struct{}),
@@ -232,7 +242,7 @@ func NewOTELMetricsManager(ownContainerID, ownPodUID string) *OTELMetricsManager
 	m.alertSuppressedTotal = mustCounter("node_agent.alert.suppressed.total",
 		"Total alerts suppressed before delivery, labeled by rule_id and reason")
 
-	registerResourceMetrics(meter, &m.containerCount, ownContainerID, ownPodUID)
+	registerResourceMetrics(meter, &m.containerCount, ownContainerID, ownPodUID, hostCgroupMounted)
 
 	return m
 }

--- a/pkg/metricsmanager/otel/otel_metrics_manager.go
+++ b/pkg/metricsmanager/otel/otel_metrics_manager.go
@@ -101,7 +101,11 @@ type OTELMetricsManager struct {
 // the cgroup memory gauges resolve the correct container scope under the
 // host-mounted cgroup tree. Pass "" when unknown — the gauges then fall back to
 // /proc-based resolution and report 0 if that fails.
-func NewOTELMetricsManager(ownContainerID string) *OTELMetricsManager {
+//
+// ownPodUID is this agent's own pod UID (from the same k8s API call); it
+// verifies the pod-level cgroup slice the pod memory gauges read from. Pass ""
+// when unknown — the pod slice is then accepted on its name shape alone.
+func NewOTELMetricsManager(ownContainerID, ownPodUID string) *OTELMetricsManager {
 	meter := otelsetup.Meter()
 	m := &OTELMetricsManager{
 		undeclaredRulesSet: make(map[string]struct{}),
@@ -228,7 +232,7 @@ func NewOTELMetricsManager(ownContainerID string) *OTELMetricsManager {
 	m.alertSuppressedTotal = mustCounter("node_agent.alert.suppressed.total",
 		"Total alerts suppressed before delivery, labeled by rule_id and reason")
 
-	registerResourceMetrics(meter, &m.containerCount, ownContainerID)
+	registerResourceMetrics(meter, &m.containerCount, ownContainerID, ownPodUID)
 
 	return m
 }

--- a/pkg/metricsmanager/otel/resource_metrics.go
+++ b/pkg/metricsmanager/otel/resource_metrics.go
@@ -6,12 +6,15 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -20,10 +23,14 @@ const cgroupRoot = "/sys/fs/cgroup"
 // registerResourceMetrics wires up observable gauges for process-level and
 // host-level resource. Called once from NewOTELMetricsManager; panics on
 // instrument creation failure (same policy as mustCounter/mustGauge).
-func registerResourceMetrics(meter metric.Meter, containerCount *atomic.Int64, ownContainerID string) {
+func registerResourceMetrics(meter metric.Meter, containerCount *atomic.Int64, ownContainerID, ownPodUID string) {
 	// Per-process memory gauges (rss + cgroup usage/limit) — shared with the
 	// sbom-scanner sidecar so both containers report the same memory signals.
 	RegisterProcessMemoryMetrics(meter, ownContainerID)
+
+	// Pod-scoped memory gauges — registered only here (the main agent), never
+	// from the sidecar-shared RegisterProcessMemoryMetrics.
+	RegisterPodMemoryMetrics(meter, ownContainerID, ownPodUID)
 
 	hostMemTotal := readHostMemTotalBytes()
 	hostCPUCount := int64(runtime.NumCPU())
@@ -98,6 +105,42 @@ func RegisterProcessMemoryMetrics(meter metric.Meter, ownContainerID string) {
 	}, rssGauge, cgroupMemGauge, cgroupLimitGauge)
 }
 
+// RegisterPodMemoryMetrics registers pod-scoped memory gauges covering every
+// container in this pod, including sidecars with no instrumentation of their
+// own. Called only from registerResourceMetrics (the main agent), never from
+// the shared RegisterProcessMemoryMetrics — registering it per-container would
+// double-count the pod under any aggregation.
+//
+// ownContainerID == "" (sbom-scanner sidecar, cmd/host, cmd/ecs) registers
+// nothing at all, so no empty series is ever emitted from those topologies.
+func RegisterPodMemoryMetrics(meter metric.Meter, ownContainerID, ownPodUID string) {
+	if ownContainerID == "" {
+		return
+	}
+
+	podMemGauge, err := meter.Int64ObservableGauge("node_agent.pod.memory.cgroup_bytes",
+		metric.WithDescription("Pod memory usage from the parent pod cgroup slice (kubepods-...-pod<UID>.slice) memory.current — covers every container in the pod, including uninstrumented sidecars"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		panic("otelmetrics: gauge node_agent.pod.memory.cgroup_bytes: " + err.Error())
+	}
+	podLimitGauge, err := meter.Int64ObservableGauge("node_agent.pod.memory.cgroup_limit_bytes",
+		metric.WithDescription("Pod memory limit from the parent pod cgroup slice memory.max (0 = unlimited or unresolved). Pair with node_agent.pod.memory.cgroup_bytes for OOM headroom."),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		panic("otelmetrics: gauge node_agent.pod.memory.cgroup_limit_bytes: " + err.Error())
+	}
+
+	_, _ = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		cur, lim := readPodCgroupMem(ownContainerID, ownPodUID)
+		o.ObserveInt64(podMemGauge, cur)
+		o.ObserveInt64(podLimitGauge, lim)
+		return nil
+	}, podMemGauge, podLimitGauge)
+}
+
 func readProcessRSSBytes() int64 {
 	f, err := os.Open("/proc/self/status")
 	if err != nil {
@@ -122,6 +165,7 @@ var (
 	cgroupResolveOnce sync.Once
 	cgroupCurrentPath string // path to memory.current / memory.usage_in_bytes ("" if unresolved)
 	cgroupMaxPath     string // path to memory.max / memory.limit_in_bytes ("" if unresolved)
+	cgroupScopeDir    string // this container's ".scope" dir under cgroupRoot ("" if not found that way); reused by the pod-level resolver
 )
 
 // readCgroupMem returns the process's cgroup memory usage and limit in bytes
@@ -166,6 +210,7 @@ func readCgroupMem(ownContainerID string) (current, limit int64) {
 func resolveCgroupMemoryPaths(ownContainerID string) (current, max string) {
 	if ownContainerID != "" {
 		if dir := findCgroupScopeDir(cgroupRoot, ownContainerID); dir != "" {
+			cgroupScopeDir = dir // published under cgroupResolveOnce for cachedCgroupScopeDir
 			return filepath.Join(dir, "memory.current"), filepath.Join(dir, "memory.max")
 		}
 	}
@@ -184,6 +229,127 @@ func resolveCgroupMemoryPaths(ownContainerID string) (current, max string) {
 	return "", ""
 }
 
+var (
+	podCgroupResolveOnce sync.Once
+	podCgroupCurrentPath string // path to the pod slice's memory.current ("" if unresolved)
+	podCgroupMaxPath     string // path to the pod slice's memory.max ("" if unresolved)
+)
+
+// podSliceNameRe matches a systemd pod-slice directory name and captures the
+// escaped pod UID. Only the "pod<uid>.slice" *suffix* is mandatory; any number
+// of leading "<segment>-" parts is accepted, which covers every real shape:
+// "pod<uid>.slice", "kubepods-pod<uid>.slice" (guaranteed QoS),
+// "kubepods-<tier>-pod<uid>.slice" (burstable/besteffort) and the extra
+// segments a custom kubelet --cgroup-root introduces
+// ("kubelet-kubepods-burstable-pod<uid>.slice"). The QoS and root slices
+// ("kubepods.slice", "kubepods-burstable.slice", "kubepods-besteffort.slice",
+// "system.slice") are still rejected by shape since none of them ends in
+// "pod<uid>.slice". Loosening the prefix is safe because the mandatory pod-UID
+// equality check below — not the name shape — is the real correctness guard. A
+// pod UID is 32 hex digits plus 4 separators, which systemd escapes "-" → "_",
+// hence [0-9a-f_]{32,}; that escaping is also why the "-"-delimited prefix
+// segments can never eat into the UID capture.
+var podSliceNameRe = regexp.MustCompile(`^(?:[a-z0-9]+-)*pod([0-9a-f_]{32,})\.slice$`)
+
+// resolvePodCgroupMemoryPaths locates the pod-level cgroup memory files by
+// walking one level up from this container's ".scope" directory to its parent
+// "kubepods-...-pod<UID>.slice". The kernel already aggregates every container
+// in the pod at that level, including third-party sidecars (clamav) that carry
+// no OTEL instrumentation of their own.
+//
+// systemd cgroup driver on cgroup v2 only. The parent-name guard below matches
+// the systemd slice naming convention; under the cgroupfs driver
+// findCgroupScopeDir does not match at all (it requires a ".scope" suffix). The
+// memory.current check is likewise v2-only: this function hardcodes the v2
+// filename pair in its return, so accepting a v1 directory would hand back
+// paths that do not exist. Both cases return "", "".
+//
+// Returns "", "" when the pod slice cannot be positively identified.
+func resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID string) (current, max string) {
+	return resolvePodCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, ownPodUID)
+}
+
+// resolvePodCgroupMemoryPathsUnder is the testable core of
+// resolvePodCgroupMemoryPaths, parameterised on the cgroup tree root.
+func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (current, max string) {
+	// Sidecar / cmd/host / cmd/ecs topologies: no own container ID means no pod
+	// slice can be identified, and a pod-level number would be wrong anyway.
+	// This is by design, so it is deliberately not logged.
+	if ownContainerID == "" {
+		return "", ""
+	}
+	// Past this point we expected to find a pod slice, so every failure is a
+	// possible misconfiguration. The result is cached for the process lifetime,
+	// so log what was rejected — otherwise the silence is indistinguishable
+	// from the by-design case above, forever.
+	reject := func(rejected string) (string, string) {
+		logger.L().Debug("otelmetrics: pod-level cgroup memory unresolved, pod memory metrics will report 0",
+			helpers.String("containerID", ownContainerID),
+			helpers.String("podUID", ownPodUID),
+			helpers.String("rejected", rejected))
+		return "", ""
+	}
+	dir := cachedCgroupScopeDir(root, ownContainerID)
+	if dir == "" {
+		return reject("no .scope directory found for this container ID")
+	}
+	// Never let the walk-up escape to a QoS or node-wide slice.
+	parent := filepath.Dir(dir)
+	if parent == dir || parent == root || !strings.HasPrefix(parent+"/", root+"/") {
+		return reject("scope directory has no in-tree parent slice: " + dir)
+	}
+	m := podSliceNameRe.FindStringSubmatch(filepath.Base(parent))
+	if m == nil {
+		return reject("parent slice name is not a pod slice: " + filepath.Base(parent))
+	}
+	// Mandatory verification against the pod UID when it is known; the regex
+	// already constrains the captured segment to [0-9a-f_], so no case folding
+	// is involved. An unknown UID falls back to the name-shape guard alone.
+	if ownPodUID != "" && m[1] != strings.ReplaceAll(ownPodUID, "-", "_") {
+		return reject("parent slice belongs to a different pod UID: " + filepath.Base(parent))
+	}
+	if !fileExists(filepath.Join(parent, "memory.current")) {
+		return reject("parent slice has no memory.current (cgroup v1?): " + parent)
+	}
+	return filepath.Join(parent, "memory.current"), filepath.Join(parent, "memory.max")
+}
+
+// cachedCgroupScopeDir returns this container's ".scope" directory in the
+// cgroup tree. Under the real cgroup root it reuses the container-level
+// resolver's cached result — both resolvers look for the exact same directory —
+// so the tree is walked at most once per process instead of once per resolver.
+// A test root falls back to a direct walk.
+func cachedCgroupScopeDir(root, ownContainerID string) string {
+	if root != cgroupRoot {
+		return findCgroupScopeDir(root, ownContainerID)
+	}
+	cgroupResolveOnce.Do(func() {
+		cgroupCurrentPath, cgroupMaxPath = resolveCgroupMemoryPaths(ownContainerID)
+	})
+	return cgroupScopeDir
+}
+
+// readPodCgroupMem returns the pod-level cgroup memory usage and limit in bytes
+// (limit 0 = unlimited / unresolved). Paths are resolved once and cached — a
+// pod never changes cgroup — mirroring readCgroupMem's contract: a stale path
+// yields a read error and therefore 0, never a wrong number.
+func readPodCgroupMem(ownContainerID, ownPodUID string) (current, limit int64) {
+	podCgroupResolveOnce.Do(func() {
+		podCgroupCurrentPath, podCgroupMaxPath = resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID)
+	})
+	if podCgroupCurrentPath != "" {
+		if data, err := os.ReadFile(podCgroupCurrentPath); err == nil {
+			current = parseCgroupMemValue(string(data))
+		}
+	}
+	if podCgroupMaxPath != "" {
+		if data, err := os.ReadFile(podCgroupMaxPath); err == nil {
+			limit = parseCgroupMemValue(string(data))
+		}
+	}
+	return current, limit
+}
+
 // parseSelfCgroupV2 returns the cgroup v2 path from the "0::<path>" line of
 // /proc/self/cgroup and ok=true when that line is present (path may be "/", the
 // namespace root). ok=false means no cgroupv2 line (e.g. cgroupv1-only).
@@ -196,20 +362,73 @@ func parseSelfCgroupV2(content string) (string, bool) {
 	return "", false
 }
 
-// findCgroupScopeDir walks the cgroup tree for a "*<id>*.scope" directory.
-// Returns the first match, or "" if none. Bounded one-time cost (cached caller).
+// scopeNameMatchesID reports whether a cgroup ".scope" directory name identifies
+// exactly the given container ID — i.e. the ID appears as a whole
+// delimiter-bounded segment ("cri-containerd-<id>.scope", "docker-<id>.scope",
+// "crio-<id>.scope"), not as a substring of a longer hex ID.
+func scopeNameMatchesID(name, id string) bool {
+	if id == "" || !strings.HasSuffix(name, ".scope") {
+		return false
+	}
+	base := strings.TrimSuffix(name, ".scope")
+	// The ID must end the name (no trailing hex) and start at a delimiter
+	// boundary (no leading hex), so a longer ID that merely contains the query
+	// as a substring cannot match.
+	if !strings.HasSuffix(base, id) {
+		return false
+	}
+	if len(base) == len(id) {
+		return true
+	}
+	switch base[len(base)-len(id)-1] {
+	case '-', '_', '.', '/':
+		return true
+	}
+	return false
+}
+
+// findCgroupScopeDir walks the cgroup tree for the ".scope" directory belonging
+// to container id. Returns the first *verified* match, or "" if none. Bounded
+// one-time cost (cached caller).
+//
+// Root cause note (hypothesis H4 for the observed "cgroup_bytes < rss_bytes"
+// anomaly): the previous implementation matched on directory *name* only and
+// returned filepath.SkipAll on that bare name match. On a cgroup-v1/hybrid host
+// WalkDir visits /sys/fs/cgroup/blkio, /cpu, /cpuacct, /devices, /freezer — all
+// lexically before /memory — and any of them can hold a
+// "cri-containerd-<id>.scope" directory. The walk therefore locked in a
+// directory with no memory.current, readCgroupMem silently read 0, and
+// sync.Once cached that outcome for the process lifetime.
+//
+// The memory.current existence check below is therefore load-bearing, not
+// defensive, and so is "keep walking" (return nil) instead of SkipAll on a
+// name-only match: that is what lets the walk skip the decoy controller
+// subtrees and reach the real memory-controller scope.
+//
+// The check deliberately accepts the cgroupv2 filename memory.current *only*,
+// never the cgroupv1 memory.usage_in_bytes: resolveCgroupMemoryPaths returns
+// the v2 filename pair unconditionally once this function succeeds, so
+// accepting a v1 directory would hand back paths that do not exist and
+// reproduce H4 verbatim. Returning "" on a v1 host is strictly better — it lets
+// resolveCgroupMemoryPaths fall through to its later strategies, including the
+// cgroupv1 fixed-mount fallback, instead of caching a dead v2 path.
 func findCgroupScopeDir(root, id string) string {
+	if id == "" {
+		return ""
+	}
 	var found string
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || !d.IsDir() {
 			return nil //nolint:nilerr // skip unreadable subtrees, keep walking
 		}
-		name := d.Name()
-		if strings.HasSuffix(name, ".scope") && strings.Contains(name, id) {
-			found = path
-			return filepath.SkipAll
+		if !scopeNameMatchesID(d.Name(), id) {
+			return nil
 		}
-		return nil
+		if !fileExists(filepath.Join(path, "memory.current")) {
+			return nil // name matches but wrong controller subtree — keep walking
+		}
+		found = path
+		return filepath.SkipAll
 	})
 	return found
 }

--- a/pkg/metricsmanager/otel/resource_metrics.go
+++ b/pkg/metricsmanager/otel/resource_metrics.go
@@ -23,14 +23,19 @@ const cgroupRoot = "/sys/fs/cgroup"
 // registerResourceMetrics wires up observable gauges for process-level and
 // host-level resource. Called once from NewOTELMetricsManager; panics on
 // instrument creation failure (same policy as mustCounter/mustGauge).
-func registerResourceMetrics(meter metric.Meter, containerCount *atomic.Int64, ownContainerID, ownPodUID string) {
+//
+// hostCgroupMounted must be true only for the entrypoint that bind-mounts the
+// HOST's /sys/fs/cgroup over its own (the Kubernetes DaemonSet, cmd/main.go)
+// — see resolveCgroupMemoryPathsUnder's doc comment for why this can't be
+// inferred from ownContainerID alone.
+func registerResourceMetrics(meter metric.Meter, containerCount *atomic.Int64, ownContainerID, ownPodUID string, hostCgroupMounted bool) {
 	// Per-process memory gauges (rss + cgroup usage/limit) — shared with the
 	// sbom-scanner sidecar so both containers report the same memory signals.
-	RegisterProcessMemoryMetrics(meter, ownContainerID)
+	RegisterProcessMemoryMetrics(meter, ownContainerID, hostCgroupMounted)
 
 	// Pod-scoped memory gauges — registered only here (the main agent), never
 	// from the sidecar-shared RegisterProcessMemoryMetrics.
-	RegisterPodMemoryMetrics(meter, ownContainerID, ownPodUID)
+	RegisterPodMemoryMetrics(meter, ownContainerID, ownPodUID, hostCgroupMounted)
 
 	hostMemTotal := readHostMemTotalBytes()
 	hostCPUCount := int64(runtime.NumCPU())
@@ -68,12 +73,18 @@ func registerResourceMetrics(meter metric.Meter, containerCount *atomic.Int64, o
 // Both the main agent and the sbom-scanner sidecar call this so each container
 // reports its own memory usage and limit (distinguished downstream by
 // service.name). ownContainerID, when non-empty, lets the cgroup resolver find
-// the correct scope under a host-mounted cgroup tree (the main-agent topology);
-// pass "" for containers that mount their own namespaced /sys/fs/cgroup (the
-// sidecar), where a direct read of the namespace root works.
+// the correct scope under a host-mounted cgroup tree (the main-agent topology).
+//
+// hostCgroupMounted must be true only for callers that bind-mount the HOST's
+// /sys/fs/cgroup over their own (the Kubernetes DaemonSet). It must be false
+// for every caller that mounts its own namespaced /sys/fs/cgroup — the
+// sbom-scanner sidecar, and any entrypoint (cmd/host, cmd/ecs) that isn't the
+// Kubernetes DaemonSet — regardless of whether ownContainerID happens to be
+// known for that call. This can't be inferred from ownContainerID alone: see
+// resolveCgroupMemoryPathsUnder's doc comment for why.
 //
 // MUST be called after otelsetup.InitProviders so the real MeterProvider is set.
-func RegisterProcessMemoryMetrics(meter metric.Meter, ownContainerID string) {
+func RegisterProcessMemoryMetrics(meter metric.Meter, ownContainerID string, hostCgroupMounted bool) {
 	rssGauge, err := meter.Int64ObservableGauge("node_agent.process.memory.rss_bytes",
 		metric.WithDescription("Process RSS (resident set size) from /proc/self/status"),
 		metric.WithUnit("By"),
@@ -98,7 +109,7 @@ func RegisterProcessMemoryMetrics(meter metric.Meter, ownContainerID string) {
 
 	_, _ = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		o.ObserveInt64(rssGauge, readProcessRSSBytes())
-		cur, lim := readCgroupMem(ownContainerID)
+		cur, lim := readCgroupMem(ownContainerID, hostCgroupMounted)
 		o.ObserveInt64(cgroupMemGauge, cur)
 		o.ObserveInt64(cgroupLimitGauge, lim)
 		return nil
@@ -111,10 +122,17 @@ func RegisterProcessMemoryMetrics(meter metric.Meter, ownContainerID string) {
 // the shared RegisterProcessMemoryMetrics — registering it per-container would
 // double-count the pod under any aggregation.
 //
-// ownContainerID == "" (sbom-scanner sidecar, cmd/host, cmd/ecs) registers
-// nothing at all, so no empty series is ever emitted from those topologies.
-func RegisterPodMemoryMetrics(meter metric.Meter, ownContainerID, ownPodUID string) {
+// ownContainerID == "" registers nothing at all, so no empty series is ever
+// emitted. This is by-design and silent for topologies with no Kubernetes pod
+// concept at all (the sbom-scanner sidecar, cmd/host, cmd/ecs) — but on the
+// Kubernetes DaemonSet (hostCgroupMounted == true) an empty ownContainerID is
+// always anomalous (a startup race in resolveOwnContainerID, never a
+// legitimate state), so that specific combination is logged.
+func RegisterPodMemoryMetrics(meter metric.Meter, ownContainerID, ownPodUID string, hostCgroupMounted bool) {
 	if ownContainerID == "" {
+		if hostCgroupMounted {
+			logger.L().Warning("otelmetrics: own container ID unresolved on the Kubernetes DaemonSet topology, pod memory metrics will not be registered")
+		}
 		return
 	}
 
@@ -134,7 +152,7 @@ func RegisterPodMemoryMetrics(meter metric.Meter, ownContainerID, ownPodUID stri
 	}
 
 	_, _ = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-		cur, lim := readPodCgroupMem(ownContainerID, ownPodUID)
+		cur, lim := readPodCgroupMem(ownContainerID, ownPodUID, hostCgroupMounted)
 		o.ObserveInt64(podMemGauge, cur)
 		o.ObserveInt64(podLimitGauge, lim)
 		return nil
@@ -171,9 +189,9 @@ var (
 // readCgroupMem returns the process's cgroup memory usage and limit in bytes
 // (limit 0 = unlimited / unresolved). Paths are resolved once and cached since
 // a process never changes cgroup.
-func readCgroupMem(ownContainerID string) (current, limit int64) {
+func readCgroupMem(ownContainerID string, hostCgroupMounted bool) (current, limit int64) {
 	cgroupResolveOnce.Do(func() {
-		cgroupCurrentPath, cgroupMaxPath = resolveCgroupMemoryPaths(ownContainerID)
+		cgroupCurrentPath, cgroupMaxPath = resolveCgroupMemoryPaths(ownContainerID, hostCgroupMounted)
 	})
 	if cgroupCurrentPath != "" {
 		if data, err := os.ReadFile(cgroupCurrentPath); err == nil {
@@ -190,10 +208,21 @@ func readCgroupMem(ownContainerID string) (current, limit int64) {
 
 // resolveCgroupMemoryPaths locates this process's cgroup memory files.
 //
-// node-agent runs with a private cgroup namespace (so /proc/self/cgroup
-// reports "0::/") while bind-mounting the host's /sys/fs/cgroup over its own,
-// so the namespaced path cannot be joined with the host tree — reading the
-// fixed root path yields 0. Strategies, in order:
+// hostCgroupMounted is the deployment-level topology signal that decides
+// which strategies below are safe — it is NOT derivable from ownContainerID.
+// Those are two independent questions:
+//   - "do I know my own container ID right now" (ownContainerID) can be
+//     empty even for a host-mounted caller, e.g. a startup race in
+//     resolveOwnContainerID before the pod's ContainerStatuses are populated.
+//   - "is cgroupRoot the HOST's cgroup tree, or my own namespaced one"
+//     (hostCgroupMounted) is fixed per entrypoint/deployment and never
+//     changes at runtime.
+//
+// Conflating them (treating ownContainerID == "" as sufficient permission to
+// read cgroupRoot's own root) is exactly how a host-mounted caller with an
+// unresolved container ID would silently report the whole node's memory as
+// its own — the same wrong-but-plausible failure mode this function exists
+// to prevent for the "scope not found" case. Strategies, in order:
 //
 //  1. If our own container ID is known (resolved from the k8s API at startup),
 //     find the matching *.scope directory in the host cgroup tree and read
@@ -204,16 +233,6 @@ func readCgroupMem(ownContainerID string) (current, limit int64) {
 //     /proc/self/mountinfo is polluted with every other container's ID via
 //     shared mount propagation of /host.
 //
-//     When the container ID is known but no scope directory can be verified,
-//     this returns "", "" immediately — it deliberately does NOT fall through
-//     to strategies 2/3 below. Those two strategies read from cgroupRoot's own
-//     root, which is only a valid proxy for "this container's memory" when the
-//     caller mounts its own namespaced /sys/fs/cgroup (strategy 2/3's actual
-//     intended topology, see below). For the main agent, which bind-mounts the
-//     HOST's /sys/fs/cgroup, that same root is the whole node — falling
-//     through would silently report the host's memory as this container's own
-//     (a wrong-but-plausible number is worse than a missing series).
-//
 //  2. Join /proc/self/cgroup with the cgroup root; use it if memory.current
 //     exists there. This covers both the host cgroup namespace (rel is the full
 //     path) and a container's own namespaced /sys/fs/cgroup mount, where
@@ -222,31 +241,43 @@ func readCgroupMem(ownContainerID string) (current, limit int64) {
 //
 //  3. cgroupv1 fixed mount layout.
 //
-// Strategies 2 and 3 only run when ownContainerID == "" — i.e. the caller
-// either doesn't know which container it is, or mounts its own namespaced
-// cgroup root (see above), the two cases where reading cgroupRoot's own root
-// is actually scoped to the right thing.
-func resolveCgroupMemoryPaths(ownContainerID string) (current, max string) {
-	return resolveCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, readFileString("/proc/self/cgroup"))
+// Strategies 2 and 3 read cgroupRoot's own root, which is only a valid proxy
+// for "this container's memory" when the caller mounts its own namespaced
+// /sys/fs/cgroup — i.e. hostCgroupMounted == false. They run whenever
+// hostCgroupMounted == false, regardless of whether strategy 1 was attempted
+// or what it found, since a non-host-mounted caller's own root is always
+// safe to read. When hostCgroupMounted == true, only strategy 1 is ever
+// tried; if it doesn't resolve, this returns "", "" — never a wrong number.
+func resolveCgroupMemoryPaths(ownContainerID string, hostCgroupMounted bool) (current, max string) {
+	return resolveCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, hostCgroupMounted, readFileString("/proc/self/cgroup"))
 }
 
 // resolveCgroupMemoryPathsUnder is the testable core of resolveCgroupMemoryPaths:
 // root replaces the cgroupRoot const, and selfCgroupContent replaces a live
 // read of /proc/self/cgroup, so tests can exercise every strategy against a
 // synthetic tree instead of the real host filesystem.
-func resolveCgroupMemoryPathsUnder(root, ownContainerID, selfCgroupContent string) (current, max string) {
+func resolveCgroupMemoryPathsUnder(root, ownContainerID string, hostCgroupMounted bool, selfCgroupContent string) (current, max string) {
 	if ownContainerID != "" {
-		dir := findCgroupScopeDir(root, ownContainerID)
-		if dir == "" {
-			return "", ""
+		if dir := findCgroupScopeDir(root, ownContainerID); dir != "" {
+			cgroupScopeDir = dir // published under cgroupResolveOnce for cachedCgroupScopeDir
+			if fileExists(filepath.Join(dir, "memory.current")) {
+				return filepath.Join(dir, "memory.current"), filepath.Join(dir, "memory.max")
+			}
+			// cgroupv1: same (verified) directory, different filenames.
+			return filepath.Join(dir, "memory.usage_in_bytes"), filepath.Join(dir, "memory.limit_in_bytes")
 		}
-		cgroupScopeDir = dir // published under cgroupResolveOnce for cachedCgroupScopeDir
-		if fileExists(filepath.Join(dir, "memory.current")) {
-			return filepath.Join(dir, "memory.current"), filepath.Join(dir, "memory.max")
-		}
-		// cgroupv1: same (verified) directory, different filenames.
-		return filepath.Join(dir, "memory.usage_in_bytes"), filepath.Join(dir, "memory.limit_in_bytes")
 	}
+	if hostCgroupMounted {
+		// root is the HOST's cgroup tree, not ours. Whether ownContainerID was
+		// known or not, we could not verify a container-scoped directory, and
+		// there is no safe unscoped fallback here: reading root's own files
+		// would report the whole node's memory as this container's own.
+		return "", ""
+	}
+	// root is this caller's OWN namespaced cgroup (sbom-scanner sidecar, or any
+	// entrypoint that isn't the host-mounted Kubernetes DaemonSet) — safe to
+	// read directly regardless of whether the container ID resolved above.
+	//
 	// cgroupv2: join /proc/self/cgroup with the root. filepath.Join collapses
 	// the "0::/" namespace-root case to root itself.
 	if rel, ok := parseSelfCgroupV2(selfCgroupContent); ok {
@@ -291,21 +322,21 @@ var podSliceNameRe = regexp.MustCompile(`^(?:[a-z0-9]+-)*pod([0-9a-f_]{32,})\.sl
 // in the pod at that level, including third-party sidecars (clamav) that carry
 // no OTEL instrumentation of their own.
 //
-// systemd cgroup driver on cgroup v2 only. The parent-name guard below matches
-// the systemd slice naming convention; under the cgroupfs driver
-// findCgroupScopeDir does not match at all (it requires a ".scope" suffix). The
-// memory.current check is likewise v2-only: this function hardcodes the v2
-// filename pair in its return, so accepting a v1 directory would hand back
-// paths that do not exist. Both cases return "", "".
+// systemd cgroup driver only. The parent-name guard below matches the systemd
+// slice naming convention; under the cgroupfs driver findCgroupScopeDir does
+// not match at all (it requires a ".scope" suffix), so this returns "", "".
+// Both cgroupv2 (memory.current) and cgroupv1 (memory.usage_in_bytes) parent
+// slices are supported — whichever filename pair is actually present at the
+// verified parent directory is what gets read.
 //
 // Returns "", "" when the pod slice cannot be positively identified.
-func resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID string) (current, max string) {
-	return resolvePodCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, ownPodUID)
+func resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID string, hostCgroupMounted bool) (current, max string) {
+	return resolvePodCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, ownPodUID, hostCgroupMounted)
 }
 
 // resolvePodCgroupMemoryPathsUnder is the testable core of
 // resolvePodCgroupMemoryPaths, parameterised on the cgroup tree root.
-func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (current, max string) {
+func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string, hostCgroupMounted bool) (current, max string) {
 	// Sidecar / cmd/host / cmd/ecs topologies: no own container ID means no pod
 	// slice can be identified, and a pod-level number would be wrong anyway.
 	// This is by design, so it is deliberately not logged.
@@ -323,7 +354,7 @@ func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (c
 			helpers.String("rejected", rejected))
 		return "", ""
 	}
-	dir := cachedCgroupScopeDir(root, ownContainerID)
+	dir := cachedCgroupScopeDir(root, ownContainerID, hostCgroupMounted)
 	if dir == "" {
 		return reject("no .scope directory found for this container ID")
 	}
@@ -342,10 +373,14 @@ func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (c
 	if ownPodUID != "" && m[1] != strings.ReplaceAll(ownPodUID, "-", "_") {
 		return reject("parent slice belongs to a different pod UID: " + filepath.Base(parent))
 	}
-	if !fileExists(filepath.Join(parent, "memory.current")) {
-		return reject("parent slice has no memory.current (cgroup v1?): " + parent)
+	if fileExists(filepath.Join(parent, "memory.current")) {
+		return filepath.Join(parent, "memory.current"), filepath.Join(parent, "memory.max")
 	}
-	return filepath.Join(parent, "memory.current"), filepath.Join(parent, "memory.max")
+	// cgroupv1: same (verified) parent slice, different filenames.
+	if fileExists(filepath.Join(parent, "memory.usage_in_bytes")) {
+		return filepath.Join(parent, "memory.usage_in_bytes"), filepath.Join(parent, "memory.limit_in_bytes")
+	}
+	return reject("parent slice has no memory-accounting file: " + parent)
 }
 
 // cachedCgroupScopeDir returns this container's ".scope" directory in the
@@ -353,12 +388,12 @@ func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (c
 // resolver's cached result — both resolvers look for the exact same directory —
 // so the tree is walked at most once per process instead of once per resolver.
 // A test root falls back to a direct walk.
-func cachedCgroupScopeDir(root, ownContainerID string) string {
+func cachedCgroupScopeDir(root, ownContainerID string, hostCgroupMounted bool) string {
 	if root != cgroupRoot {
 		return findCgroupScopeDir(root, ownContainerID)
 	}
 	cgroupResolveOnce.Do(func() {
-		cgroupCurrentPath, cgroupMaxPath = resolveCgroupMemoryPaths(ownContainerID)
+		cgroupCurrentPath, cgroupMaxPath = resolveCgroupMemoryPaths(ownContainerID, hostCgroupMounted)
 	})
 	return cgroupScopeDir
 }
@@ -367,9 +402,9 @@ func cachedCgroupScopeDir(root, ownContainerID string) string {
 // (limit 0 = unlimited / unresolved). Paths are resolved once and cached — a
 // pod never changes cgroup — mirroring readCgroupMem's contract: a stale path
 // yields a read error and therefore 0, never a wrong number.
-func readPodCgroupMem(ownContainerID, ownPodUID string) (current, limit int64) {
+func readPodCgroupMem(ownContainerID, ownPodUID string, hostCgroupMounted bool) (current, limit int64) {
 	podCgroupResolveOnce.Do(func() {
-		podCgroupCurrentPath, podCgroupMaxPath = resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID)
+		podCgroupCurrentPath, podCgroupMaxPath = resolvePodCgroupMemoryPaths(ownContainerID, ownPodUID, hostCgroupMounted)
 	})
 	if podCgroupCurrentPath != "" {
 		if data, err := os.ReadFile(podCgroupCurrentPath); err == nil {

--- a/pkg/metricsmanager/otel/resource_metrics.go
+++ b/pkg/metricsmanager/otel/resource_metrics.go
@@ -194,37 +194,71 @@ func readCgroupMem(ownContainerID string) (current, limit int64) {
 // reports "0::/") while bind-mounting the host's /sys/fs/cgroup over its own,
 // so the namespaced path cannot be joined with the host tree — reading the
 // fixed root path yields 0. Strategies, in order:
+//
 //  1. If our own container ID is known (resolved from the k8s API at startup),
-//     find the matching *.scope directory in the host cgroup tree. This is the
-//     node-agent topology. Self-discovery from /proc is unreliable here:
-//     /proc/self/cgroup is "0::/", and /proc/self/mountinfo is polluted with
-//     every other container's ID via shared mount propagation of /host.
+//     find the matching *.scope directory in the host cgroup tree and read
+//     whichever memory-accounting filenames actually exist there (cgroupv2
+//     memory.current/memory.max, or cgroupv1 memory.usage_in_bytes/
+//     memory.limit_in_bytes). This is the node-agent topology. Self-discovery
+//     from /proc is unreliable here: /proc/self/cgroup is "0::/", and
+//     /proc/self/mountinfo is polluted with every other container's ID via
+//     shared mount propagation of /host.
+//
+//     When the container ID is known but no scope directory can be verified,
+//     this returns "", "" immediately — it deliberately does NOT fall through
+//     to strategies 2/3 below. Those two strategies read from cgroupRoot's own
+//     root, which is only a valid proxy for "this container's memory" when the
+//     caller mounts its own namespaced /sys/fs/cgroup (strategy 2/3's actual
+//     intended topology, see below). For the main agent, which bind-mounts the
+//     HOST's /sys/fs/cgroup, that same root is the whole node — falling
+//     through would silently report the host's memory as this container's own
+//     (a wrong-but-plausible number is worse than a missing series).
+//
 //  2. Join /proc/self/cgroup with the cgroup root; use it if memory.current
 //     exists there. This covers both the host cgroup namespace (rel is the full
 //     path) and a container's own namespaced /sys/fs/cgroup mount, where
 //     /proc/self/cgroup is "0::/" and the namespace root (cgroupRoot itself) is
-//     the container's own cgroup — the sbom-scanner sidecar topology. The main
-//     agent overrides /sys/fs/cgroup with the host tree, whose root has no
-//     memory.current, so this path no-ops there and strategy 1 wins.
+//     the container's own cgroup — the sbom-scanner sidecar topology.
+//
 //  3. cgroupv1 fixed mount layout.
+//
+// Strategies 2 and 3 only run when ownContainerID == "" — i.e. the caller
+// either doesn't know which container it is, or mounts its own namespaced
+// cgroup root (see above), the two cases where reading cgroupRoot's own root
+// is actually scoped to the right thing.
 func resolveCgroupMemoryPaths(ownContainerID string) (current, max string) {
+	return resolveCgroupMemoryPathsUnder(cgroupRoot, ownContainerID, readFileString("/proc/self/cgroup"))
+}
+
+// resolveCgroupMemoryPathsUnder is the testable core of resolveCgroupMemoryPaths:
+// root replaces the cgroupRoot const, and selfCgroupContent replaces a live
+// read of /proc/self/cgroup, so tests can exercise every strategy against a
+// synthetic tree instead of the real host filesystem.
+func resolveCgroupMemoryPathsUnder(root, ownContainerID, selfCgroupContent string) (current, max string) {
 	if ownContainerID != "" {
-		if dir := findCgroupScopeDir(cgroupRoot, ownContainerID); dir != "" {
-			cgroupScopeDir = dir // published under cgroupResolveOnce for cachedCgroupScopeDir
+		dir := findCgroupScopeDir(root, ownContainerID)
+		if dir == "" {
+			return "", ""
+		}
+		cgroupScopeDir = dir // published under cgroupResolveOnce for cachedCgroupScopeDir
+		if fileExists(filepath.Join(dir, "memory.current")) {
 			return filepath.Join(dir, "memory.current"), filepath.Join(dir, "memory.max")
 		}
+		// cgroupv1: same (verified) directory, different filenames.
+		return filepath.Join(dir, "memory.usage_in_bytes"), filepath.Join(dir, "memory.limit_in_bytes")
 	}
 	// cgroupv2: join /proc/self/cgroup with the root. filepath.Join collapses
-	// the "0::/" namespace-root case to cgroupRoot itself.
-	if rel, ok := parseSelfCgroupV2(readFileString("/proc/self/cgroup")); ok {
-		dir := filepath.Join(cgroupRoot, rel)
+	// the "0::/" namespace-root case to root itself.
+	if rel, ok := parseSelfCgroupV2(selfCgroupContent); ok {
+		dir := filepath.Join(root, rel)
 		if fileExists(filepath.Join(dir, "memory.current")) {
 			return filepath.Join(dir, "memory.current"), filepath.Join(dir, "memory.max")
 		}
 	}
 	// cgroupv1 fallback (fixed mount layout).
-	if fileExists("/sys/fs/cgroup/memory/memory.usage_in_bytes") {
-		return "/sys/fs/cgroup/memory/memory.usage_in_bytes", "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	v1Current := filepath.Join(root, "memory", "memory.usage_in_bytes")
+	if fileExists(v1Current) {
+		return v1Current, filepath.Join(root, "memory", "memory.limit_in_bytes")
 	}
 	return "", ""
 }
@@ -283,7 +317,7 @@ func resolvePodCgroupMemoryPathsUnder(root, ownContainerID, ownPodUID string) (c
 	// so log what was rejected — otherwise the silence is indistinguishable
 	// from the by-design case above, forever.
 	reject := func(rejected string) (string, string) {
-		logger.L().Debug("otelmetrics: pod-level cgroup memory unresolved, pod memory metrics will report 0",
+		logger.L().Warning("otelmetrics: pod-level cgroup memory unresolved, pod memory metrics will report 0",
 			helpers.String("containerID", ownContainerID),
 			helpers.String("podUID", ownPodUID),
 			helpers.String("rejected", rejected))
@@ -397,21 +431,22 @@ func scopeNameMatchesID(name, id string) bool {
 // WalkDir visits /sys/fs/cgroup/blkio, /cpu, /cpuacct, /devices, /freezer — all
 // lexically before /memory — and any of them can hold a
 // "cri-containerd-<id>.scope" directory. The walk therefore locked in a
-// directory with no memory.current, readCgroupMem silently read 0, and
-// sync.Once cached that outcome for the process lifetime.
+// directory with no memory accounting file at all, readCgroupMem silently
+// read 0, and sync.Once cached that outcome for the process lifetime.
 //
-// The memory.current existence check below is therefore load-bearing, not
-// defensive, and so is "keep walking" (return nil) instead of SkipAll on a
-// name-only match: that is what lets the walk skip the decoy controller
-// subtrees and reach the real memory-controller scope.
+// The existence check below is therefore load-bearing, not defensive, and so
+// is "keep walking" (return nil) instead of SkipAll on a name-only match:
+// that is what lets the walk skip the decoy controller subtrees and reach the
+// real memory-controller scope.
 //
-// The check deliberately accepts the cgroupv2 filename memory.current *only*,
-// never the cgroupv1 memory.usage_in_bytes: resolveCgroupMemoryPaths returns
-// the v2 filename pair unconditionally once this function succeeds, so
-// accepting a v1 directory would hand back paths that do not exist and
-// reproduce H4 verbatim. Returning "" on a v1 host is strictly better — it lets
-// resolveCgroupMemoryPaths fall through to its later strategies, including the
-// cgroupv1 fixed-mount fallback, instead of caching a dead v2 path.
+// The check accepts EITHER the cgroupv2 filename memory.current or the
+// cgroupv1 filename memory.usage_in_bytes — cgroup v1's memory controller
+// mounts as its own subtree with its own copy of the directory name, so a v1
+// host's real memory-controller scope has memory.usage_in_bytes, not
+// memory.current, and rejecting it here would make v1 hosts indistinguishable
+// from "no scope found at all". resolveCgroupMemoryPaths re-checks which file
+// is actually present at the returned directory and returns the matching
+// pair, so this never hands back a nonexistent path.
 func findCgroupScopeDir(root, id string) string {
 	if id == "" {
 		return ""
@@ -424,7 +459,9 @@ func findCgroupScopeDir(root, id string) string {
 		if !scopeNameMatchesID(d.Name(), id) {
 			return nil
 		}
-		if !fileExists(filepath.Join(path, "memory.current")) {
+		hasV2 := fileExists(filepath.Join(path, "memory.current"))
+		hasV1 := fileExists(filepath.Join(path, "memory.usage_in_bytes"))
+		if !hasV2 && !hasV1 {
 			return nil // name matches but wrong controller subtree — keep walking
 		}
 		found = path
@@ -435,6 +472,15 @@ func findCgroupScopeDir(root, id string) string {
 
 // parseCgroupMemValue parses a cgroup memory file value; the literal "max"
 // (cgroupv2 unlimited) and unparseable input both yield 0.
+// v1UnlimitedThreshold is a generous lower bound for cgroup v1's "unlimited"
+// limit sentinel (kernels report a value near math.MaxInt64, rounded down to
+// a page boundary — the exact value depends on page size/arch, e.g.
+// 9223372036854771712 on 4KB-page x86_64). No real container's memory usage
+// or limit can plausibly reach this, so treating anything at or above it as
+// "unlimited" (0) matches the cgroupv2 "max" convention without risking a
+// false positive on a real value.
+const v1UnlimitedThreshold = int64(1) << 62
+
 func parseCgroupMemValue(s string) int64 {
 	s = strings.TrimSpace(s)
 	if s == "" || s == "max" {
@@ -442,6 +488,9 @@ func parseCgroupMemValue(s string) int64 {
 	}
 	v, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
+		return 0
+	}
+	if v >= v1UnlimitedThreshold {
 		return 0
 	}
 	return v

--- a/pkg/metricsmanager/otel/resource_metrics_test.go
+++ b/pkg/metricsmanager/otel/resource_metrics_test.go
@@ -3,6 +3,7 @@ package otelmetrics
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,9 @@ func TestFindCgroupScopeDir(t *testing.T) {
 	scope := filepath.Join(root, "kubepods.slice", "kubepods-besteffort.slice",
 		"kubepods-besteffort-poduid.slice", "cri-containerd-"+id+".scope")
 	require.NoError(t, os.MkdirAll(scope, 0o755))
+	// The resolver only accepts a candidate that is a real memory-controller
+	// cgroup (see findCgroupScopeDir), so the fixture must carry memory.current.
+	require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.current"), []byte("123\n"), 0o644))
 	// A sibling scope for a different container must not match.
 	other := filepath.Join(root, "kubepods.slice", "cri-containerd-"+
 		"1111111111111111111111111111111111111111111111111111111111111111.scope")
@@ -63,6 +67,270 @@ func TestFindCgroupScopeDir(t *testing.T) {
 	assert.Equal(t, scope, got)
 
 	assert.Empty(t, findCgroupScopeDir(root, "deadbeef"), "unknown id → no match")
+}
+
+func TestScopeNameMatchesID(t *testing.T) {
+	const id = "e75962bca00d51fae3534887fbbd77b012464637c93b3be3f397dfa30a2eb8be"
+	tests := []struct {
+		name    string
+		dirName string
+		id      string
+		want    bool
+	}{
+		{"containerd exact", "cri-containerd-" + id + ".scope", id, true},
+		{"docker exact", "docker-" + id + ".scope", id, true},
+		{"crio exact", "crio-" + id + ".scope", id, true},
+		{"bare id", id + ".scope", id, true},
+		{"longer id with query as prefix", "cri-containerd-" + id + "deadbeef.scope", id, false},
+		{"longer id with query as suffix", "cri-containerd-deadbeef" + id + ".scope", id, false},
+		{"truncated query vs full id scope", "cri-containerd-" + id + ".scope", id[:32], false},
+		{"empty id", "cri-containerd-" + id + ".scope", "", false},
+		{"not a scope dir", "kubepods-burstable-pod" + id + ".slice", id, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, scopeNameMatchesID(tt.dirName, tt.id))
+		})
+	}
+}
+
+// TestFindCgroupScopeDir_NoSubstringFalsePositive asserts the exact-ID scope
+// wins over a sibling whose (longer) ID merely contains the query as a
+// substring, regardless of the order WalkDir visits them in.
+func TestFindCgroupScopeDir_NoSubstringFalsePositive(t *testing.T) {
+	const id = "abc1230000000000000000000000000000000000000000000000000000000000"
+
+	mkScope := func(t *testing.T, dir, scopeName string) string {
+		t.Helper()
+		p := filepath.Join(dir, scopeName)
+		require.NoError(t, os.MkdirAll(p, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(p, "memory.current"), []byte("1\n"), 0o644))
+		return p
+	}
+
+	tests := []struct {
+		name        string
+		exactParent string
+		decoyParent string
+	}{
+		{"exact visited first", "aaa.slice", "zzz.slice"},
+		{"decoy visited first", "zzz.slice", "aaa.slice"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			exact := mkScope(t, filepath.Join(root, tt.exactParent), "cri-containerd-"+id+".scope")
+			mkScope(t, filepath.Join(root, tt.decoyParent), "cri-containerd-"+id+"deadbeef.scope")
+			assert.Equal(t, exact, findCgroupScopeDir(root, id))
+		})
+	}
+}
+
+// TestFindCgroupScopeDir_SkipsControllerWithoutMemoryFiles pins the H4 fix: a
+// name match under a controller subtree with no memory.current must not stop
+// the walk, and a cgroup-v1-only directory must not be accepted at all.
+func TestFindCgroupScopeDir_SkipsControllerWithoutMemoryFiles(t *testing.T) {
+	const id = "abc1230000000000000000000000000000000000000000000000000000000000"
+	scopeName := "cri-containerd-" + id + ".scope"
+
+	// "blkio" sorts before "memory", so the pre-fix resolver returned it.
+	t.Run("skips decoy controller subtree", func(t *testing.T) {
+		root := t.TempDir()
+		decoy := filepath.Join(root, "blkio", "kubepods.slice", scopeName)
+		require.NoError(t, os.MkdirAll(decoy, 0o755))
+		wantDir := filepath.Join(root, "memory", "kubepods.slice", scopeName)
+		require.NoError(t, os.MkdirAll(wantDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(wantDir, "memory.current"), []byte("123\n"), 0o644))
+
+		assert.Equal(t, wantDir, findCgroupScopeDir(root, id))
+	})
+
+	t.Run("no candidate has memory.current", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "blkio", "kubepods.slice", scopeName), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "cpu", "kubepods.slice", scopeName), 0o755))
+
+		assert.Empty(t, findCgroupScopeDir(root, id), "no memory-controller match → no path, not a wrong path")
+	})
+
+	// cgroup v1: resolveCgroupMemoryPaths hardcodes the v2 filename pair at its
+	// return, so accepting a v1 directory here would yield nonexistent paths.
+	t.Run("cgroupv1 filename is not accepted", func(t *testing.T) {
+		root := t.TempDir()
+		scope := filepath.Join(root, "memory", "kubepods.slice", scopeName)
+		require.NoError(t, os.MkdirAll(scope, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.usage_in_bytes"), []byte("123\n"), 0o644))
+
+		assert.Empty(t, findCgroupScopeDir(root, id), "v1 hosts must fall through to the later strategies")
+	})
+}
+
+const (
+	testPodUID        = "11111111-2222-3333-4444-555555555555"
+	testPodUIDEscaped = "11111111_2222_3333_4444_555555555555"
+	testNodeAgentID   = "abc1230000000000000000000000000000000000000000000000000000000000"
+	testClamavID      = "def4560000000000000000000000000000000000000000000000000000000000"
+	testSBOMScannerID = "0987650000000000000000000000000000000000000000000000000000000000"
+)
+
+// mkPodCgroupTree creates <root>/<parentRel> holding parentFiles, with one
+// ".scope" child per container ID (each a valid memory-controller cgroup).
+// Returns the parent (pod slice) directory.
+func mkPodCgroupTree(t *testing.T, root, parentRel string, parentFiles map[string]string, containerIDs ...string) string {
+	t.Helper()
+	parent := filepath.Join(root, parentRel)
+	require.NoError(t, os.MkdirAll(parent, 0o755))
+	for name, content := range parentFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(parent, name), []byte(content), 0o644))
+	}
+	for i, id := range containerIDs {
+		scope := filepath.Join(parent, "cri-containerd-"+id+".scope")
+		require.NoError(t, os.MkdirAll(scope, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.current"),
+			[]byte(strconv.Itoa(100000*(i+2))+"\n"), 0o644))
+	}
+	return parent
+}
+
+// TestResolvePodCgroupMemoryPaths asserts the resolver reads the pod slice
+// itself — a value distinct from every child scope and from their sum — and
+// that the result does not depend on how many child scopes exist.
+func TestResolvePodCgroupMemoryPaths(t *testing.T) {
+	parentRel := filepath.Join("kubepods.slice", "kubepods-burstable.slice",
+		"kubepods-burstable-pod"+testPodUIDEscaped+".slice")
+	podFiles := map[string]string{"memory.current": "900000\n", "memory.max": "1500000\n"}
+
+	assertPodRead := func(t *testing.T, root, podSlice string) {
+		t.Helper()
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		require.Equal(t, filepath.Join(podSlice, "memory.current"), cur)
+		require.Equal(t, filepath.Join(podSlice, "memory.max"), max)
+		assert.Equal(t, int64(900000), parseCgroupMemValue(readFileString(cur)))
+		assert.Equal(t, int64(1500000), parseCgroupMemValue(readFileString(max)))
+	}
+
+	t.Run("three child scopes", func(t *testing.T) {
+		root := t.TempDir()
+		podSlice := mkPodCgroupTree(t, root, parentRel, podFiles,
+			testNodeAgentID, testClamavID, testSBOMScannerID)
+		assertPodRead(t, root, podSlice)
+	})
+
+	t.Run("one child scope", func(t *testing.T) {
+		root := t.TempDir()
+		podSlice := mkPodCgroupTree(t, root, parentRel, podFiles, testNodeAgentID)
+		assertPodRead(t, root, podSlice)
+	})
+}
+
+func TestResolvePodCgroupMemoryPaths_Guards(t *testing.T) {
+	podFiles := map[string]string{"memory.current": "900000\n", "memory.max": "1500000\n"}
+
+	t.Run("empty container id", func(t *testing.T) {
+		root := t.TempDir()
+		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
+			podFiles, testNodeAgentID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, "", testPodUID)
+		assert.Empty(t, cur)
+		assert.Empty(t, max)
+	})
+
+	t.Run("scope directly under root", func(t *testing.T) {
+		root := t.TempDir()
+		mkPodCgroupTree(t, root, ".", podFiles, testNodeAgentID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		assert.Empty(t, cur, "must never escape above the cgroup root")
+		assert.Empty(t, max)
+	})
+
+	t.Run("pod slice missing memory.current", func(t *testing.T) {
+		root := t.TempDir()
+		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
+			nil, testNodeAgentID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		assert.Empty(t, cur)
+		assert.Empty(t, max)
+	})
+
+	t.Run("cgroupv1 pod slice", func(t *testing.T) {
+		root := t.TempDir()
+		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
+			map[string]string{"memory.usage_in_bytes": "900000\n", "memory.limit_in_bytes": "1500000\n"}, testNodeAgentID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		assert.Empty(t, cur, "v1 pod slice must fail to zero, not to nonexistent v2 paths")
+		assert.Empty(t, max)
+	})
+
+	// Both halves of the name guard's truth table. The reject set is the
+	// dangerous one: on a real node kubepods.slice and the QoS slices do have a
+	// memory.current, so the file-existence check alone would not stop them.
+	t.Run("parent name shapes", func(t *testing.T) {
+		tests := []struct {
+			baseName string
+			accept   bool
+		}{
+			{"pod" + testPodUIDEscaped + ".slice", true},
+			{"kubepods-pod" + testPodUIDEscaped + ".slice", true},
+			{"kubepods-burstable-pod" + testPodUIDEscaped + ".slice", true},
+			{"kubepods-besteffort-pod" + testPodUIDEscaped + ".slice", true},
+			// Custom kubelet --cgroup-root: an extra segment before "kubepods-".
+			{"kubelet-kubepods-burstable-pod" + testPodUIDEscaped + ".slice", true},
+			{"kubepods.slice", false},
+			{"kubepods-burstable.slice", false},
+			{"kubepods-besteffort.slice", false},
+			{"system.slice", false},
+		}
+		for _, tt := range tests {
+			t.Run(tt.baseName, func(t *testing.T) {
+				root := t.TempDir()
+				parent := mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", tt.baseName),
+					podFiles, testNodeAgentID)
+				cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+				if tt.accept {
+					assert.Equal(t, filepath.Join(parent, "memory.current"), cur)
+					assert.Equal(t, filepath.Join(parent, "memory.max"), max)
+					return
+				}
+				assert.Empty(t, cur)
+				assert.Empty(t, max)
+			})
+		}
+	})
+}
+
+func TestResolvePodCgroupMemoryPaths_PodUIDVerification(t *testing.T) {
+	const otherUIDEscaped = "99999999_8888_7777_6666_555555555555"
+	podFiles := map[string]string{"memory.current": "900000\n", "memory.max": "1500000\n"}
+
+	tests := []struct {
+		name      string
+		sliceName string
+		ownPodUID string
+		accept    bool
+	}{
+		{"matching uid", "kubepods-burstable-pod" + testPodUIDEscaped + ".slice", testPodUID, true},
+		{"matching uid, bare kubepods prefix", "kubepods-pod" + testPodUIDEscaped + ".slice", testPodUID, true},
+		{"matching uid, custom cgroup-root prefix", "kubelet-kubepods-burstable-pod" + testPodUIDEscaped + ".slice", testPodUID, true},
+		{"different well-formed uid", "kubepods-burstable-pod" + otherUIDEscaped + ".slice", testPodUID, false},
+		{"different well-formed uid, custom cgroup-root prefix", "kubelet-kubepods-burstable-pod" + otherUIDEscaped + ".slice", testPodUID, false},
+		{"different well-formed uid, bare kubepods prefix", "kubepods-pod" + otherUIDEscaped + ".slice", testPodUID, false},
+		{"unknown uid falls back to the name guard", "kubepods-burstable-pod" + testPodUIDEscaped + ".slice", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			parent := mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", tt.sliceName),
+				podFiles, testNodeAgentID)
+			cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, tt.ownPodUID)
+			if tt.accept {
+				assert.Equal(t, filepath.Join(parent, "memory.current"), cur)
+				assert.Equal(t, filepath.Join(parent, "memory.max"), max)
+				return
+			}
+			assert.Empty(t, cur, "a well-formed but wrong pod UID must be rejected")
+			assert.Empty(t, max)
+		})
+	}
 }
 
 // TestResolveCgroupMemoryPaths_FastPath verifies the /proc/self/cgroup join

--- a/pkg/metricsmanager/otel/resource_metrics_test.go
+++ b/pkg/metricsmanager/otel/resource_metrics_test.go
@@ -153,16 +153,103 @@ func TestFindCgroupScopeDir_SkipsControllerWithoutMemoryFiles(t *testing.T) {
 		assert.Empty(t, findCgroupScopeDir(root, id), "no memory-controller match → no path, not a wrong path")
 	})
 
-	// cgroup v1: resolveCgroupMemoryPaths hardcodes the v2 filename pair at its
-	// return, so accepting a v1 directory here would yield nonexistent paths.
-	t.Run("cgroupv1 filename is not accepted", func(t *testing.T) {
+	// cgroup v1: the memory-controller scope has memory.usage_in_bytes, not
+	// memory.current. findCgroupScopeDir must accept it — resolveCgroupMemoryPaths
+	// is what decides which filename pair to read from the verified directory.
+	t.Run("cgroupv1 filename is accepted", func(t *testing.T) {
 		root := t.TempDir()
 		scope := filepath.Join(root, "memory", "kubepods.slice", scopeName)
 		require.NoError(t, os.MkdirAll(scope, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.usage_in_bytes"), []byte("123\n"), 0o644))
 
-		assert.Empty(t, findCgroupScopeDir(root, id), "v1 hosts must fall through to the later strategies")
+		assert.Equal(t, scope, findCgroupScopeDir(root, id))
 	})
+}
+
+// TestResolveCgroupMemoryPathsUnder pins the fix for the cgroup-v1 node-wide
+// misattribution: when ownContainerID is known, resolution must never fall
+// through to the unscoped strategies (2/3) meant for the "caller mounts its
+// own namespaced cgroup root" topology — those return the wrong number (the
+// whole host's memory, not this container's) for a caller that bind-mounts
+// the host's cgroup tree. It also pins proper cgroup-v1 support: a verified
+// v1-only scope directory must be read via its own (v1) filenames, not
+// silently dropped.
+func TestResolveCgroupMemoryPathsUnder(t *testing.T) {
+	const id = "abc1230000000000000000000000000000000000000000000000000000000000"
+	scopeName := "cri-containerd-" + id + ".scope"
+
+	t.Run("known container ID, v2 scope resolved", func(t *testing.T) {
+		root := t.TempDir()
+		scope := filepath.Join(root, "memory", "kubepods.slice", scopeName)
+		require.NoError(t, os.MkdirAll(scope, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.current"), []byte("123\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.max"), []byte("456\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		assert.Equal(t, filepath.Join(scope, "memory.current"), cur)
+		assert.Equal(t, filepath.Join(scope, "memory.max"), max)
+	})
+
+	t.Run("known container ID, v1-only scope resolved via its own filenames", func(t *testing.T) {
+		root := t.TempDir()
+		scope := filepath.Join(root, "memory", "kubepods.slice", scopeName)
+		require.NoError(t, os.MkdirAll(scope, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.usage_in_bytes"), []byte("123\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.limit_in_bytes"), []byte("456\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		assert.Equal(t, filepath.Join(scope, "memory.usage_in_bytes"), cur)
+		assert.Equal(t, filepath.Join(scope, "memory.limit_in_bytes"), max)
+	})
+
+	t.Run("known container ID, no scope found anywhere never falls through to the unscoped fixed-mount path", func(t *testing.T) {
+		root := t.TempDir()
+		// A v1 fixed-mount file DOES exist at the root — simulating the host's
+		// own (node-wide) cgroup accounting file, reachable via strategy 3 if
+		// resolution incorrectly fell through to it. No scope directory for
+		// `id` exists anywhere, so this container's own cgroup genuinely
+		// cannot be found.
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "memory"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.usage_in_bytes"), []byte("999999999\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.limit_in_bytes"), []byte("999999999\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		assert.Empty(t, cur, "must not fall through to the node-wide fixed-mount file for a known container ID")
+		assert.Empty(t, max)
+	})
+
+	t.Run("empty container ID falls through to the v2 self-cgroup strategy", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(root, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.current"), []byte("111\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.max"), []byte("222\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, "", "0::/\n")
+		assert.Equal(t, filepath.Join(root, "memory.current"), cur)
+		assert.Equal(t, filepath.Join(root, "memory.max"), max)
+	})
+
+	t.Run("empty container ID falls through to the v1 fixed-mount strategy", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "memory"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.usage_in_bytes"), []byte("333\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.limit_in_bytes"), []byte("444\n"), 0o644))
+
+		// No "0::" line at all (pure cgroup-v1 host) — strategy 2 no-ops.
+		cur, max := resolveCgroupMemoryPathsUnder(root, "", "4:memory:/kubepods.slice\n")
+		assert.Equal(t, filepath.Join(root, "memory", "memory.usage_in_bytes"), cur)
+		assert.Equal(t, filepath.Join(root, "memory", "memory.limit_in_bytes"), max)
+	})
+}
+
+// TestParseCgroupMemValue_V1UnlimitedSentinel pins the cgroup-v1 "unlimited"
+// normalization: a value at or above the sentinel threshold reports as 0
+// (unlimited), matching the cgroupv2 "max" convention, instead of a huge and
+// misleading-looking number.
+func TestParseCgroupMemValue_V1UnlimitedSentinel(t *testing.T) {
+	assert.Equal(t, int64(0), parseCgroupMemValue("9223372036854771712"))
+	assert.Equal(t, int64(0), parseCgroupMemValue("max"))
+	assert.Equal(t, int64(536870912), parseCgroupMemValue("536870912")) // 512MiB, a real limit, unaffected
 }
 
 const (

--- a/pkg/metricsmanager/otel/resource_metrics_test.go
+++ b/pkg/metricsmanager/otel/resource_metrics_test.go
@@ -173,7 +173,12 @@ func TestFindCgroupScopeDir_SkipsControllerWithoutMemoryFiles(t *testing.T) {
 // whole host's memory, not this container's) for a caller that bind-mounts
 // the host's cgroup tree. It also pins proper cgroup-v1 support: a verified
 // v1-only scope directory must be read via its own (v1) filenames, not
-// silently dropped.
+// silently dropped. hostCgroupMounted, not ownContainerID, decides whether
+// the unscoped strategies (2/3) are ever reachable — see the four
+// "hostCgroupMounted" subtests, which pin the residual regression found in
+// review: an empty ownContainerID on the HOST-MOUNTED topology (a startup
+// race, not the sidecar's own-namespace topology) must not fall through
+// either.
 func TestResolveCgroupMemoryPathsUnder(t *testing.T) {
 	const id = "abc1230000000000000000000000000000000000000000000000000000000000"
 	scopeName := "cri-containerd-" + id + ".scope"
@@ -185,7 +190,7 @@ func TestResolveCgroupMemoryPathsUnder(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.current"), []byte("123\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.max"), []byte("456\n"), 0o644))
 
-		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, true, "")
 		assert.Equal(t, filepath.Join(scope, "memory.current"), cur)
 		assert.Equal(t, filepath.Join(scope, "memory.max"), max)
 	})
@@ -197,12 +202,12 @@ func TestResolveCgroupMemoryPathsUnder(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.usage_in_bytes"), []byte("123\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(scope, "memory.limit_in_bytes"), []byte("456\n"), 0o644))
 
-		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, true, "")
 		assert.Equal(t, filepath.Join(scope, "memory.usage_in_bytes"), cur)
 		assert.Equal(t, filepath.Join(scope, "memory.limit_in_bytes"), max)
 	})
 
-	t.Run("known container ID, no scope found anywhere never falls through to the unscoped fixed-mount path", func(t *testing.T) {
+	t.Run("hostCgroupMounted=true, known container ID, no scope found anywhere never falls through", func(t *testing.T) {
 		root := t.TempDir()
 		// A v1 fixed-mount file DOES exist at the root — simulating the host's
 		// own (node-wide) cgroup accounting file, reachable via strategy 3 if
@@ -213,32 +218,63 @@ func TestResolveCgroupMemoryPathsUnder(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.usage_in_bytes"), []byte("999999999\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.limit_in_bytes"), []byte("999999999\n"), 0o644))
 
-		cur, max := resolveCgroupMemoryPathsUnder(root, id, "")
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, true, "")
 		assert.Empty(t, cur, "must not fall through to the node-wide fixed-mount file for a known container ID")
 		assert.Empty(t, max)
 	})
 
-	t.Run("empty container ID falls through to the v2 self-cgroup strategy", func(t *testing.T) {
+	t.Run("hostCgroupMounted=true, empty container ID never falls through either (the residual regression)", func(t *testing.T) {
+		root := t.TempDir()
+		// Same node-wide file as above, plus a "0::/" self-cgroup line — both
+		// unscoped strategies are reachable in principle. This reproduces the
+		// exact scenario from review: the main agent (host-mounted) hits an
+		// early-startup race in resolveOwnContainerID (ownContainerID == ""),
+		// while still bind-mounting the host tree. hostCgroupMounted=true must
+		// close this off regardless of ownContainerID.
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "memory"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.usage_in_bytes"), []byte("8589934592\n"), 0o644)) // 8 GiB "whole node"
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.limit_in_bytes"), []byte("8589934592\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, "", true, "0::/\n")
+		assert.Empty(t, cur, "an empty container ID on the host-mounted topology must not read the node-wide file either")
+		assert.Empty(t, max)
+	})
+
+	t.Run("hostCgroupMounted=false, empty container ID falls through to the v2 self-cgroup strategy", func(t *testing.T) {
 		root := t.TempDir()
 		require.NoError(t, os.MkdirAll(root, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.current"), []byte("111\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.max"), []byte("222\n"), 0o644))
 
-		cur, max := resolveCgroupMemoryPathsUnder(root, "", "0::/\n")
+		cur, max := resolveCgroupMemoryPathsUnder(root, "", false, "0::/\n")
 		assert.Equal(t, filepath.Join(root, "memory.current"), cur)
 		assert.Equal(t, filepath.Join(root, "memory.max"), max)
 	})
 
-	t.Run("empty container ID falls through to the v1 fixed-mount strategy", func(t *testing.T) {
+	t.Run("hostCgroupMounted=false, empty container ID falls through to the v1 fixed-mount strategy", func(t *testing.T) {
 		root := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(root, "memory"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.usage_in_bytes"), []byte("333\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(root, "memory", "memory.limit_in_bytes"), []byte("444\n"), 0o644))
 
 		// No "0::" line at all (pure cgroup-v1 host) — strategy 2 no-ops.
-		cur, max := resolveCgroupMemoryPathsUnder(root, "", "4:memory:/kubepods.slice\n")
+		cur, max := resolveCgroupMemoryPathsUnder(root, "", false, "4:memory:/kubepods.slice\n")
 		assert.Equal(t, filepath.Join(root, "memory", "memory.usage_in_bytes"), cur)
 		assert.Equal(t, filepath.Join(root, "memory", "memory.limit_in_bytes"), max)
+	})
+
+	t.Run("hostCgroupMounted=false, known container ID that fails to scope-resolve still falls through", func(t *testing.T) {
+		// Not a regression case — pins that non-host-mounted callers keep their
+		// existing fallback behavior even when a container ID happens to be
+		// known but unresolvable (e.g. a partial/experimental future caller).
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(root, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.current"), []byte("555\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "memory.max"), []byte("666\n"), 0o644))
+
+		cur, max := resolveCgroupMemoryPathsUnder(root, id, false, "0::/\n")
+		assert.Equal(t, filepath.Join(root, "memory.current"), cur)
+		assert.Equal(t, filepath.Join(root, "memory.max"), max)
 	})
 }
 
@@ -289,7 +325,7 @@ func TestResolvePodCgroupMemoryPaths(t *testing.T) {
 
 	assertPodRead := func(t *testing.T, root, podSlice string) {
 		t.Helper()
-		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID, true)
 		require.Equal(t, filepath.Join(podSlice, "memory.current"), cur)
 		require.Equal(t, filepath.Join(podSlice, "memory.max"), max)
 		assert.Equal(t, int64(900000), parseCgroupMemValue(readFileString(cur)))
@@ -317,7 +353,7 @@ func TestResolvePodCgroupMemoryPaths_Guards(t *testing.T) {
 		root := t.TempDir()
 		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
 			podFiles, testNodeAgentID)
-		cur, max := resolvePodCgroupMemoryPathsUnder(root, "", testPodUID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, "", testPodUID, true)
 		assert.Empty(t, cur)
 		assert.Empty(t, max)
 	})
@@ -325,7 +361,7 @@ func TestResolvePodCgroupMemoryPaths_Guards(t *testing.T) {
 	t.Run("scope directly under root", func(t *testing.T) {
 		root := t.TempDir()
 		mkPodCgroupTree(t, root, ".", podFiles, testNodeAgentID)
-		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID, true)
 		assert.Empty(t, cur, "must never escape above the cgroup root")
 		assert.Empty(t, max)
 	})
@@ -334,18 +370,18 @@ func TestResolvePodCgroupMemoryPaths_Guards(t *testing.T) {
 		root := t.TempDir()
 		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
 			nil, testNodeAgentID)
-		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID, true)
 		assert.Empty(t, cur)
 		assert.Empty(t, max)
 	})
 
-	t.Run("cgroupv1 pod slice", func(t *testing.T) {
+	t.Run("cgroupv1 pod slice is resolved via its own filenames", func(t *testing.T) {
 		root := t.TempDir()
-		mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
+		podSlice := mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", "kubepods-burstable-pod"+testPodUIDEscaped+".slice"),
 			map[string]string{"memory.usage_in_bytes": "900000\n", "memory.limit_in_bytes": "1500000\n"}, testNodeAgentID)
-		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
-		assert.Empty(t, cur, "v1 pod slice must fail to zero, not to nonexistent v2 paths")
-		assert.Empty(t, max)
+		cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID, true)
+		assert.Equal(t, filepath.Join(podSlice, "memory.usage_in_bytes"), cur)
+		assert.Equal(t, filepath.Join(podSlice, "memory.limit_in_bytes"), max)
 	})
 
 	// Both halves of the name guard's truth table. The reject set is the
@@ -372,7 +408,7 @@ func TestResolvePodCgroupMemoryPaths_Guards(t *testing.T) {
 				root := t.TempDir()
 				parent := mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", tt.baseName),
 					podFiles, testNodeAgentID)
-				cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID)
+				cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, testPodUID, true)
 				if tt.accept {
 					assert.Equal(t, filepath.Join(parent, "memory.current"), cur)
 					assert.Equal(t, filepath.Join(parent, "memory.max"), max)
@@ -408,7 +444,7 @@ func TestResolvePodCgroupMemoryPaths_PodUIDVerification(t *testing.T) {
 			root := t.TempDir()
 			parent := mkPodCgroupTree(t, root, filepath.Join("kubepods.slice", tt.sliceName),
 				podFiles, testNodeAgentID)
-			cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, tt.ownPodUID)
+			cur, max := resolvePodCgroupMemoryPathsUnder(root, testNodeAgentID, tt.ownPodUID, true)
 			if tt.accept {
 				assert.Equal(t, filepath.Join(parent, "memory.current"), cur)
 				assert.Equal(t, filepath.Join(parent, "memory.max"), max)

--- a/pkg/sbomscanner/v1/run.go
+++ b/pkg/sbomscanner/v1/run.go
@@ -54,8 +54,9 @@ func RunServer(ctx context.Context, accountID, accessKey string) {
 		// Per-process memory gauges (rss + cgroup usage/limit), same as the main
 		// agent. The sidecar mounts its own namespaced /sys/fs/cgroup (no host
 		// override), so the cgroup resolver reads the namespace root directly —
-		// no container ID needed.
-		otelmetrics.RegisterProcessMemoryMetrics(otelsetup.Meter(), "")
+		// no container ID needed. hostCgroupMounted=false: this sidecar does
+		// NOT bind-mount the host's cgroup tree, unlike the main agent.
+		otelmetrics.RegisterProcessMemoryMetrics(otelsetup.Meter(), "", false)
 	}
 
 	socketPath := os.Getenv("SOCKET_PATH")


### PR DESCRIPTION
## Overview

Adds `node_agent.pod.memory.cgroup_bytes` / `cgroup_limit_bytes`, read from the parent `kubepods-*-pod<UID>.slice` cgroup one level above the container `.scope` dir `findCgroupScopeDir` already resolves. This is what makes third-party sidecars with no OTEL instrumentation of their own (e.g. `clamav`, gated behind `capabilities.malwareDetection`) visible in pod memory accounting — the kernel already aggregates every container in the pod at that level. Additive: the existing `node_agent.process.memory.*` container-scoped metrics are unchanged in name, meaning, and scope.

Also fixes two defects in `findCgroupScopeDir`, found while investigating a live `cgroup_bytes < rss_bytes` anomaly:
- Container-ID matching was an unanchored substring (`strings.Contains`) — now a delimited-segment match, so a longer container ID that happens to contain ours as a substring can no longer be selected.
- The first name-matching `.scope` directory was accepted without verifying it actually contained `memory.current`. On cgroup-v1/hybrid hosts, the directory walk can reach an unrelated controller subtree (`blkio`, `cpu`, ...) before `memory`, silently locking onto a scope with no `memory.current` and caching a `0` read for the process lifetime (`sync.Once`). The resolver now keeps walking until it finds a real match.

Scoped to the **systemd** cgroup driver — `findCgroupScopeDir` requires a `.scope`-suffixed name, which the cgroupfs driver never produces (`kubepods/burstable/pod<uid>/<id>`, no suffix). Hosts on cgroupfs already read `0` today; this PR doesn't change that. Tracked as a follow-up.

## Additional Information

**Per-pod production verification** (SigNoz, prod-eu, 690 live pods, avg over the prior 15 min at investigation time):
- **241/690 (35%)** report `cgroup_bytes == 0` while `rss_bytes > 0` — the signature of the second defect above. ~92% of these are on standard cloud-managed instance types (AWS/Azure node pools), which default to the systemd cgroup driver, so this fix should resolve the large majority of them.
- **13/690 (2%)** show a genuine per-pod inversion (`0 < cgroup_bytes < rss_bytes`), a smaller, more modest gap (45–180MB) consistent with legitimate RSS-vs-cgroup accounting differences (e.g. page cache) rather than a resolution bug — noted honestly as not fully attributed to either defect.

No live cluster currently runs with `malwareDetection` enabled, so multi-container pod-level aggregation is verified via synthetic `t.TempDir()` cgroup fixtures rather than a real sidecar; single-container behavior (today's actual topology) is unchanged and covered by the existing + new tests.

This PR went through a 3-round Planner → Architect → Critic consensus review before implementation (two real defects were caught and fixed during that process: a pod-slice name-matching regex that rejected the guaranteed-QoS shape it claimed to accept, and a cgroup v1/v2 filename mismatch in the `memory.current`-existence check) — happy to share that trail if useful for review.

## How to Test

```
go test ./pkg/metricsmanager/otel/... -v -count=1
go vet ./...
```

Manual: compare the new `node_agent_pod_memory_cgroup_bytes` (Prometheus bridge name) against `kubectl top pod` for a real pod.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code (code-reviewer + security-reviewer agent passes, no blockers)
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

AI-skills: armosec-shared-rules:environment-links,oh-my-claudecode:plan,oh-my-claudecode:autopilot | cmds: /oh-my-claudecode:deep-dive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pod-level memory usage and memory limit metrics, including sidecar workloads.
  * Improved discovery of pod and container memory scopes across cgroup versions and deployment configurations.

* **Bug Fixes**
  * Prevented incorrect scope matches caused by partial identifiers or unavailable memory data.
  * Added validation to ensure pod metrics are associated with the correct pod.
  * Improved handling of unavailable memory limits and unresolved scope lookups.

* **Documentation**
  * Added migration guidance for pod memory metrics and scope-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->