### PR TITLE
fix(hostsensormanager): stop matching decoy release files as os-release

### DIFF
--- a/pkg/hostsensormanager/sensor_osrelease.go
+++ b/pkg/hostsensormanager/sensor_osrelease.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -68,7 +67,7 @@ func (s *OsReleaseSensor) getOsReleaseFile() (string, error) {
 	var etcSons []string
 	for etcSons, err = etcDir.Readdirnames(100); err == nil; etcSons, err = etcDir.Readdirnames(100) {
 		for idx := range etcSons {
-			if strings.HasSuffix(etcSons[idx], osReleaseFileSuffix) {
+			if etcSons[idx] == osReleaseFileSuffix {
 				logger.L().Debug("os release file found", helpers.String("filename", etcSons[idx]))
 				return etcSons[idx], nil
 			}

--- a/pkg/hostsensormanager/sensor_osrelease_test.go
+++ b/pkg/hostsensormanager/sensor_osrelease_test.go
@@ -1,0 +1,55 @@
+package hostsensormanager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOsReleaseFileIgnoresDecoyReleaseFiles(t *testing.T) {
+	tmp := t.TempDir()
+	etcDir := filepath.Join(tmp, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// centos-release ends with "os-release" as a substring but is a different,
+	// differently-formatted file. It must not be picked over the real one.
+	for _, name := range []string{"centos-release", "os-release"} {
+		if err := os.WriteFile(filepath.Join(etcDir, name), []byte("content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	origPrefix := hostFSPrefix
+	hostFSPrefix = tmp
+	defer func() { hostFSPrefix = origPrefix }()
+
+	s := &OsReleaseSensor{}
+	got, err := s.getOsReleaseFile()
+	if err != nil {
+		t.Fatalf("getOsReleaseFile() error = %v", err)
+	}
+	if got != "os-release" {
+		t.Errorf("getOsReleaseFile() = %q, want %q", got, "os-release")
+	}
+}
+
+func TestGetOsReleaseFileNotFoundAmongDecoysOnly(t *testing.T) {
+	tmp := t.TempDir()
+	etcDir := filepath.Join(tmp, "etc")
+	if err := os.MkdirAll(etcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(etcDir, "centos-release"), []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origPrefix := hostFSPrefix
+	hostFSPrefix = tmp
+	defer func() { hostFSPrefix = origPrefix }()
+
+	s := &OsReleaseSensor{}
+	if _, err := s.getOsReleaseFile(); err == nil {
+		t.Error("getOsReleaseFile() expected an error when only a decoy file is present, got nil")
+	}
+}


### PR DESCRIPTION
## Overview

`getOsReleaseFile` picks the /etc entry whose name ends in `os-release`. On RHEL-family hosts that also match `centos-release`, `redhat-release`, etc, since they end with the same substring. `Readdirnames` doesn't guarantee ordering, so which file wins can vary between runs, and those distro files aren't KEY=VALUE formatted like the real os-release, so whatever consumes `OsReleaseFileSpec.Content` downstream ends up parsing the wrong thing.

Switched to an exact filename match, since there's only one file we actually want here.

## How to Test

Added a test that seeds a temp /etc with both `centos-release` and `os-release` present and asserts the real one wins, plus a case with only the decoy present. Confirmed the first test fails against the old `HasSuffix` check and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS release detection to select only the exact `os-release` file.
  * Prevented similarly named files from being incorrectly identified as the operating system release file.
  * Added error handling when no valid `os-release` file is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->