### PR TITLE
feat(cel): restore ap./nn. namespace aliases for backward compatibility

### DIFF
--- a/pkg/rulemanager/cel/cel.go
+++ b/pkg/rulemanager/cel/cel.go
@@ -64,6 +64,13 @@ func NewCEL(objectCache objectcache.ObjectCache, cfg config.Config, mm ...metric
 		k8s.K8s(objectCache.K8sObjectCache(), cfg),
 		containerprofile.CP(objectCache, cfg, mm...),
 		containerprofilenetwork.CPNetwork(objectCache, cfg, mm...),
+		// Deprecated backward-compat aliases for the ap.*/nn.* CEL namespaces
+		// renamed to cp.* in #864 (no aliases were kept at the time, which
+		// silently disabled any pre-existing user rule still using the old
+		// names). Retained for a transition window; remove once user rules
+		// have migrated to cp.*.
+		containerprofile.AP(objectCache, cfg, mm...),
+		containerprofilenetwork.NN(objectCache, cfg, mm...),
 		parse.Parse(cfg),
 		net.Net(cfg),
 		process.Process(cfg),

--- a/pkg/rulemanager/cel/libraries/containerprofile/containerprofile.go
+++ b/pkg/rulemanager/cel/libraries/containerprofile/containerprofile.go
@@ -1,6 +1,8 @@
 package containerprofile
 
 import (
+	"strings"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
@@ -32,6 +34,25 @@ func CP(objectCache objectcache.ObjectCache, config config.Config, mm ...metrics
 	return cel.Lib(New(objectCache, config, mm...))
 }
 
+// AP returns the deprecated "ap.*" backward-compat alias namespace for this
+// library's cp.* functions (e.g. ap.was_executed, ap.was_path_opened, ...).
+//
+// Deprecated: kubescape/node-agent#864 renamed the ap.*/nn.* CEL helper
+// namespaces to cp.* with no backward-compatible aliases, which silently
+// disabled any pre-existing user-authored CEL rule still referencing the old
+// names (pkg/utils/cel.go logs a warning and just skips the rule on compile
+// failure). AP restores those names for a transition window: it shares the
+// same containerProfileLibrary instance and the same funcSpecs table as
+// cp.*, so every ap.* call is wired to the exact same Go implementation
+// (l.wasExecuted, l.wasPathOpened, ...) as its cp.* equivalent — only the
+// CEL-facing function name and overload id differ (cel-go requires overload
+// ids to be unique per environment, so ap.* can't literally reuse cp.*'s
+// FunctionOpt values). Remove once user rules have migrated to cp.*.
+func AP(objectCache objectcache.ObjectCache, config config.Config, mm ...metricsmanager.MetricsManager) cel.EnvOption {
+	base := New(objectCache, config, mm...).(*containerProfileLibrary)
+	return cel.Lib(&legacyContainerProfileLibrary{base: base, name: "ap", prefix: "ap."})
+}
+
 type containerProfileLibrary struct {
 	objectCache     objectcache.ObjectCache
 	functionCache   *cache.FunctionCache
@@ -48,279 +69,173 @@ func (l *containerProfileLibrary) Types() []*cel.Type {
 	return []*cel.Type{}
 }
 
-func (l *containerProfileLibrary) Declarations() map[string][]cel.FunctionOpt {
-	return map[string][]cel.FunctionOpt{
-		"cp.was_executed": {
+// containerProfileFuncSpec describes one CEL helper's overload signature and
+// its (single, shared) Go implementation. Declarations() below and the ap.*
+// legacy alias both build their cel.FunctionOpt map from this same table, so
+// the two namespaces can never register a different implementation for the
+// "same" function name.
+type containerProfileFuncSpec struct {
+	// name is the function's suffix, e.g. "was_executed" (used after the
+	// "cp."/"ap." namespace prefix, and after the "cp_"/"ap_" overload-id
+	// prefix).
+	name       string
+	argTypes   []*cel.Type
+	resultType *cel.Type
+	arity      int
+	// call invokes the shared implementation method on l.
+	call func(l *containerProfileLibrary, args []ref.Val) ref.Val
+}
+
+var containerProfileFuncSpecs = []containerProfileFuncSpec{
+	{
+		name:       "was_executed",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasExecuted(a[0], a[1]) },
+	},
+	{
+		name:       "was_executed_with_args",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)},
+		resultType: cel.BoolType,
+		arity:      3,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasExecutedWithArgs(a[0], a[1], a[2]) },
+	},
+	{
+		name:       "was_path_opened",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasPathOpened(a[0], a[1]) },
+	},
+	{
+		name:       "was_path_opened_with_flags",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)},
+		resultType: cel.BoolType,
+		arity:      3,
+		call: func(l *containerProfileLibrary, a []ref.Val) ref.Val {
+			return l.wasPathOpenedWithFlags(a[0], a[1], a[2])
+		},
+	},
+	{
+		name:       "was_path_opened_with_suffix",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasPathOpenedWithSuffix(a[0], a[1]) },
+	},
+	{
+		name:       "was_path_opened_with_prefix",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasPathOpenedWithPrefix(a[0], a[1]) },
+	},
+	{
+		name:       "was_syscall_used",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasSyscallUsed(a[0], a[1]) },
+	},
+	{
+		name:       "was_capability_used",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasCapabilityUsed(a[0], a[1]) },
+	},
+	{
+		name:       "was_endpoint_accessed",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasEndpointAccessed(a[0], a[1]) },
+	},
+	{
+		name:       "was_endpoint_accessed_with_method",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      3,
+		call: func(l *containerProfileLibrary, a []ref.Val) ref.Val {
+			return l.wasEndpointAccessedWithMethod(a[0], a[1], a[2])
+		},
+	},
+	{
+		name:       "was_endpoint_accessed_with_methods",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)},
+		resultType: cel.BoolType,
+		arity:      3,
+		call: func(l *containerProfileLibrary, a []ref.Val) ref.Val {
+			return l.wasEndpointAccessedWithMethods(a[0], a[1], a[2])
+		},
+	},
+	{
+		name:       "was_endpoint_accessed_with_prefix",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileLibrary, a []ref.Val) ref.Val {
+			return l.wasEndpointAccessedWithPrefix(a[0], a[1])
+		},
+	},
+	{
+		name:       "was_endpoint_accessed_with_suffix",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileLibrary, a []ref.Val) ref.Val {
+			return l.wasEndpointAccessedWithSuffix(a[0], a[1])
+		},
+	},
+	{
+		name:       "was_host_accessed",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call:       func(l *containerProfileLibrary, a []ref.Val) ref.Val { return l.wasHostAccessed(a[0], a[1]) },
+	},
+}
+
+// declarationsWithPrefix builds the cel.FunctionOpt map for every function in
+// containerProfileFuncSpecs, exposed as "<namePrefix><spec.name>" (e.g.
+// "cp.was_executed" or "ap.was_executed") with overload id
+// "<overloadIDPrefix>_<spec.name>" (e.g. "cp_was_executed" / "ap_was_executed" —
+// cel-go requires overload ids to be unique per environment, so the ap.*
+// alias needs its own ids even though it shares spec.call's implementation).
+func (l *containerProfileLibrary) declarationsWithPrefix(namePrefix, overloadIDPrefix string) map[string][]cel.FunctionOpt {
+	decls := make(map[string][]cel.FunctionOpt, len(containerProfileFuncSpecs))
+	for _, spec := range containerProfileFuncSpecs {
+		spec := spec
+		fullName := namePrefix + spec.name
+		overloadID := overloadIDPrefix + "_" + spec.name
+		decls[fullName] = []cel.FunctionOpt{
 			cel.Overload(
-				"cp_was_executed", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
+				overloadID, spec.argTypes, spec.resultType,
 				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
+					if len(values) != spec.arity {
+						return types.NewErr("expected %d arguments, got %d", spec.arity, len(values))
 					}
 					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_executed")
+						l.metrics.IncHelperCall(fullName)
 					}
 					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasExecuted(args[0], args[1])
+						return spec.call(l, args)
 					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_executed", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
+					cachedFunc := l.functionCache.WithCache(wrapperFunc, fullName, cache.HashForContainerProfile(l.objectCache))
+					result := cachedFunc(values...)
 					// Convert "profile not available" error to false after cache layer
 					// This ensures: 1) error is not cached, 2) rule evaluation continues normally
 					return cache.ConvertProfileNotAvailableErrToBool(result, false)
 				}),
 			),
