### PR TITLE
KUB-1364: use containerprofiles instead of applicationprofiles for storage readiness check

### DIFF
--- a/pkg/storage/v1/storage.go
+++ b/pkg/storage/v1/storage.go
@@ -63,7 +63,7 @@ func CreateStorage(namespace string) (*Storage, error) {
 
 	// wait for storage to be ready
 	if err := backoff.RetryNotify(func() error {
-		_, err := clientset.SpdxV1beta1().ApplicationProfiles("default").List(context.Background(), metav1.ListOptions{})
+		_, err := clientset.SpdxV1beta1().ContainerProfiles("default").List(context.Background(), metav1.ListOptions{})
 		return err
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 60), func(err error, d time.Duration) {
 		logger.L().Info("waiting for storage to be ready", helpers.Error(err), helpers.String("retry in", d.String()))


### PR DESCRIPTION
## Description

Updates the storage readiness check in `pkg/storage/v1/storage.go` to query `ContainerProfiles` instead of `ApplicationProfiles`.

Closes KUB-1364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage startup readiness checks to wait for the correct backend resources, reducing failures caused by premature initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->