### PR TITLE
ci: fix stale/missing component-tests matrix entries and storage image version drift

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -83,8 +83,8 @@ jobs:
           Test_08_ContainerProfilePatching,
           Test_10_MalwareDetectionTest,
           Test_11_EndpointTest,
-          Test_12_MergingProfilesTest,
-          Test_13_MergingNetworkNeighborhoodTest,
+          Test_12_AuthoredMultiSubtypeProfile,
+          Test_13_NaturalLearningLifecycle,
           Test_14_RulePoliciesTest,
           Test_15_CompletedApCannotBecomeReadyAgain,
           Test_16_ApNotStuckOnRestart,
@@ -96,11 +96,18 @@ jobs:
           Test_22_AlertOnPartialNetworkProfileTest,
           Test_23_RuleCooldownTest,
           Test_24_ProcessTreeDepthTest,
+          Test_25_RuleCooldownExactThreshold,
           Test_27_ApplicationProfileOpens,
+          Test_28_UserDefinedNetworkNeighborhood,
+          Test_30_IgnoreExcludeAndLearningDuration,
           Test_32_UnexpectedProcessArguments,
+          Test_33_AnalyzeOpensWildcardAnchoring,
           Test_34_NetworkNeighborsCIDRCollapse,
+          Test_35_ExecTTYFieldTest,
           Test_36_MultiContainerPerContainerBinding,
-          Test_48_MultiSubtypeGroupedProfileDocument
+          Test_43_RelativeOpenPathResolution,
+          Test_48_MultiSubtypeGroupedProfileDocument,
+          Test_49_EphemeralContainerFullTreatment
         ]
     steps:
       - name: Checkout code

--- a/tests/scripts/storage-tag.sh
+++ b/tests/scripts/storage-tag.sh
@@ -1,4 +1,13 @@
 #/bin/bash
 curl -s https://raw.githubusercontent.com/kubescape/helm-charts/main/charts/kubescape-operator/values.yaml -o values.yaml
-yq '.storage.image.tag' < values.yaml
+DYNAMIC_TAG=$(yq '.storage.image.tag' < values.yaml | tr -d '"')
 rm -rf values.yaml
+
+# Floor: node-agent's own go.mod-pinned kubescape/storage client version. When
+# kubescape/helm-charts' pinned server image (fetched above) lags behind what
+# this repo's client library needs, component-tests would silently regress
+# (an older server drops CRD fields the newer client sets). Take the newer of
+# the two so CI never runs against a server that predates our client.
+FLOOR_TAG=$(go list -m -f '{{.Version}}' github.com/kubescape/storage)
+
+printf '%s\n%s\n' "$DYNAMIC_TAG" "$FLOOR_TAG" | sort -V | tail -n1


### PR DESCRIPTION
## Overview

Follow-up to #864 ("chore: deprecate old profiletypes in favor of containerprofiles"), splitting out two CI-hygiene gaps that came up during that PR's review.

### 1. Stale/incomplete `component-tests.yaml` matrix

- `Test_12_MergingProfilesTest` and `Test_13_MergingNetworkNeighborhoodTest` referenced function names that no longer exist — #864 renamed them. `go test -run <name-that-matches-nothing>` prints "no tests to run" and exits 0, so these two entries were reporting green while running zero test code. Fixed to reference the current names: `Test_12_AuthoredMultiSubtypeProfile` and `Test_13_NaturalLearningLifecycle`.
- Re-derived the ground-truth test list fresh from `tests/component_test.go` on current `main` (`git grep -oE '^func (Test_[0-9]+_\w+)'`) rather than trusting any prior snapshot, and reconciled it against the matrix. Added real, matrix-shaped functions that existed but were never wired in: `Test_25_RuleCooldownExactThreshold`, `Test_28_UserDefinedNetworkNeighborhood` (the flagship end-to-end test for the #864 migration), `Test_30_IgnoreExcludeAndLearningDuration`, `Test_33_AnalyzeOpensWildcardAnchoring`, `Test_35_ExecTTYFieldTest`, `Test_43_RelativeOpenPathResolution`, `Test_49_EphemeralContainerFullTreatment`.
- Deliberately did **not** add `Test_09_FalsePositiveTest` back: on current `main` it carries its own `t.Skip("...pending storage write-serialization...")` with a comment stating it was "Also removed from the CI matrix" due to being perpetually red under storage's single-writer contention. Re-adding it to the matrix would just add a no-op skip.
- `Test_03/04/05` stay commented out exactly as they were — untouched, that's an existing, separate decision.
- `continue-on-error: true` on the job is left as-is — a separate policy call, not part of this fix.

### 2. Storage image tag drift vs. this repo's storage client version

`tests/scripts/storage-tag.sh` dynamically mirrors whatever `kubescape/helm-charts`' `main` branch has pinned for the storage server image (currently `v0.0.298`). This repo's `go.mod` pins `github.com/kubescape/storage` (the client library) to `v0.0.303`, whose `ContainerProfileSpec` has new grouped-subtype fields (`Containers`/`InitContainers`/`EphemeralContainers`) that `v0.0.298`'s server doesn't know about — confirmed by diffing that tag's `types.go`. The older server silently drops those fields on admission, so `Test_48_MultiSubtypeGroupedProfileDocument`'s round-trip read comes back empty: a deterministic CI failure, not flakiness.

This is genuine cross-repo drift — the durable fix is bumping the pin in [`kubescape/helm-charts`' `values.yaml`](https://github.com/kubescape/helm-charts/blob/main/charts/kubescape-operator/values.yaml) (out of scope here, different repo/org). What this PR does inside `node-agent`: `storage-tag.sh` now takes the **max** of the dynamically-fetched helm-charts tag and this repo's own `go.mod`-pinned floor (read via `go list -m -f '{{.Version}}' github.com/kubescape/storage`, so it never goes stale as a hardcoded literal), comparing via `sort -V`. That keeps CI's storage server from silently regressing below what this repo's client needs, without touching the other repo.

**A human should still consider bumping `kubescape/helm-charts`' pin for production parity — this PR only fixes `node-agent`'s own CI signal.**

### Also referenced (not touched here)

`Test_27_ApplicationProfileOpens` has a separate, pre-existing CI failure (an eBPF path-normalization bug) already being fixed in #893 by @entlein — unrelated to this matrix/tag work, mentioned here only for cross-reference.

### Verification

- `go build ./...`, `go vet ./...`, and `go vet -tags=component ./tests/...` all clean (no Go source was changed).
- `bash -n tests/scripts/storage-tag.sh` clean; ran the script live — it now resolves `v0.0.303` (the `go.mod` floor) instead of the stale `v0.0.298` from helm-charts.
- Parsed the updated workflow YAML and cross-checked every matrix entry against `git grep`'s function list — all 32 active entries match a real, non-skipped test function 1:1.

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for profile behavior, learning lifecycles, rule cooldowns, network neighborhoods, exclusions, wildcard matching, terminal fields, path resolution, and ephemeral environments.
  - Replaced outdated profile-merging scenarios with broader multi-subtype and lifecycle validation.

- **Chores**
  - Improved storage image version checks by comparing the chart version with the pinned storage component version and reporting newer versions when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->