-		},
-		"cp.was_executed_with_args": {
-			cel.Overload(
-				"cp_was_executed_with_args", []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 3 {
-						return types.NewErr("expected 3 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_executed_with_args")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasExecutedWithArgs(args[0], args[1], args[2])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_executed_with_args", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2])
-					// Convert "profile not available" error to false after cache layer
-					// This ensures: 1) error is not cached, 2) rule evaluation continues normally
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_path_opened": {
-			cel.Overload(
-				"cp_was_path_opened", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_path_opened")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasPathOpened(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_path_opened", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_path_opened_with_flags": {
-			cel.Overload(
-				"cp_was_path_opened_with_flags", []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 3 {
-						return types.NewErr("expected 3 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_path_opened_with_flags")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasPathOpenedWithFlags(args[0], args[1], args[2])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_path_opened_with_flags", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_path_opened_with_suffix": {
-			cel.Overload(
-				"cp_was_path_opened_with_suffix", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_path_opened_with_suffix")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasPathOpenedWithSuffix(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_path_opened_with_suffix", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_path_opened_with_prefix": {
-			cel.Overload(
-				"cp_was_path_opened_with_prefix", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_path_opened_with_prefix")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasPathOpenedWithPrefix(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_path_opened_with_prefix", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_syscall_used": {
-			cel.Overload(
-				"cp_was_syscall_used", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_syscall_used")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasSyscallUsed(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_syscall_used", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_capability_used": {
-			cel.Overload(
-				"cp_was_capability_used", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_capability_used")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasCapabilityUsed(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_capability_used", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_endpoint_accessed": {
-			cel.Overload(
-				"cp_was_endpoint_accessed", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_endpoint_accessed")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasEndpointAccessed(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_endpoint_accessed", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_endpoint_accessed_with_method": {
-			cel.Overload(
-				"cp_was_endpoint_accessed_with_method", []*cel.Type{cel.StringType, cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 3 {
-						return types.NewErr("expected 3 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_endpoint_accessed_with_method")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasEndpointAccessedWithMethod(args[0], args[1], args[2])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_endpoint_accessed_with_method", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_endpoint_accessed_with_methods": {
-			cel.Overload(
-				"cp_was_endpoint_accessed_with_methods", []*cel.Type{cel.StringType, cel.StringType, cel.ListType(cel.StringType)}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 3 {
-						return types.NewErr("expected 3 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_endpoint_accessed_with_methods")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasEndpointAccessedWithMethods(args[0], args[1], args[2])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_endpoint_accessed_with_methods", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_endpoint_accessed_with_prefix": {
-			cel.Overload(
-				"cp_was_endpoint_accessed_with_prefix", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_endpoint_accessed_with_prefix")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasEndpointAccessedWithPrefix(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_endpoint_accessed_with_prefix", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_endpoint_accessed_with_suffix": {
-			cel.Overload(
-				"cp_was_endpoint_accessed_with_suffix", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_endpoint_accessed_with_suffix")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasEndpointAccessedWithSuffix(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_endpoint_accessed_with_suffix", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_host_accessed": {
-			cel.Overload(
-				"cp_was_host_accessed", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_host_accessed")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasHostAccessed(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_host_accessed", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
+		}
 	}
+	return decls
+}
+
+func (l *containerProfileLibrary) Declarations() map[string][]cel.FunctionOpt {
+	return l.declarationsWithPrefix("cp.", "cp")
 }
 
 func (l *containerProfileLibrary) CompileOptions() []cel.EnvOption {
@@ -337,6 +252,65 @@ func (l *containerProfileLibrary) ProgramOptions() []cel.ProgramOption {
 
 func (l *containerProfileLibrary) CostEstimator() checker.CostEstimator {
 	return &containerProfileCostEstimator{}
+}
+
+// legacyContainerProfileLibrary re-exposes a containerProfileLibrary's
+// funcSpecs under a legacy namespace prefix (e.g. "ap."). See AP() above.
+type legacyContainerProfileLibrary struct {
+	base   *containerProfileLibrary
+	name   string // LibraryName(), e.g. "ap"
+	prefix string // function-name prefix, e.g. "ap."
+}
+
+func (l *legacyContainerProfileLibrary) LibraryName() string {
+	return l.name
+}
+
+func (l *legacyContainerProfileLibrary) Types() []*cel.Type {
+	return l.base.Types()
+}
+
+func (l *legacyContainerProfileLibrary) Declarations() map[string][]cel.FunctionOpt {
+	return l.base.declarationsWithPrefix(l.prefix, strings.TrimSuffix(l.prefix, "."))
+}
+
+func (l *legacyContainerProfileLibrary) CompileOptions() []cel.EnvOption {
+	options := []cel.EnvOption{}
+	for name, overloads := range l.Declarations() {
+		options = append(options, cel.Function(name, overloads...))
+	}
+	return options
+}
+
+func (l *legacyContainerProfileLibrary) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+// CostEstimator translates the legacy function name back to its canonical
+// "cp." form and delegates to the base library's estimator, so ap.* calls
+// get the same cost estimate as their cp.* equivalent.
+func (l *legacyContainerProfileLibrary) CostEstimator() checker.CostEstimator {
+	return &legacyCostEstimator{inner: l.base.CostEstimator(), legacyPrefix: l.prefix, canonicalPrefix: "cp."}
+}
+
+// legacyCostEstimator adapts a checker.CostEstimator built for the "cp."
+// namespace so it also answers for a legacy-prefixed function name by
+// translating the prefix before delegating.
+type legacyCostEstimator struct {
+	inner           checker.CostEstimator
+	legacyPrefix    string
+	canonicalPrefix string
+}
+
+func (e *legacyCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	if strings.HasPrefix(function, e.legacyPrefix) {
+		function = e.canonicalPrefix + strings.TrimPrefix(function, e.legacyPrefix)
+	}
+	return e.inner.EstimateCallCost(function, overloadID, target, args)
+}
+
+func (e *legacyCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+	return e.inner.EstimateSize(element)
 }
 
 // containerProfileCostEstimator implements the checker.CostEstimator for the 'cp' library.
@@ -416,4 +390,6 @@ func (e *containerProfileCostEstimator) EstimateSize(element checker.AstNode) *c
 
 // Ensure the implementation satisfies the interface
 var _ checker.CostEstimator = (*containerProfileCostEstimator)(nil)
+var _ checker.CostEstimator = (*legacyCostEstimator)(nil)
 var _ libraries.Library = (*containerProfileLibrary)(nil)
+var _ libraries.Library = (*legacyContainerProfileLibrary)(nil)

--- a/pkg/rulemanager/cel/libraries/containerprofile/legacy_test.go
+++ b/pkg/rulemanager/cel/libraries/containerprofile/legacy_test.go
@@ -1,0 +1,260 @@
+package containerprofile
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/goradd/maps"
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	objectcachev1 "github.com/kubescape/node-agent/pkg/objectcache/v1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/kubescape/storage/pkg/registry/file/dynamicpathdetector"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLegacyAPDeclarationsMirrorCP is a drift guard: AP() must expose
+// exactly the cp.* function set under the ap. prefix, one-for-one, with no
+// functions gained or lost, and every ap.* overload id must be unique from
+// its cp.* counterpart (cel-go requires overload ids to be unique per
+// environment). If this test needs updating because Declarations() changed,
+// the same update belongs in TestDeclarationsCompileEachOverload.
+func TestLegacyAPDeclarationsMirrorCP(t *testing.T) {
+	objCache := objectcachev1.RuleObjectCacheMock{}
+	base := New(&objCache, config.Config{}).(*containerProfileLibrary)
+	alias := &legacyContainerProfileLibrary{base: base, name: "ap", prefix: "ap."}
+
+	wantNames := make([]string, 0)
+	for name := range base.Declarations() {
+		wantNames = append(wantNames, "ap."+strings.TrimPrefix(name, "cp."))
+	}
+	gotNames := make([]string, 0)
+	for name := range alias.Declarations() {
+		gotNames = append(gotNames, name)
+	}
+	sort.Strings(wantNames)
+	sort.Strings(gotNames)
+	assert.Equal(t, wantNames, gotNames, "ap.* alias set must exactly mirror cp.*'s declared functions")
+	assert.Equal(t, "ap", alias.LibraryName())
+
+	// Registering both namespaces in one env must not collide (this is what
+	// blows up at cel.NewEnv/env.Program time if overload ids aren't unique).
+	_, err := cel.NewEnv(CP(&objCache, config.Config{}), AP(&objCache, config.Config{}))
+	assert.NoError(t, err, "cp.* and ap.* must register into the same env without overload id collisions")
+}
+
+// TestLegacyAPMatchesCP_ExecOpenSyscallCapability proves that the ap.*
+// aliases for the exec/open/syscall/capability helpers evaluate identically
+// to their cp.* equivalents against the same ContainerProfile data — and
+// that cp.* itself is unaffected by AP() also being registered in the env
+// (regression guard for #864's cp.* namespace).
+func TestLegacyAPMatchesCP_ExecOpenSyscallCapability(t *testing.T) {
+	objCache := objectcachev1.RuleObjectCacheMock{
+		ContainerIDToSharedData: maps.NewSafeMap[string, *objectcache.WatchedContainerData](),
+	}
+	objCache.SetSharedContainerData("test-container-id", &objectcache.WatchedContainerData{
+		ContainerType: objectcache.Container,
+		ContainerInfos: map[objectcache.ContainerType][]objectcache.ContainerInfo{
+			objectcache.Container: {{Name: "test-container"}},
+		},
+	})
+
+	profile := &v1beta1.ContainerProfile{}
+	profile.Spec = v1beta1.ContainerProfileSpec{
+		Execs: []v1beta1.ExecCalls{
+			{Path: "/bin/bash", Args: []string{"/bin/bash", "-c", "curl http://example.com"}},
+		},
+		Opens: []v1beta1.OpenCalls{
+			{Path: "/etc/passwd", Flags: []string{"O_RDONLY"}},
+		},
+		Syscalls: []string{"open", "read", "execve"},
+		Capabilities: []string{
+			"NET_ADMIN", "SYS_ADMIN",
+		},
+	}
+	objCache.SetContainerProfile(profile)
+
+	env, err := cel.NewEnv(
+		cel.Variable("containerID", cel.StringType),
+		CP(&objCache, config.Config{}),
+		AP(&objCache, config.Config{}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create env: %v", err)
+	}
+
+	testCases := []struct {
+		name string
+		cp   string
+		ap   string
+		want bool
+	}{
+		{
+			name: "was_executed",
+			cp:   `cp.was_executed(containerID, "/bin/bash")`,
+			ap:   `ap.was_executed(containerID, "/bin/bash")`,
+			want: true,
+		},
+		{
+			name: "was_executed (miss)",
+			cp:   `cp.was_executed(containerID, "/bin/nonexistent")`,
+			ap:   `ap.was_executed(containerID, "/bin/nonexistent")`,
+			want: false,
+		},
+		{
+			name: "was_executed_with_args",
+			cp:   `cp.was_executed_with_args(containerID, "/bin/bash", ["/bin/bash", "-c", "curl http://example.com"])`,
+			ap:   `ap.was_executed_with_args(containerID, "/bin/bash", ["/bin/bash", "-c", "curl http://example.com"])`,
+			want: true,
+		},
+		{
+			name: "was_path_opened",
+			cp:   `cp.was_path_opened(containerID, "/etc/passwd")`,
+			ap:   `ap.was_path_opened(containerID, "/etc/passwd")`,
+			want: true,
+		},
+		{
+			name: "was_path_opened_with_flags",
+			cp:   `cp.was_path_opened_with_flags(containerID, "/etc/passwd", ["O_RDONLY"])`,
+			ap:   `ap.was_path_opened_with_flags(containerID, "/etc/passwd", ["O_RDONLY"])`,
+			want: true,
+		},
+		{
+			name: "was_path_opened_with_suffix",
+			cp:   `cp.was_path_opened_with_suffix(containerID, "passwd")`,
+			ap:   `ap.was_path_opened_with_suffix(containerID, "passwd")`,
+			want: true,
+		},
+		{
+			name: "was_path_opened_with_prefix",
+			cp:   `cp.was_path_opened_with_prefix(containerID, "/etc/")`,
+			ap:   `ap.was_path_opened_with_prefix(containerID, "/etc/")`,
+			want: true,
+		},
+		{
+			name: "was_syscall_used",
+			cp:   `cp.was_syscall_used(containerID, "execve")`,
+			ap:   `ap.was_syscall_used(containerID, "execve")`,
+			want: true,
+		},
+		{
+			name: "was_capability_used",
+			cp:   `cp.was_capability_used(containerID, "SYS_ADMIN")`,
+			ap:   `ap.was_capability_used(containerID, "SYS_ADMIN")`,
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cpResult := evalBool(t, env, tc.cp, map[string]interface{}{"containerID": "test-container-id"})
+			apResult := evalBool(t, env, tc.ap, map[string]interface{}{"containerID": "test-container-id"})
+			assert.Equal(t, tc.want, cpResult, "cp.* result for %s", tc.name)
+			assert.Equal(t, cpResult, apResult, "ap.* must match cp.* for %s", tc.name)
+		})
+	}
+}
+
+// TestLegacyAPMatchesCP_HTTPAndHost covers the remaining ap.* helpers
+// (endpoint + host predicates) against a projected profile, proving the
+// ap.* aliases evaluate identically to cp.*.
+func TestLegacyAPMatchesCP_HTTPAndHost(t *testing.T) {
+	pcp := endpointsPCP(
+		[]string{"/v1/api/users", "http://api.example.com/health"},
+		[]string{"/v1/api/orders/" + dynamicpathdetector.DynamicIdentifier},
+	)
+	objCache := &mockObjectCacheForPattern{pcp: pcp}
+
+	env, err := cel.NewEnv(
+		cel.Variable("containerID", cel.StringType),
+		CP(objCache, config.Config{}),
+		AP(objCache, config.Config{}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create env: %v", err)
+	}
+
+	testCases := []struct {
+		name string
+		cp   string
+		ap   string
+		want bool
+	}{
+		{
+			name: "was_endpoint_accessed",
+			cp:   `cp.was_endpoint_accessed(containerID, "/v1/api/users")`,
+			ap:   `ap.was_endpoint_accessed(containerID, "/v1/api/users")`,
+			want: true,
+		},
+		{
+			name: "was_endpoint_accessed_with_method",
+			cp:   `cp.was_endpoint_accessed_with_method(containerID, "/v1/api/users", "GET")`,
+			ap:   `ap.was_endpoint_accessed_with_method(containerID, "/v1/api/users", "GET")`,
+			want: true,
+		},
+		{
+			name: "was_endpoint_accessed_with_methods",
+			cp:   `cp.was_endpoint_accessed_with_methods(containerID, "/v1/api/users", ["GET", "POST"])`,
+			ap:   `ap.was_endpoint_accessed_with_methods(containerID, "/v1/api/users", ["GET", "POST"])`,
+			want: true,
+		},
+		{
+			name: "was_endpoint_accessed_with_prefix",
+			cp:   `cp.was_endpoint_accessed_with_prefix(containerID, "/v1/api")`,
+			ap:   `ap.was_endpoint_accessed_with_prefix(containerID, "/v1/api")`,
+			want: true,
+		},
+		{
+			name: "was_endpoint_accessed_with_suffix",
+			cp:   `cp.was_endpoint_accessed_with_suffix(containerID, "/health")`,
+			ap:   `ap.was_endpoint_accessed_with_suffix(containerID, "/health")`,
+			want: true,
+		},
+		{
+			name: "was_host_accessed",
+			cp:   `cp.was_host_accessed(containerID, "api.example.com")`,
+			ap:   `ap.was_host_accessed(containerID, "api.example.com")`,
+			want: true,
+		},
+		{
+			name: "was_endpoint_accessed (miss)",
+			cp:   `cp.was_endpoint_accessed(containerID, "/v1/api/secrets")`,
+			ap:   `ap.was_endpoint_accessed(containerID, "/v1/api/secrets")`,
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cpResult := evalBool(t, env, tc.cp, map[string]interface{}{"containerID": "cid"})
+			apResult := evalBool(t, env, tc.ap, map[string]interface{}{"containerID": "cid"})
+			assert.Equal(t, tc.want, cpResult, "cp.* result for %s", tc.name)
+			assert.Equal(t, cpResult, apResult, "ap.* must match cp.* for %s", tc.name)
+		})
+	}
+}
+
+// evalBool compiles and evaluates a CEL boolean expression against env,
+// failing the test on any compile/program/eval error.
+func evalBool(t *testing.T, env *cel.Env, expr string, activation map[string]interface{}) bool {
+	t.Helper()
+	ast, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		t.Fatalf("failed to compile %q: %v", expr, issues.Err())
+	}
+	program, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("failed to create program for %q: %v", expr, err)
+	}
+	out, _, err := program.Eval(activation)
+	if err != nil {
+		t.Fatalf("failed to eval %q: %v", expr, err)
+	}
+	result, ok := out.Value().(bool)
+	if !ok {
+		t.Fatalf("expr %q returned %T, expected bool", expr, out.Value())
+	}
+	return result
+}

--- a/pkg/rulemanager/cel/libraries/containerprofilenetwork/containerprofilenetwork.go
+++ b/pkg/rulemanager/cel/libraries/containerprofilenetwork/containerprofilenetwork.go
@@ -1,6 +1,8 @@
 package containerprofilenetwork
 
 import (
+	"strings"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types"
@@ -31,6 +33,26 @@ func CPNetwork(objectCache objectcache.ObjectCache, config config.Config, mm ...
 	return cel.Lib(New(objectCache, config, mm...))
 }
 
+// NN returns the deprecated "nn.*" backward-compat alias namespace for this
+// library's cp.* functions (e.g. nn.is_domain_in_egress,
+// nn.was_address_in_egress, ...).
+//
+// Deprecated: kubescape/node-agent#864 renamed the ap.*/nn.* CEL helper
+// namespaces to cp.* with no backward-compatible aliases, which silently
+// disabled any pre-existing user-authored CEL rule still referencing the old
+// names (pkg/utils/cel.go logs a warning and just skips the rule on compile
+// failure). NN restores those names for a transition window: it shares the
+// same containerProfileNetworkLibrary instance and the same funcSpecs table
+// as cp.*, so every nn.* call is wired to the exact same Go implementation
+// (l.wasAddressInEgress, l.isDomainInEgress, ...) as its cp.* equivalent —
+// only the CEL-facing function name and overload id differ (cel-go requires
+// overload ids to be unique per environment, so nn.* can't literally reuse
+// cp.*'s FunctionOpt values). Remove once user rules have migrated to cp.*.
+func NN(objectCache objectcache.ObjectCache, config config.Config, mm ...metricsmanager.MetricsManager) cel.EnvOption {
+	base := New(objectCache, config, mm...).(*containerProfileNetworkLibrary)
+	return cel.Lib(&legacyContainerProfileNetworkLibrary{base: base, name: "nn", prefix: "nn."})
+}
+
 type containerProfileNetworkLibrary struct {
 	objectCache     objectcache.ObjectCache
 	functionCache   *cache.FunctionCache
@@ -46,123 +68,118 @@ func (l *containerProfileNetworkLibrary) Types() []*cel.Type {
 	return []*cel.Type{}
 }
 
-func (l *containerProfileNetworkLibrary) Declarations() map[string][]cel.FunctionOpt {
-	return map[string][]cel.FunctionOpt{
-		"cp.was_address_in_egress": {
+// containerProfileNetworkFuncSpec describes one CEL helper's overload
+// signature and its (single, shared) Go implementation. Declarations()
+// below and the nn.* legacy alias both build their cel.FunctionOpt map from
+// this same table, so the two namespaces can never register a different
+// implementation for the "same" function name.
+type containerProfileNetworkFuncSpec struct {
+	// name is the function's suffix, e.g. "was_address_in_egress" (used
+	// after the "cp."/"nn." namespace prefix, and after the "cp_"/"nn_"
+	// overload-id prefix).
+	name       string
+	argTypes   []*cel.Type
+	resultType *cel.Type
+	arity      int
+	// call invokes the shared implementation method on l.
+	call func(l *containerProfileNetworkLibrary, args []ref.Val) ref.Val
+}
+
+var containerProfileNetworkFuncSpecs = []containerProfileNetworkFuncSpec{
+	{
+		name:       "was_address_in_egress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.wasAddressInEgress(a[0], a[1])
+		},
+	},
+	{
+		name:       "was_address_in_ingress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.wasAddressInIngress(a[0], a[1])
+		},
+	},
+	{
+		name:       "is_domain_in_egress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.isDomainInEgress(a[0], a[1])
+		},
+	},
+	{
+		name:       "is_domain_in_ingress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      2,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.isDomainInIngress(a[0], a[1])
+		},
+	},
+	{
+		name:       "was_address_port_protocol_in_egress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.IntType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      4,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.wasAddressPortProtocolInEgress(a[0], a[1], a[2], a[3])
+		},
+	},
+	{
+		name:       "was_address_port_protocol_in_ingress",
+		argTypes:   []*cel.Type{cel.StringType, cel.StringType, cel.IntType, cel.StringType},
+		resultType: cel.BoolType,
+		arity:      4,
+		call: func(l *containerProfileNetworkLibrary, a []ref.Val) ref.Val {
+			return l.wasAddressPortProtocolInIngress(a[0], a[1], a[2], a[3])
+		},
+	},
+}
+
+// declarationsWithPrefix builds the cel.FunctionOpt map for every function in
+// containerProfileNetworkFuncSpecs, exposed as "<namePrefix><spec.name>"
+// (e.g. "cp.was_address_in_egress" or "nn.was_address_in_egress") with
+// overload id "<overloadIDPrefix>_<spec.name>" (e.g.
+// "cp_was_address_in_egress" / "nn_was_address_in_egress" — cel-go requires
+// overload ids to be unique per environment, so the nn.* alias needs its own
+// ids even though it shares spec.call's implementation).
+func (l *containerProfileNetworkLibrary) declarationsWithPrefix(namePrefix, overloadIDPrefix string) map[string][]cel.FunctionOpt {
+	decls := make(map[string][]cel.FunctionOpt, len(containerProfileNetworkFuncSpecs))
+	for _, spec := range containerProfileNetworkFuncSpecs {
+		spec := spec
+		fullName := namePrefix + spec.name
+		overloadID := overloadIDPrefix + "_" + spec.name
+		decls[fullName] = []cel.FunctionOpt{
 			cel.Overload(
-				"cp_was_address_in_egress", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
+				overloadID, spec.argTypes, spec.resultType,
 				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
+					if len(values) != spec.arity {
+						return types.NewErr("expected %d arguments, got %d", spec.arity, len(values))
 					}
 					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_address_in_egress")
+						l.metrics.IncHelperCall(fullName)
 					}
 					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasAddressInEgress(args[0], args[1])
+						return spec.call(l, args)
 					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_address_in_egress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
+					cachedFunc := l.functionCache.WithCache(wrapperFunc, fullName, cache.HashForContainerProfile(l.objectCache))
+					result := cachedFunc(values...)
 					return cache.ConvertProfileNotAvailableErrToBool(result, false)
 				}),
 			),
-		},
-		"cp.was_address_in_ingress": {
-			cel.Overload(
-				"cp_was_address_in_ingress", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_address_in_ingress")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasAddressInIngress(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_address_in_ingress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.is_domain_in_egress": {
-			cel.Overload(
-				"cp_is_domain_in_egress", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.is_domain_in_egress")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.isDomainInEgress(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.is_domain_in_egress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.is_domain_in_ingress": {
-			cel.Overload(
-				"cp_is_domain_in_ingress", []*cel.Type{cel.StringType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 2 {
-						return types.NewErr("expected 2 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.is_domain_in_ingress")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.isDomainInIngress(args[0], args[1])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.is_domain_in_ingress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_address_port_protocol_in_egress": {
-			cel.Overload(
-				"cp_was_address_port_protocol_in_egress", []*cel.Type{cel.StringType, cel.StringType, cel.IntType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 4 {
-						return types.NewErr("expected 4 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_address_port_protocol_in_egress")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasAddressPortProtocolInEgress(args[0], args[1], args[2], args[3])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_address_port_protocol_in_egress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2], values[3])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
-		"cp.was_address_port_protocol_in_ingress": {
-			cel.Overload(
-				"cp_was_address_port_protocol_in_ingress", []*cel.Type{cel.StringType, cel.StringType, cel.IntType, cel.StringType}, cel.BoolType,
-				cel.FunctionBinding(func(values ...ref.Val) ref.Val {
-					if len(values) != 4 {
-						return types.NewErr("expected 4 arguments, got %d", len(values))
-					}
-					if l.detailedMetrics && l.metrics != nil {
-						l.metrics.IncHelperCall("cp.was_address_port_protocol_in_ingress")
-					}
-					wrapperFunc := func(args ...ref.Val) ref.Val {
-						return l.wasAddressPortProtocolInIngress(args[0], args[1], args[2], args[3])
-					}
-					cachedFunc := l.functionCache.WithCache(wrapperFunc, "cp.was_address_port_protocol_in_ingress", cache.HashForContainerProfile(l.objectCache))
-					result := cachedFunc(values[0], values[1], values[2], values[3])
-					return cache.ConvertProfileNotAvailableErrToBool(result, false)
-				}),
-			),
-		},
+		}
 	}
+	return decls
+}
+
+func (l *containerProfileNetworkLibrary) Declarations() map[string][]cel.FunctionOpt {
+	return l.declarationsWithPrefix("cp.", "cp")
 }
 
 func (l *containerProfileNetworkLibrary) CompileOptions() []cel.EnvOption {
@@ -179,6 +196,66 @@ func (l *containerProfileNetworkLibrary) ProgramOptions() []cel.ProgramOption {
 
 func (l *containerProfileNetworkLibrary) CostEstimator() checker.CostEstimator {
 	return &containerProfileNetworkCostEstimator{}
+}
+
+// legacyContainerProfileNetworkLibrary re-exposes a
+// containerProfileNetworkLibrary's funcSpecs under a legacy namespace prefix
+// (e.g. "nn."). See NN() above.
+type legacyContainerProfileNetworkLibrary struct {
+	base   *containerProfileNetworkLibrary
+	name   string // LibraryName(), e.g. "nn"
+	prefix string // function-name prefix, e.g. "nn."
+}
+
+func (l *legacyContainerProfileNetworkLibrary) LibraryName() string {
+	return l.name
+}
+
+func (l *legacyContainerProfileNetworkLibrary) Types() []*cel.Type {
+	return l.base.Types()
+}
+
+func (l *legacyContainerProfileNetworkLibrary) Declarations() map[string][]cel.FunctionOpt {
+	return l.base.declarationsWithPrefix(l.prefix, strings.TrimSuffix(l.prefix, "."))
+}
+
+func (l *legacyContainerProfileNetworkLibrary) CompileOptions() []cel.EnvOption {
+	options := []cel.EnvOption{}
+	for name, overloads := range l.Declarations() {
+		options = append(options, cel.Function(name, overloads...))
+	}
+	return options
+}
+
+func (l *legacyContainerProfileNetworkLibrary) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{}
+}
+
+// CostEstimator translates the legacy function name back to its canonical
+// "cp." form and delegates to the base library's estimator, so nn.* calls
+// get the same cost estimate as their cp.* equivalent.
+func (l *legacyContainerProfileNetworkLibrary) CostEstimator() checker.CostEstimator {
+	return &legacyNetworkCostEstimator{inner: l.base.CostEstimator(), legacyPrefix: l.prefix, canonicalPrefix: "cp."}
+}
+
+// legacyNetworkCostEstimator adapts a checker.CostEstimator built for the
+// "cp." namespace so it also answers for a legacy-prefixed function name by
+// translating the prefix before delegating.
+type legacyNetworkCostEstimator struct {
+	inner           checker.CostEstimator
+	legacyPrefix    string
+	canonicalPrefix string
+}
+
+func (e *legacyNetworkCostEstimator) EstimateCallCost(function, overloadID string, target *checker.AstNode, args []checker.AstNode) *checker.CallEstimate {
+	if strings.HasPrefix(function, e.legacyPrefix) {
+		function = e.canonicalPrefix + strings.TrimPrefix(function, e.legacyPrefix)
+	}
+	return e.inner.EstimateCallCost(function, overloadID, target, args)
+}
+
+func (e *legacyNetworkCostEstimator) EstimateSize(element checker.AstNode) *checker.SizeEstimate {
+	return e.inner.EstimateSize(element)
 }
 
 // containerProfileNetworkCostEstimator implements the checker.CostEstimator for the 'cpnetwork' library.
@@ -208,4 +285,6 @@ func (e *containerProfileNetworkCostEstimator) EstimateSize(element checker.AstN
 
 // Ensure the implementation satisfies the interface
 var _ checker.CostEstimator = (*containerProfileNetworkCostEstimator)(nil)
+var _ checker.CostEstimator = (*legacyNetworkCostEstimator)(nil)
 var _ libraries.Library = (*containerProfileNetworkLibrary)(nil)
+var _ libraries.Library = (*legacyContainerProfileNetworkLibrary)(nil)

--- a/pkg/rulemanager/cel/libraries/containerprofilenetwork/legacy_test.go
+++ b/pkg/rulemanager/cel/libraries/containerprofilenetwork/legacy_test.go
@@ -1,0 +1,174 @@
+package containerprofilenetwork
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/goradd/maps"
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	objectcachev1 "github.com/kubescape/node-agent/pkg/objectcache/v1"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+// TestLegacyNNDeclarationsMirrorCP is a drift guard: NN() must expose
+// exactly the cp.* function set under the nn. prefix, one-for-one, with no
+// functions gained or lost, and every nn.* overload id must be unique from
+// its cp.* counterpart (cel-go requires overload ids to be unique per
+// environment).
+func TestLegacyNNDeclarationsMirrorCP(t *testing.T) {
+	objCache := objectcachev1.RuleObjectCacheMock{}
+	base := New(&objCache, config.Config{}).(*containerProfileNetworkLibrary)
+	alias := &legacyContainerProfileNetworkLibrary{base: base, name: "nn", prefix: "nn."}
+
+	wantNames := make([]string, 0)
+	for name := range base.Declarations() {
+		wantNames = append(wantNames, "nn."+strings.TrimPrefix(name, "cp."))
+	}
+	gotNames := make([]string, 0)
+	for name := range alias.Declarations() {
+		gotNames = append(gotNames, name)
+	}
+	sort.Strings(wantNames)
+	sort.Strings(gotNames)
+	assert.Equal(t, wantNames, gotNames, "nn.* alias set must exactly mirror cp.*'s declared functions")
+	assert.Equal(t, "nn", alias.LibraryName())
+
+	// Registering both namespaces in one env must not collide.
+	_, err := cel.NewEnv(CPNetwork(&objCache, config.Config{}), NN(&objCache, config.Config{}))
+	assert.NoError(t, err, "cp.* and nn.* must register into the same env without overload id collisions")
+}
+
+// TestLegacyNNMatchesCP proves that every nn.* alias evaluates identically
+// to its cp.* equivalent against the same ContainerProfile egress/ingress
+// data — and that cp.* itself is unaffected by NN() also being registered
+// (regression guard for #864's cp.* namespace). Covers all 6 nn.* helpers.
+func TestLegacyNNMatchesCP(t *testing.T) {
+	objCache := objectcachev1.RuleObjectCacheMock{
+		ContainerIDToSharedData: maps.NewSafeMap[string, *objectcache.WatchedContainerData](),
+	}
+	objCache.SetSharedContainerData("test-container-id", &objectcache.WatchedContainerData{
+		ContainerType: objectcache.Container,
+		ContainerInfos: map[objectcache.ContainerType][]objectcache.ContainerInfo{
+			objectcache.Container: {{Name: "test-container"}},
+		},
+	})
+
+	profile := &v1beta1.ContainerProfile{}
+	profile.Spec = v1beta1.ContainerProfileSpec{
+		Egress: []v1beta1.NetworkNeighbor{
+			{
+				IPAddress: "192.168.1.100",
+				DNSNames:  []string{"api.example.com"},
+				Ports: []v1beta1.NetworkPort{
+					{Name: "tcp-80", Protocol: "TCP", Port: ptr.To(int32(80))},
+				},
+			},
+		},
+		Ingress: []v1beta1.NetworkNeighbor{
+			{
+				IPAddress: "172.16.0.10",
+				DNSNames:  []string{"loadbalancer.example.com"},
+				Ports: []v1beta1.NetworkPort{
+					{Name: "tcp-8080", Protocol: "TCP", Port: ptr.To(int32(8080))},
+				},
+			},
+		},
+	}
+	objCache.SetContainerProfile(profile)
+
+	env, err := cel.NewEnv(
+		cel.Variable("containerID", cel.StringType),
+		CPNetwork(&objCache, config.Config{}),
+		NN(&objCache, config.Config{}),
+	)
+	if err != nil {
+		t.Fatalf("failed to create env: %v", err)
+	}
+
+	testCases := []struct {
+		name string
+		cp   string
+		nn   string
+		want bool
+	}{
+		{
+			name: "was_address_in_egress",
+			cp:   `cp.was_address_in_egress(containerID, "192.168.1.100")`,
+			nn:   `nn.was_address_in_egress(containerID, "192.168.1.100")`,
+			want: true,
+		},
+		{
+			name: "was_address_in_egress (miss)",
+			cp:   `cp.was_address_in_egress(containerID, "10.0.0.1")`,
+			nn:   `nn.was_address_in_egress(containerID, "10.0.0.1")`,
+			want: false,
+		},
+		{
+			name: "was_address_in_ingress",
+			cp:   `cp.was_address_in_ingress(containerID, "172.16.0.10")`,
+			nn:   `nn.was_address_in_ingress(containerID, "172.16.0.10")`,
+			want: true,
+		},
+		{
+			name: "is_domain_in_egress",
+			cp:   `cp.is_domain_in_egress(containerID, "api.example.com")`,
+			nn:   `nn.is_domain_in_egress(containerID, "api.example.com")`,
+			want: true,
+		},
+		{
+			name: "is_domain_in_ingress",
+			cp:   `cp.is_domain_in_ingress(containerID, "loadbalancer.example.com")`,
+			nn:   `nn.is_domain_in_ingress(containerID, "loadbalancer.example.com")`,
+			want: true,
+		},
+		{
+			name: "was_address_port_protocol_in_egress",
+			cp:   `cp.was_address_port_protocol_in_egress(containerID, "192.168.1.100", 80, "TCP")`,
+			nn:   `nn.was_address_port_protocol_in_egress(containerID, "192.168.1.100", 80, "TCP")`,
+			want: true,
+		},
+		{
+			name: "was_address_port_protocol_in_ingress",
+			cp:   `cp.was_address_port_protocol_in_ingress(containerID, "172.16.0.10", 8080, "TCP")`,
+			nn:   `nn.was_address_port_protocol_in_ingress(containerID, "172.16.0.10", 8080, "TCP")`,
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cpResult := evalBool(t, env, tc.cp, map[string]interface{}{"containerID": "test-container-id"})
+			nnResult := evalBool(t, env, tc.nn, map[string]interface{}{"containerID": "test-container-id"})
+			assert.Equal(t, tc.want, cpResult, "cp.* result for %s", tc.name)
+			assert.Equal(t, cpResult, nnResult, "nn.* must match cp.* for %s", tc.name)
+		})
+	}
+}
+
+// evalBool compiles and evaluates a CEL boolean expression against env,
+// failing the test on any compile/program/eval error.
+func evalBool(t *testing.T, env *cel.Env, expr string, activation map[string]interface{}) bool {
+	t.Helper()
+	ast, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		t.Fatalf("failed to compile %q: %v", expr, issues.Err())
+	}
+	program, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("failed to create program for %q: %v", expr, err)
+	}
+	out, _, err := program.Eval(activation)
+	if err != nil {
+		t.Fatalf("failed to eval %q: %v", expr, err)
+	}
+	result, ok := out.Value().(bool)
+	if !ok {
+		t.Fatalf("expr %q returned %T, expected bool", expr, out.Value())
+	}
+	return result
+}


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

#864 renamed the CEL rule-library namespaces used by user-authored detection rules from `ap.*`/`nn.*` to `cp.*` with no backward-compatible aliases, so any pre-existing customer rule still using the old names now silently stops compiling (and silently stops detecting anything — `pkg/utils/cel.go` just logs a warning on compile failure). This PR restores `ap.*`/`nn.*` as deprecated aliases of the same `cp.*` implementations for a transition window.

## Overview

CEL rules are loaded from CRDs at runtime, i.e. users can (and do) author their own rules. Any pre-existing customer rule that still references the old `ap.`/`nn.` function names now fails to compile. On a compile failure, `pkg/utils/cel.go` just logs `logger.L().Warning("CEL expression disabled: failed to compile", ...)` and disables the expression — a silent fail-open. The rule doesn't error loudly, it just stops detecting anything, and nobody is told.

This PR closes that gap by registering the same helper functions under **both** namespaces for a transition/deprecation window:

- `cp.*` (unchanged, still the canonical/recommended namespace used by this project's own shipped default rules)
- `ap.*` / `nn.*` (new: deprecated backward-compat aliases)

### Aliased functions

**`ap.*` (14, in `pkg/rulemanager/cel/libraries/containerprofile`):** `was_executed`, `was_executed_with_args`, `was_path_opened`, `was_path_opened_with_flags`, `was_path_opened_with_suffix`, `was_path_opened_with_prefix`, `was_syscall_used`, `was_capability_used`, `was_endpoint_accessed`, `was_endpoint_accessed_with_method`, `was_endpoint_accessed_with_methods`, `was_endpoint_accessed_with_prefix`, `was_endpoint_accessed_with_suffix`, `was_host_accessed`.

**`nn.*` (6, in `pkg/rulemanager/cel/libraries/containerprofilenetwork`):** `was_address_in_egress`, `was_address_in_ingress`, `is_domain_in_egress`, `is_domain_in_ingress`, `was_address_port_protocol_in_egress`, `was_address_port_protocol_in_ingress`.

### Implementation notes

- Both `containerprofile.go` and `containerprofilenetwork.go` were refactored from a hand-written `map[string][]cel.FunctionOpt` literal into a small `funcSpec` table (one entry per helper: name suffix, arg types, arity, and a closure calling the existing implementation method, e.g. `l.wasExecuted`). `Declarations()` and the new `AP()`/`NN()` alias both build their function map from that *same* table, so the `cp.*` and legacy namespaces can never end up calling a different implementation for "the same" function — there is exactly one place the detection logic lives.
- `cel-go` requires overload ids to be unique per environment (not just per function name) — reusing a `cp.*` function's `cel.FunctionOpt` verbatim under an `ap.`/`nn.` name causes an `overload already exists` panic at `env.Program()` time once both namespaces are registered together. So the alias registers its own overload ids (`ap_*`/`nn_*`) — only this CEL-facing glue is duplicated, not the actual predicate logic.
- `AP()`/`NN()` and the registration in `cel.go` are commented as deprecated: the expectation is these get removed in a future release once users have migrated their rules to `cp.*`.
- No behavior change to `cp.*` itself; regression-covered by tests below.

### Tests

New tests in `pkg/rulemanager/cel/libraries/containerprofile/legacy_test.go` and `.../containerprofilenetwork/legacy_test.go`:

- `TestLegacyAPDeclarationsMirrorCP` / `TestLegacyNNDeclarationsMirrorCP`: drift guard — the alias's declared function set exactly mirrors `cp.*`'s (one-for-one), and both namespaces register into the same `cel.Env` without overload-id collisions.
- `TestLegacyAPMatchesCP_ExecOpenSyscallCapability` / `TestLegacyAPMatchesCP_HTTPAndHost`: all 14 `ap.*` helpers compile and evaluate against real `ContainerProfile` data, matching their `cp.*` equivalent's result on the same input (including a miss case), and confirm `cp.*` is unaffected by `ap.*` also being registered.
- `TestLegacyNNMatchesCP`: all 6 `nn.*` helpers, same approach, against egress/ingress `ContainerProfile` data.

`go test ./pkg/rulemanager/cel/...` and `./pkg/rulemanager/...` are green, including the new tests. `go build ./...`, `go vet ./...` are clean, and `gofmt -l` reports no issues on any file touched by this PR.

Related: #864

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backward-compatible `ap.*` aliases for container profile helpers.
  * Added backward-compatible `nn.*` aliases for container profile network helpers.
  * Legacy aliases provide the same results and validation as the existing `cp.*` functions.

* **Bug Fixes**
  * Prevented naming conflicts when legacy and current namespaces are used together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->