### PR TITLE
fix rule failure runtime alert path handling

### DIFF
--- a/pkg/rulemanager/rule_manager.go
+++ b/pkg/rulemanager/rule_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubescape/node-agent/pkg/metricsmanager"
 	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/objectcache/containerprofilecache"
+	"github.com/kubescape/node-agent/pkg/otelsetup"
 	"github.com/kubescape/node-agent/pkg/processtree"
 	bindingcache "github.com/kubescape/node-agent/pkg/rulebindingmanager"
 	"github.com/kubescape/node-agent/pkg/rulemanager/cel"
@@ -34,15 +35,14 @@ import (
 	"github.com/kubescape/node-agent/pkg/rulemanager/profilehelper"
 	"github.com/kubescape/node-agent/pkg/rulemanager/ruleadapters"
 	"github.com/kubescape/node-agent/pkg/rulemanager/rulecooldown"
-	"github.com/kubescape/node-agent/pkg/otelsetup"
 	"github.com/kubescape/node-agent/pkg/rulemanager/types"
 	typesv1 "github.com/kubescape/node-agent/pkg/rulemanager/types/v1"
 	"github.com/kubescape/node-agent/pkg/utils"
 
-	corev1 "k8s.io/api/core/v1"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -93,7 +93,6 @@ func CreateRuleManager(
 	mntnsRegistry contextdetection.Registry,
 	agentVersion string,
 ) (*RuleManager, error) {
-	ruleFailureCreator := ruleadapters.NewRuleFailureCreator(enricher, dnsManager, adapterFactory, armotypes.AlertSourcePlatformK8sAgent, agentVersion)
 	rulePolicyValidator := NewRulePolicyValidator(objectCache)
 	detectorManager := detectors.NewDetectorManager(mntnsRegistry)
 
@@ -111,12 +110,13 @@ func CreateRuleManager(
 		processManager:      processManager,
 		ruleCooldown:        ruleCooldown,
 		celEvaluator:        celEvaluator,
-		ruleFailureCreator:  ruleFailureCreator,
 		rulePolicyValidator: rulePolicyValidator,
 		mntnsRegistry:       mntnsRegistry,
 		detectorManager:     detectorManager,
 		alertLogDedup:       expirable.NewLRU[string, struct{}](1000, nil, 60*time.Second),
 	}
+
+	r.ruleFailureCreator = ruleadapters.NewRuleFailureCreator(enricher, dnsManager, adapterFactory, armotypes.AlertSourcePlatformK8sAgent, agentVersion, &r.containerIdToPid)
 
 	// Compile the initial projection spec and start a goroutine that
 	// recompiles whenever rule bindings change.

--- a/pkg/rulemanager/ruleadapters/creator.go
+++ b/pkg/rulemanager/ruleadapters/creator.go
@@ -202,26 +202,23 @@ func (r *RuleFailureCreator) setCloudServices(ruleFailure *types.GenericRuleFail
 
 func (r *RuleFailureCreator) setBaseRuntimeAlert(ruleFailure *types.GenericRuleFailure) {
 	var hostPath string
-	var err error
-	var path string
-
 	triggerEvent := ruleFailure.GetTriggerEvent()
+	processTree := ruleFailure.GetRuntimeProcessDetails().ProcessTree
 
-	if ruleFailure.GetRuntimeProcessDetails().ProcessTree.Path == "" {
-		path, err = utils.GetPathFromPid(ruleFailure.GetRuntimeProcessDetails().ProcessTree.PID)
+	if processTree.Path == "" {
+		path, err := utils.GetPathFromPid(processTree.PID)
 		if err != nil {
 			return
 		}
-		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", ruleFailure.GetRuntimeProcessDetails().ProcessTree.PID, path))
-	}
-
-	if err != nil { // FIXME WTF it's always nil here
-		if ruleFailure.GetRuntimeProcessDetails().ProcessTree.Path != "" && triggerEvent != nil {
-			hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", r.containerIdToPid.Get(triggerEvent.GetContainerID()),
-				ruleFailure.GetRuntimeProcessDetails().ProcessTree.Path))
-		}
+		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", processTree.PID, path))
 	} else {
-		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", ruleFailure.GetRuntimeProcessDetails().ProcessTree.PID, path))
+		pidToUse := processTree.PID
+		if triggerEvent != nil {
+			if containerPID := r.containerIdToPid.Get(triggerEvent.GetContainerID()); containerPID != 0 {
+				pidToUse = containerPID
+			}
+		}
+		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", pidToUse, processTree.Path))
 	}
 
 	baseRuntimeAlert := ruleFailure.GetBaseRuntimeAlert()
@@ -231,6 +228,7 @@ func (r *RuleFailureCreator) setBaseRuntimeAlert(ruleFailure *types.GenericRuleF
 	}
 	var size int64 = 0
 	if hostPath != "" {
+		var err error
 		size, err = utils.GetFileSize(hostPath)
 		if err != nil {
 			size = 0

--- a/pkg/rulemanager/ruleadapters/creator.go
+++ b/pkg/rulemanager/ruleadapters/creator.go
@@ -47,15 +47,16 @@ type RuleFailureCreator struct {
 	agentVersion     string
 }
 
-func NewRuleFailureCreator(enricher types.Enricher, dnsManager dnsmanager.DNSResolver, adapterFactory *EventRuleAdapterFactory, alertPlatform armotypes.AlertSourcePlatform, agentVersion string) *RuleFailureCreator {
+func NewRuleFailureCreator(enricher types.Enricher, dnsManager dnsmanager.DNSResolver, adapterFactory *EventRuleAdapterFactory, alertPlatform armotypes.AlertSourcePlatform, agentVersion string, containerIdToPid *maps.SafeMap[string, uint32]) *RuleFailureCreator {
 	hashCache := expirable.NewLRU[string, *FileHashCache](hashCacheMaxSize, nil, hashCacheTTL)
 	return &RuleFailureCreator{
-		adapterFactory: adapterFactory,
-		dnsManager:     dnsManager,
-		enricher:       enricher,
-		hashCache:      hashCache,
-		alertPlatform:  alertPlatform,
-		agentVersion:   agentVersion,
+		adapterFactory:   adapterFactory,
+		containerIdToPid: containerIdToPid,
+		dnsManager:       dnsManager,
+		enricher:         enricher,
+		hashCache:        hashCache,
+		alertPlatform:    alertPlatform,
+		agentVersion:     agentVersion,
 	}
 }
 
@@ -200,25 +201,31 @@ func (r *RuleFailureCreator) setCloudServices(ruleFailure *types.GenericRuleFail
 
 }
 
-func (r *RuleFailureCreator) setBaseRuntimeAlert(ruleFailure *types.GenericRuleFailure) {
-	var hostPath string
-	triggerEvent := ruleFailure.GetTriggerEvent()
-	processTree := ruleFailure.GetRuntimeProcessDetails().ProcessTree
-
+func (r *RuleFailureCreator) getHostPath(processTree armotypes.Process, triggerEvent utils.EnrichEvent) (string, error) {
 	if processTree.Path == "" {
 		path, err := utils.GetPathFromPid(processTree.PID)
 		if err != nil {
-			return
+			return "", err
 		}
-		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", processTree.PID, path))
-	} else {
-		pidToUse := processTree.PID
-		if triggerEvent != nil {
-			if containerPID := r.containerIdToPid.Get(triggerEvent.GetContainerID()); containerPID != 0 {
-				pidToUse = containerPID
-			}
+		return filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", processTree.PID, path)), nil
+	}
+
+	pidToUse := processTree.PID
+	if triggerEvent != nil {
+		if containerPID := r.containerIdToPid.Get(triggerEvent.GetContainerID()); containerPID != 0 {
+			pidToUse = containerPID
 		}
-		hostPath = filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", pidToUse, processTree.Path))
+	}
+	return filepath.Join("/proc", fmt.Sprintf("/%d/root/%s", pidToUse, processTree.Path)), nil
+}
+
+func (r *RuleFailureCreator) setBaseRuntimeAlert(ruleFailure *types.GenericRuleFailure) {
+	triggerEvent := ruleFailure.GetTriggerEvent()
+	processTree := ruleFailure.GetRuntimeProcessDetails().ProcessTree
+
+	hostPath, err := r.getHostPath(processTree, triggerEvent)
+	if err != nil {
+		return
 	}
 
 	baseRuntimeAlert := ruleFailure.GetBaseRuntimeAlert()

--- a/pkg/rulemanager/ruleadapters/creator_test.go
+++ b/pkg/rulemanager/ruleadapters/creator_test.go
@@ -1,0 +1,55 @@
+package ruleadapters
+
+import (
+	armotypes "github.com/armosec/armoapi-go/armotypes"
+	"github.com/goradd/maps"
+	"github.com/kubescape/node-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type MockEnrichEvent struct {
+	utils.EnrichEvent
+	containerID string
+}
+
+func (m *MockEnrichEvent) GetContainerID() string {
+	return m.containerID
+}
+
+func TestGetHostPath_MappedContainerID(t *testing.T) {
+	containerIdToPid := new(maps.SafeMap[string, uint32])
+	containerIdToPid.Set("test-container", 1234)
+
+	creator := &RuleFailureCreator{
+		containerIdToPid: containerIdToPid,
+	}
+
+	mockTrigger := &MockEnrichEvent{containerID: "test-container"}
+	processTree := armotypes.Process{
+		Path: "/bin/sh",
+		PID:  9999,
+	}
+
+	hostPath, err := creator.getHostPath(processTree, mockTrigger)
+	assert.NoError(t, err)
+	assert.Equal(t, "/proc/1234/root/bin/sh", hostPath)
+}
+
+func TestGetHostPath_MissingContainerID(t *testing.T) {
+	containerIdToPid := new(maps.SafeMap[string, uint32])
+
+	creator := &RuleFailureCreator{
+		containerIdToPid: containerIdToPid,
+	}
+
+	mockTrigger := &MockEnrichEvent{containerID: "test-container-not-mapped"}
+	processTree := armotypes.Process{
+		Path: "/bin/sh",
+		PID:  9999,
+	}
+
+	hostPath, err := creator.getHostPath(processTree, mockTrigger)
+	assert.NoError(t, err)
+	assert.Equal(t, "/proc/9999/root/bin/sh", hostPath)
+}


### PR DESCRIPTION
## Description

Fixes incorrect host path resolution in `setBaseRuntimeAlert`.

The existing implementation checked `err` after `GetPathFromPid`, even though the function already returned when `err != nil`. As a result, that error branch was unreachable.

When `ProcessTree.Path` was already available, the local `path` variable remained empty and could be used to construct an incorrect `hostPath`.

## Changes

- Remove the unreachable `err != nil` branch.
- Use `ProcessTree.Path` directly when it is already available.
- Resolve the path using `GetPathFromPid` only when `ProcessTree.Path` is empty.
- Use the container PID when available, with the process PID as a fallback.
- Scope error variables closer to where they are used.

## Testing

- Ran `gofmt` and `git diff --check`.
- Verified Linux compilation with:

  `GOOS=linux GOARCH=amd64 go build ./pkg/rulemanager/ruleadapters/...`

- Ran the relevant Go tests in a Linux Docker environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved executable path resolution for runtime alerts involving containerized processes.
  * Alerts now use the correct host path when a container-to-process mapping is available.
  * Added fallback handling when container mappings or process paths are unavailable.
  * Corrected file-size error handling to improve alert reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->