### PR TITLE
fix(networkstream): key stream entities by container ID outside Kubernetes

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -154,8 +154,7 @@ correlation is an upgrade, not a dependency.
 | `nodeProfileServiceEnabled` | bool | `false` | Enable node profiling |
 | `fimEnabled` | bool | `false` | Enable File Integrity Monitoring |
 | `httpDetectionEnabled` | bool | `false` | Enable HTTP traffic parsing |
-| `hostMalwareSensorEnabled` | bool | `false` | Enable host-level malware sensor |
-| `hostNetworkSensorEnabled` | bool | `false` | Enable host-level network sensor |
+| `hostMonitoringEnabled` | bool | `false` | Monitor the host's own namespace as a synthetic container |
 | `prometheusExporterEnabled` | bool | `false` | Enable Prometheus metrics |
 | `fullPathTracingEnabled` | bool | `true` | Include full executable paths |
 | `enableEmbeddedSBOMs` | bool | `false` | Use embedded SBOMs from images |

--- a/docs/features/network-stream-entity-keying.md
+++ b/docs/features/network-stream-entity-keying.md
@@ -1,0 +1,102 @@
+# Network-stream entity keying
+
+The network stream groups a flush interval's connections into **entities**: one per
+container, plus one for the node itself. Downstream, the entity is the unit a finding
+is attributed to, so two workloads sharing an entity are indistinguishable to every
+consumer of the stream.
+
+This document covers how an event picks its entity, in `pkg/networkstream/v1`. The
+per-connection process identity carried inside an entity is a separate concern — see
+[network-stream-process-attribution.md](network-stream-process-attribution.md).
+
+## The rule
+
+```go
+entityID := event.GetContainerID()
+if entityID == "" || entityID == armotypes.HostContainerID {
+    entityID = nodeName          // the node's own traffic
+}
+```
+
+Only traffic that is not a container's collapses onto the node entity: an event with
+no container ID, or with the `"host"` sentinel that `procfs.go` assigns to processes
+outside every tracked mount namespace. Everything else keys by container ID.
+
+## What this replaced
+
+The node fallback used to fire on `ns.k8sObjectCache == nil` as well:
+
+```go
+if entityId == "" || ns.k8sObjectCache == nil {
+    entityId = ns.nodeName
+}
+```
+
+The object cache is a Kubernetes API cache. In this repo's binary it is always
+present, but embedders that run the sensor outside a cluster — on a host, or on an
+AWS ECS instance — construct the stream with a nil cache. There *every* event,
+including every container's, was folded onto the single node entity: an ECS task's
+containers all reported as the instance, and per-workload attribution downstream was
+impossible.
+
+The keying on Kubernetes is unchanged. There the cache is always non-nil, so the
+removed disjunct was never the reason an event moved to the node.
+
+## Outside Kubernetes, entities are created on first sight
+
+An entity is normally announced by `ContainerCallback`. An event for an entity that
+does not exist is logged and dropped.
+
+That drop is why the keying fix alone is not enough outside Kubernetes: the embedders
+above do not subscribe this package's `ContainerCallback` at all, so no container
+entity is ever announced and every container event would key to an ID that is not in
+the map. When `kubernetesMode` is off, `entityForEventLocked` therefore creates a
+container entity the first time it sees one, carrying the container ID and nothing
+else — the pod and workload fields stay empty until something announces the container.
+
+**In Kubernetes it keeps dropping**, which is what makes this change inert there. A
+missing entity in a cluster does not mean "never announced"; it means the container
+was removed or is ignored. And a removal is not quiet: the container collection
+publishes `EventTypeRemoveContainer` *before* the container leaves the collection and
+then keeps it in a 2-second cache for enrichers, while node-agent dispatches this
+callback onto a worker pool — so events for a container that is already gone keep
+arriving for a while after it dies. Creating an entity for them would put a container
+with no pod or workload identity into the payload, for a pod that no longer exists,
+on every pod termination.
+
+Where `ContainerCallback` does run, the two can arrive in either order and neither
+destroys the other's work. If the announcement came first, the entity already exists
+and the event path leaves its identity fields alone. If it came second — which is
+routine, because the container watcher submits the callback to a worker pool while
+events flow straight through, so a container's first egress lands before it is
+announced — it fills the identity in over the event maps already there instead of
+replacing them.
+
+The node entity is excluded from that merge. It is not announced; it is created at
+construction and remade by every flush, so there is no unannounced window to rescue,
+and excluding it means announcing the virtual host container behaves exactly as it
+did before.
+
+## Unannounced entities are pruned when they go quiet
+
+An entity born from an event has no container lifecycle behind it — the callback that
+would deliver its removal is the one that was missing in the first place. Left alone
+it would sit in the map forever and ride along in every later payload, which on a host
+with container churn grows without bound.
+
+`snapshotAndClear` deletes such an entity after an interval with no traffic on it. The
+set of entities this applies to is tracked explicitly (`unannouncedEntities`) rather
+than inferred from an empty metadata field, because pruning an *announced* entity would
+throw away the workload identity `enrichWorkloadDetails` resolved and never recover it.
+`ContainerCallback` clears the mark, so once a container is announced — in either order
+relative to its first event — silence stops meaning "gone".
+
+A merely idle container costs one entity re-creation on its next event.
+
+## Kubernetes-mode enrichment is guarded
+
+`buildNetworkEvent` enriches pod- and service-kind destination endpoints from
+`common.K8sInventoryCache`, which is only built when `cfg.KubernetesMode` is set. The
+lookups are now behind a nil check, so a pod- or service-kind endpoint arriving
+anywhere else leaves the connection unenriched instead of dereferencing a nil
+interface.

