### PR TITLE
ci: support component tests for fork PRs

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to Quay.io
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
           registry: quay.io/kubescape
@@ -28,16 +29,39 @@ jobs:
           echo "Installing IG version: ${IG_VERSION}"
           curl -sL https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${IG_VERSION}/ig-linux-${IG_ARCH}-${IG_VERSION}.tar.gz | sudo tar -C /usr/local/bin -xzf - ig
           sudo chmod +x /usr/local/bin/ig
-      - name: Build the Image and Push to Quay.io
+      - name: Build the image
         id: build-and-push-image
         run: |
           COMMIT_HASH=$(git rev-parse --short HEAD)
           export IMAGE_TAG=test-${COMMIT_HASH}
           export IMAGE_REPO=quay.io/kubescape/node-agent
+
           echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
-          export IMAGE_NAME=quay.io/kubescape/node-agent:${IMAGE_TAG}
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
-          make docker-build TAG=${IMAGE_TAG} IMAGE=${IMAGE_REPO} && make docker-push TAG=${IMAGE_TAG} IMAGE=${IMAGE_REPO}
+
+          make docker-build TAG=${IMAGE_TAG} IMAGE=${IMAGE_REPO}
+
+      - name: Push image to Quay.io
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          make docker-push \
+            TAG=${{ steps.build-and-push-image.outputs.image_tag }} \
+            IMAGE=${{ steps.build-and-push-image.outputs.image_repo }}
+
+      - name: Save image for fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          docker save \
+            ${{ steps.build-and-push-image.outputs.image_repo }}:${{ steps.build-and-push-image.outputs.image_tag }} \
+            -o node-agent-image.tar
+
+      - name: Upload image artifact for fork PR
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-agent-image
+          path: node-agent-image.tar
+          retention-days: 1
     outputs:
       image_tag: ${{ steps.build-and-push-image.outputs.image_tag }}
       image_repo: ${{ steps.build-and-push-image.outputs.image_repo }}
@@ -80,6 +104,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Download fork PR image
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/download-artifact@v4
+        with:
+          name: node-agent-image
+
+      - name: Load fork PR image
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          docker load -i node-agent-image.tar
+
       - name: Set up Kind
         run: |
           curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
@@ -88,11 +123,19 @@ jobs:
           curl -LO "https://dl.k8s.io/release/v1.35.0/bin/linux/amd64/kubectl"
           chmod +x ./kubectl
           sudo mv ./kubectl /usr/local/bin/kubectl
+
+      - name: Load fork PR image into Kind
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          ./kind load docker-image \
+            ${{ needs.build-and-push-image.outputs.image_repo }}:${{ needs.build-and-push-image.outputs.image_tag }}
+
       - name: Install Helm and Kubectl
         run: |
           curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
           chmod 700 get_helm.sh
           sudo ./get_helm.sh
+
       - name: Install Prometheus and Node Exporter
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
## Summary

This PR updates the component-test workflow so fork PRs can run component tests without access to Kubescape's Quay credentials.

### Problem

Fork PRs currently reach the Quay login step, but fork workflows do not have access to the registry credentials. This produces the `Username and password required` failure even when the code changes themselves are unrelated to registry authentication.

### Approach

- Skip Quay login for fork PRs.
- Build the Node Agent image for both trusted and fork PRs.
- Keep publishing to Quay for trusted/internal PRs.
- For fork PRs, save the built image as a GitHub Actions artifact instead of pushing it.
- Download/load that exact image in each component-test matrix job and load it into Kind before Helm deployment.

This keeps the existing component-test coverage while removing the dependency on registry credentials for external contributions.

### Validation

- `git diff --check` passes locally.
- The workflow changes are limited to `.github/workflows/component-tests.yaml`.
- The next step is to validate the behavior through the PR's GitHub Actions run, especially that Quay login/push are skipped for the fork path and the image artifact is successfully loaded into Kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component testing for pull requests from forks.
  * Ensured test images are available without requiring external registry access.
  * Restricted container registry login and image publishing to trusted repository pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->