--- a/pkg/networkstream/v1/network_stream.go
+++ b/pkg/networkstream/v1/network_stream.go
@@ -48,6 +48,12 @@ type NetworkStream struct {
 	eventsNotificationChannel chan armotypes.NetworkStream
 	dnsSupport                bool
 	processTreeManager        processtree.ProcessTreeManager
+
+	// unannouncedEntities holds the entity IDs the event path created because
+	// ContainerCallback never announced the container. Nothing will ever remove
+	// them — the callback that would deliver the removal is the one that is
+	// missing — so snapshotAndClear prunes them once they go quiet.
+	unannouncedEntities map[string]struct{}
 }
 
 func NewNetworkStream(ctx context.Context, cfg config.Config, k8sObjectCache objectcache.K8sObjectCache, dnsResolver dnsmanager.DNSResolver, nodeName string, eventsNotificationChannel chan armotypes.NetworkStream, dnsSupport bool, processTreeManager processtree.ProcessTreeManager) (*NetworkStream, error) {
@@ -85,16 +91,23 @@ func NewNetworkStream(ctx context.Context, cfg config.Config, k8sObjectCache obj
 		eventsNotificationChannel: eventsNotificationChannel,
 		dnsSupport:                dnsSupport,
 		processTreeManager:        processTreeManager,
+		unannouncedEntities:       make(map[string]struct{}),
 	}
 
 	// Create the host entity
-	ns.networkEventsStorage.Entities[nodeName] = armotypes.NetworkStreamEntity{
+	ns.networkEventsStorage.Entities[nodeName] = newHostEntity()
+
+	return &ns, nil
+}
+
+// newHostEntity builds the entity that carries the node's own traffic — everything
+// not attributable to a container.
+func newHostEntity() armotypes.NetworkStreamEntity {
+	return armotypes.NetworkStreamEntity{
 		Kind:     armotypes.NetworkStreamEntityKindHost,
 		Inbound:  make(map[string]armotypes.NetworkStreamEvent),
 		Outbound: make(map[string]armotypes.NetworkStreamEvent),
 	}
-
-	return &ns, nil
 }
 
 func (ns *NetworkStream) ContainerCallback(notif containercollection.PubSubEvent) {
@@ -106,7 +119,7 @@ func (ns *NetworkStream) ContainerCallback(notif containercollection.PubSubEvent
 		if utils.IsHostContainer(notif.Container) {
 			containerID = ns.nodeName
 		}
-		ns.networkEventsStorage.Entities[containerID] = armotypes.NetworkStreamEntity{
+		entity := armotypes.NetworkStreamEntity{
 			Kind: armotypes.NetworkStreamEntityKindContainer,
 			NetworkStreamEntityContainer: armotypes.NetworkStreamEntityContainer{
 				ContainerName: notif.Container.Runtime.ContainerName,
@@ -117,6 +130,20 @@ func (ns *NetworkStream) ContainerCallback(notif containercollection.PubSubEvent
 			Inbound:  make(map[string]armotypes.NetworkStreamEvent),
 			Outbound: make(map[string]armotypes.NetworkStreamEvent),
 		}
+		// The watcher submits this callback to a worker pool, so the event path may
+		// already have recorded traffic against this container — a new container's
+		// first egress lands in exactly that window. Announcing it supplies the
+		// identity; it must not throw the traffic away.
+		// Not the node entity: that one exists from construction and is remade by
+		// every flush, so it has no unannounced window to rescue, and leaving it
+		// alone keeps this callback's node-entity behaviour exactly as it was.
+		if existing, ok := ns.networkEventsStorage.Entities[containerID]; ok && containerID != ns.nodeName {
+			entity.Inbound = existing.Inbound
+			entity.Outbound = existing.Outbound
+		}
+		ns.networkEventsStorage.Entities[containerID] = entity
+		// The container is announced now, so silence no longer means it is gone.
+		delete(ns.unannouncedEntities, containerID)
 		ns.eventsStorageMutex.Unlock()
 		if ns.k8sObjectCache != nil && !utils.IsHostContainer(notif.Container) {
 			go ns.enrichWorkloadDetails(notif.Container.Runtime.ContainerID)
@@ -128,6 +155,7 @@ func (ns *NetworkStream) ContainerCallback(notif containercollection.PubSubEvent
 			containerID = ns.nodeName
 		}
 		delete(ns.networkEventsStorage.Entities, containerID)
+		delete(ns.unannouncedEntities, containerID)
 		ns.eventsStorageMutex.Unlock()
 	}
 }
@@ -180,25 +208,7 @@ func (ns *NetworkStream) Start() {
 				logger.L().Info("NetworkStream - stopping")
 				return
 			case <-ticker.C:
-				// Snapshot and clear only; both sends and the tree copies stay outside
-				// the lock. This path has a history of mutex stalls.
-				ns.eventsStorageMutex.Lock()
-				snapshot := snapshotNetworkStream(&ns.networkEventsStorage)
-
-				// Clear the storage
-				for entityId := range ns.networkEventsStorage.Entities {
-					entity := ns.networkEventsStorage.Entities[entityId]
-					entity.Inbound = make(map[string]armotypes.NetworkStreamEvent)
-					entity.Outbound = make(map[string]armotypes.NetworkStreamEvent)
-					ns.networkEventsStorage.Entities[entityId] = entity
-				}
-				// Re-create the host entity
-				ns.networkEventsStorage.Entities[ns.nodeName] = armotypes.NetworkStreamEntity{
-					Kind:     armotypes.NetworkStreamEntityKindHost,
-					Inbound:  make(map[string]armotypes.NetworkStreamEvent),
-					Outbound: make(map[string]armotypes.NetworkStreamEvent),
-				}
-				ns.eventsStorageMutex.Unlock()
+				snapshot := ns.snapshotAndClear()
 
 				// Before the send: once the snapshot is on the channel, its maps belong
 				// to the consumer.
@@ -224,6 +234,41 @@ func (ns *NetworkStream) Start() {
 			}
 		}
 	}()
+}
+
+// snapshotAndClear takes the interval's events and resets the live storage under a
+// single lock. Snapshot and clear only; both sends and the tree copies stay outside
+// the lock. This path has a history of mutex stalls.
+func (ns *NetworkStream) snapshotAndClear() *armotypes.NetworkStream {
+	ns.eventsStorageMutex.Lock()
+	defer ns.eventsStorageMutex.Unlock()
+
+	// Pruned before the snapshot, so a dead container never reaches a payload at all.
+	// An entity the event path created has no container lifecycle behind it, so an
+	// interval without traffic is the only "it is gone" signal there is. Keeping it
+	// would put a dead container in every later payload — unbounded growth wherever
+	// containers churn. A container that is merely idle costs one re-creation on its
+	// next event.
+	for entityID := range ns.unannouncedEntities {
+		entity, ok := ns.networkEventsStorage.Entities[entityID]
+		if !ok || (len(entity.Inbound) == 0 && len(entity.Outbound) == 0) {
+			delete(ns.networkEventsStorage.Entities, entityID)
+			delete(ns.unannouncedEntities, entityID)
+		}
+	}
+
+	snapshot := snapshotNetworkStream(&ns.networkEventsStorage)
+
+	// Clear the storage
+	for entityID, entity := range ns.networkEventsStorage.Entities {
+		entity.Inbound = make(map[string]armotypes.NetworkStreamEvent)
+		entity.Outbound = make(map[string]armotypes.NetworkStreamEvent)
+		ns.networkEventsStorage.Entities[entityID] = entity
+	}
+	// Re-create the host entity
+	ns.networkEventsStorage.Entities[ns.nodeName] = newHostEntity()
+
+	return snapshot
 }
 
 func (ns *NetworkStream) ReportEnrichedEvent(enrichedEvent *events.EnrichedEvent) {
@@ -303,18 +348,8 @@ func (ns *NetworkStream) handleDnsEvent(event utils.DNSEvent, processTree *armot
 	ns.eventsStorageMutex.Lock()
 	defer ns.eventsStorageMutex.Unlock()
 
-	entityId := event.GetContainerID()
-	// Normalize host container ID to nodeName
-	if entityId == armotypes.HostContainerID {
-		entityId = ns.nodeName
-	}
-	if entityId == "" || ns.k8sObjectCache == nil {
-		entityId = ns.nodeName
-	}
-
-	entity, ok := ns.networkEventsStorage.Entities[entityId]
+	entity, entityId, ok := ns.entityForEventLocked(event.GetContainerID())
 	if !ok {
-		logger.L().Error("NetworkStream - entity not found", helpers.String("entity ID", entityId))
 		return
 	}
 
@@ -365,18 +400,8 @@ func (ns *NetworkStream) handleNetworkEvent(event utils.NetworkEvent, processTre
 	ns.eventsStorageMutex.Lock()
 	defer ns.eventsStorageMutex.Unlock()
 
-	entityId := event.GetContainerID()
-	// Normalize host container ID to nodeName
-	if entityId == armotypes.HostContainerID {
-		entityId = ns.nodeName
-	}
-	if entityId == "" || ns.k8sObjectCache == nil {
-		entityId = ns.nodeName
-	}
-
-	entity, ok := ns.networkEventsStorage.Entities[entityId]
+	entity, entityId, ok := ns.entityForEventLocked(event.GetContainerID())
 	if !ok {
-		logger.L().Error("NetworkStream - entity not found", helpers.String("entity ID", entityId))
 		return
 	}
 
@@ -396,6 +421,67 @@ func (ns *NetworkStream) handleNetworkEvent(event utils.NetworkEvent, processTre
 		entity.Inbound[endpointID] = networkEvent
 	}
 	ns.networkEventsStorage.Entities[entityId] = entity
+}
+
+// entityForEventLocked resolves the entity an event belongs to, reporting false when
+// the event has nowhere to go and must be dropped.
+//
+// Only traffic that is not a container's — no container ID, or the host sentinel —
+// collapses onto the node entity. Everything else keys by container ID. That used to
+// depend on the Kubernetes object cache being present, so on ECS and host installs
+// every container's traffic was merged into the node and no per-container entity
+// existed at all.
+//
+// Outside Kubernetes the entity is also created here, which is what makes the keying
+// useful there: nothing announces a container to this package, so an event for an
+// unknown entity was simply dropped and no container entity could ever exist. Such
+// entities are recorded in unannouncedEntities, because they are the ones
+// snapshotAndClear has to prune.
+//
+// In Kubernetes the container lifecycle is reliable, so a missing entity means the
+// container was removed or is ignored, not that it was never announced — and the
+// collection publishes the removal BEFORE the container leaves it, so events keep
+// arriving for a container that is already gone. Creating one there would emit a
+// container with no pod or workload identity for a pod that no longer exists, so
+// Kubernetes keeps dropping.
+//
+// Callers must hold eventsStorageMutex for writing.
+func (ns *NetworkStream) entityForEventLocked(containerID string) (armotypes.NetworkStreamEntity, string, bool) {
+	entityID := containerID
+	if entityID == "" || entityID == armotypes.HostContainerID {
+		entityID = ns.nodeName
+	}
+
+	if entity, ok := ns.networkEventsStorage.Entities[entityID]; ok {
+		return entity, entityID, true
+	}
+
+	// The node entity is created at construction and re-created by every flush, so
+	// it is only missing if the host container was removed in between. Restore it as
+	// the host rather than inventing a container whose ID is the node's name, and
+	// leave it unprunable.
+	if entityID == ns.nodeName {
+		entity := newHostEntity()
+		ns.networkEventsStorage.Entities[entityID] = entity
+		return entity, entityID, true
+	}
+
+	if ns.cfg.KubernetesMode {
+		logger.L().Error("NetworkStream - entity not found", helpers.String("entity ID", entityID))
+		return armotypes.NetworkStreamEntity{}, entityID, false
+	}
+
+	entity := armotypes.NetworkStreamEntity{
+		Kind: armotypes.NetworkStreamEntityKindContainer,
+		NetworkStreamEntityContainer: armotypes.NetworkStreamEntityContainer{
+			ContainerID: entityID,
+		},
+		Inbound:  make(map[string]armotypes.NetworkStreamEvent),
+		Outbound: make(map[string]armotypes.NetworkStreamEvent),
+	}
+	ns.networkEventsStorage.Entities[entityID] = entity
+	ns.unannouncedEntities[entityID] = struct{}{}
+	return entity, entityID, true
 }
 
 func (ns *NetworkStream) buildNetworkEvent(event utils.NetworkEvent, processTree *armotypes.ProcessTree, ref *armotypes.ProcessRef) armotypes.NetworkStreamEvent {
@@ -427,33 +513,39 @@ func (ns *NetworkStream) buildNetworkEvent(event utils.NetworkEvent, processTree
 		Protocol:  armotypes.NetworkStreamEventProtocol(event.GetProto()),
 	}
 
-	if armotypes.EndpointKind(dstEndpoint.Kind) == armotypes.EndpointKindPod {
-		slimPod := ns.k8sInventory.GetPodByIp(dstEndpoint.Addr)
-		if slimPod != nil {
-			networkEvent.PodName = slimPod.Name
-			networkEvent.PodNamespace = slimPod.Namespace
+	// The inventory is only built in Kubernetes mode. Outside it a pod- or
+	// service-kind endpoint leaves the connection unenriched rather than
+	// dereferencing a nil interface.
+	if ns.k8sInventory != nil {
+		switch armotypes.EndpointKind(dstEndpoint.Kind) {
+		case armotypes.EndpointKindPod:
+			slimPod := ns.k8sInventory.GetPodByIp(dstEndpoint.Addr)
+			if slimPod != nil {
+				networkEvent.PodName = slimPod.Name
+				networkEvent.PodNamespace = slimPod.Namespace
 
-			workloadKind := ""
-			workloadName := ""
+				workloadKind := ""
+				workloadName := ""
 
-			if len(slimPod.OwnerReferences) > 0 {
-				workloadKind = slimPod.OwnerReferences[0].Kind
-				if WorkloadKind(workloadKind) == ReplicaSet {
-					workloadKind = string(Deployment)
+				if len(slimPod.OwnerReferences) > 0 {
+					workloadKind = slimPod.OwnerReferences[0].Kind
+					if WorkloadKind(workloadKind) == ReplicaSet {
+						workloadKind = string(Deployment)
+					}
+					// TODO: handle similar cases for CronJob -> Job -> Pod.
+					workloadName = extractWorkloadName(slimPod.Name, WorkloadKind(workloadKind))
 				}
-				// TODO: handle similar cases for CronJob -> Job -> Pod.
-				workloadName = extractWorkloadName(slimPod.Name, WorkloadKind(workloadKind))
-			}
 
-			networkEvent.WorkloadName = workloadName
-			networkEvent.WorkloadKind = workloadKind
-			networkEvent.WorkloadNamespace = slimPod.Namespace
-		}
-	} else if armotypes.EndpointKind(dstEndpoint.Kind) == armotypes.EndpointKindService {
-		slimService := ns.k8sInventory.GetSvcByIp(dstEndpoint.Addr)
-		if slimService != nil {
-			networkEvent.ServiceName = slimService.Name
-			networkEvent.ServiceNamespace = slimService.Namespace
+				networkEvent.WorkloadName = workloadName
+				networkEvent.WorkloadKind = workloadKind
+				networkEvent.WorkloadNamespace = slimPod.Namespace
+			}
+		case armotypes.EndpointKindService:
+			slimService := ns.k8sInventory.GetSvcByIp(dstEndpoint.Addr)
+			if slimService != nil {
+				networkEvent.ServiceName = slimService.Name
+				networkEvent.ServiceNamespace = slimService.Namespace
+			}
 		}
 	}
 

--- a/pkg/networkstream/v1/network_stream_test.go
+++ b/pkg/networkstream/v1/network_stream_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/armosec/armoapi-go/armotypes"
 	mapset "github.com/deckarep/golang-set/v2"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/types"
 	"github.com/kubescape/node-agent/pkg/config"
 	"github.com/kubescape/node-agent/pkg/dnsmanager"
 	"github.com/kubescape/node-agent/pkg/exporters"
+	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/processtree"
 	"github.com/kubescape/node-agent/pkg/utils"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +54,26 @@ func newTestStreamWithChannel(t *testing.T, mgr processtree.ProcessTreeManager, 
 	return ns
 }
 
+// addContainerNotification is what the container collection publishes when a
+// container appears, carrying the pod identity the stream entity is built from.
+func addContainerNotification(containerID, containerName, namespace, podName string) containercollection.PubSubEvent {
+	return containercollection.PubSubEvent{
+		Type: containercollection.EventTypeAddContainer,
+		Container: &containercollection.Container{
+			Runtime: containercollection.RuntimeMetadata{
+				BasicRuntimeMetadata: types.BasicRuntimeMetadata{
+					ContainerID:   containerID,
+					ContainerName: containerName,
+					ContainerPID:  4242, // not 1: IsHostContainer treats pid 1 as the host
+				},
+			},
+			K8s: containercollection.K8sMetadata{
+				BasicK8sMetadata: types.BasicK8sMetadata{Namespace: namespace, PodName: podName},
+			},
+		},
+	}
+}
+
 func outboundEvent(pid uint32, addr string, port uint16) *utils.StructEvent {
 	return &utils.StructEvent{
 		Pid:         pid,
@@ -65,6 +87,273 @@ func outboundEvent(pid uint32, addr string, port uint16) *utils.StructEvent {
 
 func treeFor(pid uint32, comm string) *armotypes.ProcessTree {
 	return &armotypes.ProcessTree{ProcessTree: armotypes.Process{PID: pid, Comm: comm}}
+}
+
+// containerEvent is an outbound event attributed to a container, which is what
+// every event outside the host's own namespace looks like.
+func containerEvent(containerID string, pid uint32, addr string, port uint16) *utils.StructEvent {
+	event := outboundEvent(pid, addr, port)
+	event.ContainerID = containerID
+	return event
+}
+
+// TestHandleNetworkEvent_ContainersKeepSeparateEntities: outside Kubernetes every
+// event used to be folded onto the node entity, so an ECS task's containers were
+// indistinguishable in the stream. Each container must own its entity.
+func TestHandleNetworkEvent_ContainersKeepSeparateEntities(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock()) // k8sObjectCache nil: the host/ECS shape
+
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+	ns.handleNetworkEvent(containerEvent("container-b", 202, "5.6.7.8", 443), nil)
+
+	require.Len(t, ns.networkEventsStorage.Entities["container-a"].Outbound, 1)
+	require.Len(t, ns.networkEventsStorage.Entities["container-b"].Outbound, 1)
+	assert.Empty(t, ns.networkEventsStorage.Entities[testNodeName].Outbound,
+		"container traffic must not be attributed to the node")
+}
+
+// TestHandleNetworkEvent_UnannouncedEntityCarriesContainerIdentity: nothing announces an
+// ECS container to the stream, so the entity born on the first event is the only
+// place its kind and ID can come from.
+func TestHandleNetworkEvent_UnannouncedEntityCarriesContainerIdentity(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+
+	entity := ns.networkEventsStorage.Entities["container-a"]
+	assert.Equal(t, armotypes.NetworkStreamEntityKindContainer, entity.Kind)
+	assert.Equal(t, "container-a", entity.ContainerID)
+}
+
+// TestHandleDnsEvent_ContainersKeepSeparateEntities mirrors the network-event case
+// for DNS, which keys entities through the same path.
+func TestHandleDnsEvent_ContainersKeepSeparateEntities(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	dnsEvent := func(containerID string) *utils.StructEvent {
+		return &utils.StructEvent{ContainerID: containerID, DNSName: "evil.example.com.", DstPort: 53, Timestamp: time.Now().UnixNano()}
+	}
+
+	ns.handleDnsEvent(dnsEvent("container-a"), nil)
+	ns.handleDnsEvent(dnsEvent("container-b"), nil)
+
+	assert.Len(t, ns.networkEventsStorage.Entities["container-a"].Outbound, 1)
+	assert.Len(t, ns.networkEventsStorage.Entities["container-b"].Outbound, 1)
+	assert.Empty(t, ns.networkEventsStorage.Entities[testNodeName].Outbound)
+}
+
+// TestHandleNetworkEvent_HostTrafficStaysOnTheNodeEntity: only traffic that is not
+// a container's — no container ID, or the host sentinel — collapses onto the node.
+func TestHandleNetworkEvent_HostTrafficStaysOnTheNodeEntity(t *testing.T) {
+	for _, containerID := range []string{"", armotypes.HostContainerID} {
+		t.Run("containerID="+containerID, func(t *testing.T) {
+			ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+
+			ns.handleNetworkEvent(containerEvent(containerID, 101, "1.2.3.4", 443), nil)
+
+			assert.Len(t, ns.networkEventsStorage.Entities[testNodeName].Outbound, 1)
+			assert.Len(t, ns.networkEventsStorage.Entities, 1, "no entity may be created for the sentinel itself")
+			assert.Equal(t, armotypes.NetworkStreamEntityKindHost, ns.networkEventsStorage.Entities[testNodeName].Kind)
+		})
+	}
+}
+
+// TestHandleNetworkEvent_KeyingIgnoresK8sObjectCache is the Kubernetes-inertness pin:
+// the entity an event lands on is decided by the event's container ID alone. The cache
+// used to force every event onto the node whenever it was absent, which is the whole
+// bug — but the Kubernetes side of that condition must keep behaving exactly as it did.
+func TestHandleNetworkEvent_KeyingIgnoresK8sObjectCache(t *testing.T) {
+	for name, cache := range map[string]objectcache.K8sObjectCache{
+		"kubernetes": &objectcache.K8sObjectCacheMock{},
+		"host/ecs":   nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ns, err := NewNetworkStream(context.Background(), config.Config{}, cache, stubResolver{}, testNodeName, nil, true, processtree.NewProcessTreeManagerMock())
+			require.NoError(t, err)
+
+			ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+			ns.handleNetworkEvent(containerEvent("", 202, "5.6.7.8", 80), nil)
+
+			assert.Len(t, ns.networkEventsStorage.Entities["container-a"].Outbound, 1)
+			assert.Len(t, ns.networkEventsStorage.Entities[testNodeName].Outbound, 1)
+		})
+	}
+}
+
+// TestHandleNetworkEvent_AnnouncedContainerKeepsItsMetadata: where ContainerCallback
+// does run, the entity it registered — with the pod identity the backend keys on —
+// must not be replaced by the bare entity the event path would create.
+func TestHandleNetworkEvent_AnnouncedContainerKeepsItsMetadata(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.ContainerCallback(addContainerNotification("container-a", "nginx", "default", "nginx-abc"))
+
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+
+	entity := ns.networkEventsStorage.Entities["container-a"]
+	require.Len(t, entity.Outbound, 1)
+	assert.Equal(t, "nginx", entity.ContainerName)
+	assert.Equal(t, "default", entity.PodNamespace)
+	assert.Equal(t, "nginx-abc", entity.PodName)
+}
+
+// TestContainerCallback_KeepsWhatTheEventPathAlreadyRecorded: the container watcher
+// submits this callback to a worker pool, so a container's first connections can be
+// recorded before it is announced — the window a new container's first egress falls
+// into. Announcing it must add identity, not discard the traffic.
+func TestContainerCallback_KeepsWhatTheEventPathAlreadyRecorded(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+
+	ns.ContainerCallback(addContainerNotification("container-a", "nginx", "default", "nginx-abc"))
+
+	entity := ns.networkEventsStorage.Entities["container-a"]
+	assert.Len(t, entity.Outbound, 1, "traffic recorded before the announcement must survive it")
+	assert.Equal(t, "nginx", entity.ContainerName, "and the announcement still supplies the identity")
+}
+
+// TestHandleNetworkEvent_KubernetesStillDropsUnknownEntities: in Kubernetes the
+// container lifecycle is reliable, so a missing entity means the container was removed
+// or is ignored — not that it was never announced. Creating one would emit a container
+// with no pod or workload identity for a pod that is already gone, and the remove event
+// is published BEFORE the container leaves the collection, so events keep arriving for
+// it. Kubernetes keeps dropping, exactly as before.
+func TestHandleNetworkEvent_KubernetesStillDropsUnknownEntities(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.cfg.KubernetesMode = true // the constructor cannot: it needs a live inventory
+
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+
+	assert.NotContains(t, ns.networkEventsStorage.Entities, "container-a")
+	assert.Empty(t, ns.unannouncedEntities)
+}
+
+// TestHandleNetworkEvent_RestoresTheNodeEntityAsHost: the node entity is created at
+// construction and re-created by every flush, so it is only ever missing because the
+// host container was removed in between. It must come back as the host — never as a
+// container whose ID is the node's name — and it must never become prunable.
+func TestHandleNetworkEvent_RestoresTheNodeEntityAsHost(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	hostNotif := addContainerNotification(armotypes.HostContainerID, "", "", "")
+	hostNotif.Container.Runtime.ContainerPID = 1 // what makes IsHostContainer true
+	hostNotif.Type = containercollection.EventTypeRemoveContainer
+	ns.ContainerCallback(hostNotif)
+	require.NotContains(t, ns.networkEventsStorage.Entities, testNodeName)
+
+	ns.handleNetworkEvent(containerEvent(armotypes.HostContainerID, 101, "1.2.3.4", 443), nil)
+
+	entity := ns.networkEventsStorage.Entities[testNodeName]
+	assert.Equal(t, armotypes.NetworkStreamEntityKindHost, entity.Kind)
+	assert.Empty(t, entity.ContainerID, "the node is not a container")
+	require.Len(t, entity.Outbound, 1)
+
+	ns.snapshotAndClear()
+	ns.snapshotAndClear()
+	assert.Contains(t, ns.networkEventsStorage.Entities, testNodeName, "the node entity is never prunable")
+}
+
+// TestContainerCallback_LeavesTheNodeEntityAlone pins an inertness decision, not a
+// desirable behaviour. With host monitoring on, the virtual host container is announced
+// at startup and this callback overwrites the node entity — losing whatever it held and
+// mislabelling it as a container until the next flush restores its kind. That is
+// pre-existing and out of scope here, so the merge above is scoped to real containers:
+// announcing the host container does nothing it did not already do. Do not "simplify"
+// that condition away without deciding what the node entity's kind should be.
+func TestContainerCallback_LeavesTheNodeEntityAlone(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(containerEvent(armotypes.HostContainerID, 101, "1.2.3.4", 443), nil)
+	require.Len(t, ns.networkEventsStorage.Entities[testNodeName].Outbound, 1)
+
+	hostNotif := addContainerNotification(armotypes.HostContainerID, "", "", "")
+	hostNotif.Container.Runtime.ContainerPID = 1 // what makes IsHostContainer true
+	ns.ContainerCallback(hostNotif)
+
+	assert.Empty(t, ns.networkEventsStorage.Entities[testNodeName].Outbound,
+		"the node entity behaves exactly as it did before this change")
+}
+
+// TestContainerCallback_RemoveLeavesNoDanglingMark: the prune set is only meaningful as
+// a subset of the entity map. A mark left behind for an entity that is gone would have
+// the prune reasoning about something that no longer exists.
+func TestContainerCallback_RemoveLeavesNoDanglingMark(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+	require.Contains(t, ns.unannouncedEntities, "container-a")
+
+	notif := addContainerNotification("container-a", "nginx", "default", "nginx-abc")
+	notif.Type = containercollection.EventTypeRemoveContainer
+	ns.ContainerCallback(notif)
+
+	assert.NotContains(t, ns.networkEventsStorage.Entities, "container-a")
+	assert.NotContains(t, ns.unannouncedEntities, "container-a")
+}
+
+// TestSnapshotAndClear_PrunesIdleUnannouncedEntities: an entity created from an event has no
+// lifecycle callback behind it, so nothing would ever remove it. Left in place it would
+// ride along in every later payload — unbounded growth on a host with container churn.
+// An interval with no traffic is the only "it is gone" signal available.
+func TestSnapshotAndClear_PrunesIdleUnannouncedEntities(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+
+	// The interval that carried its traffic must keep the entity: the events are in
+	// the snapshot, and dropping the entity here would only churn it.
+	snapshot := ns.snapshotAndClear()
+	require.Len(t, snapshot.Entities["container-a"].Outbound, 1)
+	assert.Contains(t, ns.networkEventsStorage.Entities, "container-a")
+
+	// The pruning interval must not carry the dead entity either: it is dropped
+	// before the snapshot is taken, so it never reaches a payload at all.
+	snapshot = ns.snapshotAndClear() // a second interval, with nothing on it
+	assert.NotContains(t, snapshot.Entities, "container-a")
+	assert.NotContains(t, ns.networkEventsStorage.Entities, "container-a")
+	assert.Contains(t, ns.networkEventsStorage.Entities, testNodeName, "the node entity is never pruned")
+}
+
+// TestSnapshotAndClear_KeepsIdleAnnouncedEntities: a container the callback registered
+// is removed by the callback, not by silence. Pruning it on an idle interval would drop
+// the workload identity that enrichWorkloadDetails resolved and never recover it.
+func TestSnapshotAndClear_KeepsIdleAnnouncedEntities(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.ContainerCallback(addContainerNotification("container-a", "nginx", "default", "nginx-abc"))
+
+	ns.snapshotAndClear()
+	ns.snapshotAndClear()
+
+	entity, ok := ns.networkEventsStorage.Entities["container-a"]
+	require.True(t, ok, "an announced container outlives its idle intervals")
+	assert.Equal(t, "nginx", entity.ContainerName)
+}
+
+// TestSnapshotAndClear_AnnouncingAnEntityStopsThePruning: the two paths can create
+// the same entity in either order. Once the callback vouches for a container, silence
+// must stop meaning "gone".
+func TestSnapshotAndClear_AnnouncingAnEntityStopsThePruning(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	ns.handleNetworkEvent(containerEvent("container-a", 101, "1.2.3.4", 443), nil)
+	ns.ContainerCallback(addContainerNotification("container-a", "nginx", "default", "nginx-abc"))
+
+	ns.snapshotAndClear()
+	ns.snapshotAndClear()
+
+	assert.Contains(t, ns.networkEventsStorage.Entities, "container-a")
+}
+
+// TestBuildNetworkEvent_PodEndpointWithoutK8sInventory: the inventory only exists in
+// Kubernetes mode, so a pod- or service-kind endpoint reaching this code anywhere else
+// would dereference a nil interface and take the agent down.
+func TestBuildNetworkEvent_PodEndpointWithoutK8sInventory(t *testing.T) {
+	ns := newTestStream(t, processtree.NewProcessTreeManagerMock())
+	require.Nil(t, ns.k8sInventory)
+
+	for _, kind := range []types.EndpointKind{types.EndpointKindPod, types.EndpointKindService} {
+		t.Run(string(kind), func(t *testing.T) {
+			event := outboundEvent(101, "1.2.3.4", 443)
+			event.DstEndpoint = types.L3Endpoint{Addr: "1.2.3.4", Kind: kind}
+
+			assert.NotPanics(t, func() { ns.handleNetworkEvent(event, nil) })
+			assert.Len(t, ns.networkEventsStorage.Entities[testNodeName].Outbound, 1,
+				"the connection is still recorded, only its Kubernetes enrichment is missing")
+		})
+	}
 }
 
 // TestHandleNetworkEvent_TwoProcessesSameEndpoint pins the DATA LOSS this change


### PR DESCRIPTION
## Summary

Outside Kubernetes the network stream folded every container's traffic onto the single node entity, so no per-container entity existed and per-workload attribution was impossible. This keys entities by container ID instead — collapsing onto the node only for traffic that is not a container's — and creates the entity on first sight where nothing announces containers. The Kubernetes path is unchanged.

## Overview

`handleNetworkEvent` and `handleDnsEvent` decide which stream entity a connection belongs to. Today the fallback onto the node entity fires whenever `ns.k8sObjectCache == nil`:

```go
if entityId == "" || ns.k8sObjectCache == nil {
    entityId = ns.nodeName
}
```

That cache is a Kubernetes API cache. In this repo's binary it is always present, but embedders that run the sensor outside a cluster construct the stream with a nil cache — and there *every* event, including every container's, is folded onto the single node entity. No per-container entity is ever created, so every container on the machine is indistinguishable in the stream and per-workload attribution downstream is impossible.

After this change the collapse happens only for traffic that is not a container's: an empty container ID, or the `"host"` sentinel that `procfs.go` assigns to processes outside every tracked mount namespace. Everything else keys by container ID.

Keying alone is not enough, because an event for an entity that does not exist is dropped, and outside Kubernetes nothing subscribes this package's `ContainerCallback` — so no container entity is ever announced. When `kubernetesMode` is off, the entity is therefore created on the container's first event, and pruned once it goes an interval without traffic, so a machine with container churn does not accumulate dead ones.

**In Kubernetes it keeps dropping, and that is deliberate.** A missing entity in a cluster does not mean "never announced"; it means the container was removed or is ignored. Removal is not quiet, either: the container collection publishes `EventTypeRemoveContainer` *before* the container leaves the collection and then holds it in a 2-second cache for enrichers, while the watcher dispatches this callback onto a worker pool. So events for a container that is already gone keep arriving for a while afterwards. Creating entities for those would put a container carrying no pod or workload identity into the payload, for a pod that no longer exists, on every pod termination.

Two smaller fixes ride along:

- **Traffic recorded before a container is announced is no longer thrown away.** `containerCallback` submits its subscribers to a worker pool while events flow straight through, so a container's first outbound connection routinely lands before its `AddContainer` reaches this package. The announcement now fills identity in over the event maps already there instead of replacing them. The node entity is excluded — it is not announced, so it has no such window, and excluding it keeps that path byte-identical.
- **The `k8sInventory` lookups in `buildNetworkEvent` are nil-guarded.** The inventory is only built when `kubernetesMode` is set, so a pod- or service-kind endpoint arriving anywhere else would dereference a nil interface.

## Additional Information

**Effect on Kubernetes: none.** The removed `k8sObjectCache == nil` disjunct never fired there, and every new behaviour is either behind `!cfg.KubernetesMode` or scoped away from the node entity. `TestHandleNetworkEvent_KeyingIgnoresK8sObjectCache` and `TestHandleNetworkEvent_KubernetesStillDropsUnknownEntities` pin that.

One known gap is deliberately **not** addressed here. `ContainerCallback` deletes a stopped container's entity along with any traffic it had not yet flushed, losing up to one interval — which matters most for a short-lived container that makes a single outbound connection. That behaviour is pre-existing and untouched by this PR: it is neither introduced nor widened here. But per-container entities make it matter more, so I will follow up with a separate PR that retires the entity at the next flush instead of deleting it. I am keeping it separate because that one *is* a Kubernetes behaviour change and deserves its own review rather than riding inside a change whose point is that Kubernetes is unaffected.

Docs: adds `docs/features/network-stream-entity-keying.md`. Also drops `hostNetworkSensorEnabled` and `hostMalwareSensorEnabled` from `docs/CONFIGURATION.md` — neither key exists anywhere in the codebase, while `hostMonitoringEnabled`, which does, was missing from the table.

## How to Test

This package does not build on macOS, since inspektor-gadget is Linux-only. On a Mac:

```
docker run --rm -v "$PWD":/src -w /src -v "$(go env GOMODCACHE)":/go/pkg/mod \
  golang:1.25 bash -c 'go test -race ./pkg/networkstream/...'
```

On Linux, `go test -race ./pkg/networkstream/...`.

15 new tests (18 cases with subtests) cover the keying, the platform gate, entity creation and pruning, the announcement merge in both arrival orders, node-entity restoration, and the nil-inventory guard. I checked each one earns its place by reverting the corresponding behaviour individually and confirming that test — and only that test — fails. The rest of the unit suite is unaffected.

<!-- armosec-pr: v=1 via=manual -->

<!-- AI-skills: superpowers:test-driven-development -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network and DNS activity is now attributed to separate container entities.
  * Non-Kubernetes environments can create temporary container entities from observed traffic.
  * Host activity is consistently associated with the node entity.
  * Container metadata and activity recorded before announcement are preserved.
  * Network endpoint enrichment safely supports pod and service details when inventory is available.

* **Bug Fixes**
  * Unknown Kubernetes entities continue to be excluded.
  * Idle, unannounced container entities are automatically removed.
  * Snapshot and shutdown handling now safely isolate and flush collected data.

* **Documentation**
  * Updated the host monitoring configuration reference.
  * Added documentation for network-stream entity keying and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->