### PR TITLE
test: add unit tests for malwaremanager, healthmanager, and nodeprofilemanager

### DIFF
--- a/pkg/healthmanager/health_manager_test.go
+++ b/pkg/healthmanager/health_manager_test.go
@@ -1,0 +1,99 @@
+package healthmanager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubescape/node-agent/pkg/containerwatcher"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockUnreadyWatcher struct {
+	containerwatcher.ContainerWatcherMock
+}
+
+func (m *mockUnreadyWatcher) Ready() bool {
+	return false
+}
+
+func TestNewHealthManager(t *testing.T) {
+	hm := NewHealthManager()
+	assert.NotNil(t, hm)
+	assert.Equal(t, 7888, hm.port)
+	assert.Nil(t, hm.containerWatcher)
+}
+
+func TestLivenessProbe_AlwaysReturnsOK(t *testing.T) {
+	hm := NewHealthManager()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", nil)
+	w := httptest.NewRecorder()
+
+	hm.livenessProbe(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestReadinessProbe(t *testing.T) {
+	tests := []struct {
+		name           string
+		setWatcher     bool
+		isReady        bool
+		expectedStatus int
+	}{
+		{
+			name:           "nil container watcher returns 500",
+			setWatcher:     false,
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "unready container watcher returns 500",
+			setWatcher:     true,
+			isReady:        false,
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name:           "container watcher ready returns 200",
+			setWatcher:     true,
+			isReady:        true,
+			expectedStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hm := NewHealthManager()
+
+			if tt.setWatcher {
+				if tt.isReady {
+					hm.SetContainerWatcher(&containerwatcher.ContainerWatcherMock{})
+				} else {
+					hm.SetContainerWatcher(&mockUnreadyWatcher{})
+				}
+			}
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+			w := httptest.NewRecorder()
+
+			hm.readinessProbe(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestSetContainerWatcher(t *testing.T) {
+	hm := NewHealthManager()
+	assert.Nil(t, hm.containerWatcher)
+
+	mock := &containerwatcher.ContainerWatcherMock{}
+	hm.SetContainerWatcher(mock)
+
+	assert.NotNil(t, hm.containerWatcher)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", nil)
+	w := httptest.NewRecorder()
+	hm.readinessProbe(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/pkg/malwaremanager/v1/malware_manager_test.go
+++ b/pkg/malwaremanager/v1/malware_manager_test.go
@@ -1,0 +1,271 @@
+package malwaremanager
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/exporters"
+	"github.com/kubescape/node-agent/pkg/malwaremanager"
+	"github.com/kubescape/node-agent/pkg/metricsmanager"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/node-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
+	igtypes "github.com/inspektor-gadget/inspektor-gadget/pkg/types"
+	malwaretypes "github.com/kubescape/node-agent/pkg/malwaremanager/v1/types"
+)
+
+type mockMalwareScanner struct {
+	result malwaremanager.MalwareResult
+}
+
+func (m *mockMalwareScanner) Scan(_ utils.EventType, _ utils.K8sEvent, _ uint32) malwaremanager.MalwareResult {
+	return m.result
+}
+
+type trackingExporter struct {
+	exporters.ExporterMock
+	malwareAlerts []malwaremanager.MalwareResult
+}
+
+func (e *trackingExporter) SendMalwareAlert(result malwaremanager.MalwareResult) {
+	e.malwareAlerts = append(e.malwareAlerts, result)
+}
+
+func newTestMalwareManager(scanners []malwaremanager.MalwareScanner, exp exporters.Exporter) *MalwareManager {
+	return &MalwareManager{
+		cfg:             config.Config{},
+		malwareScanners: scanners,
+		exporter:        exp,
+		k8sClient:       nil,
+		nodeName:        "test-node",
+		clusterName:     "test-cluster",
+		metrics:         metricsmanager.NewMetricsMock(),
+		k8sObjectCache:  &objectcache.K8sObjectCacheMock{},
+	}
+}
+
+func TestCreateMalwareManager_NoClamAV(t *testing.T) {
+	orig, present := os.LookupEnv("CLAMAV_SOCKET")
+	if present {
+		require.NoError(t, os.Unsetenv("CLAMAV_SOCKET"))
+		t.Cleanup(func() {
+			assert.NoError(t, os.Setenv("CLAMAV_SOCKET", orig))
+		})
+	}
+
+	cfg := config.Config{}
+	mm, err := CreateMalwareManager(
+		cfg, nil, "node-1", "cluster-1",
+		&exporters.ExporterMock{},
+		metricsmanager.NewMetricsMock(),
+		&objectcache.K8sObjectCacheMock{},
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, mm)
+	assert.Equal(t, "node-1", mm.nodeName)
+	assert.Equal(t, "cluster-1", mm.clusterName)
+}
+
+func TestReportEvent_ExecType(t *testing.T) {
+	exp := &trackingExporter{}
+	scanner := &mockMalwareScanner{
+		result: &malwaretypes.GenericMalwareResult{
+			BasicRuntimeAlert: armotypes.BaseRuntimeAlert{
+				AlertName: "Trojan.Test",
+				Severity:  10,
+			},
+			RuntimeProcessDetails: armotypes.ProcessTree{
+				ProcessTree: armotypes.Process{
+					PID:  12345,
+					Comm: "malware",
+				},
+				ContainerID: "container-1",
+			},
+			TriggerEvent: &utils.StructEvent{
+				ContainerID: "container-1",
+				Namespace:   "default",
+				Pod:         "test-pod",
+				Container:   "test-container",
+			},
+			MalwareRuntimeAlert: armotypes.MalwareAlert{
+				MalwareDescription: "Test malware",
+			},
+			RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
+				ContainerID: "container-1",
+				Namespace:   "default",
+				PodName:     "test-pod",
+			},
+		},
+	}
+
+	mm := newTestMalwareManager([]malwaremanager.MalwareScanner{scanner}, exp)
+
+	mm.containerIdToPid.Set("container-1", uint32(100))
+
+	event := &utils.StructEvent{
+		EventType:   utils.ExecveEventType,
+		ContainerID: "container-1",
+		Namespace:   "default",
+		Pod:         "test-pod",
+	}
+
+	mm.ReportEvent(utils.ExecveEventType, event)
+
+	assert.Len(t, exp.malwareAlerts, 1)
+	assert.Equal(t, "Trojan.Test", exp.malwareAlerts[0].GetBasicRuntimeAlert().AlertName)
+}
+
+func TestReportEvent_OpenType(t *testing.T) {
+	exp := &trackingExporter{}
+	scanner := &mockMalwareScanner{result: nil}
+
+	mm := newTestMalwareManager([]malwaremanager.MalwareScanner{scanner}, exp)
+
+	event := &utils.StructEvent{
+		EventType:   utils.OpenEventType,
+		ContainerID: "container-1",
+		Namespace:   "default",
+		Pod:         "test-pod",
+		Path:        "/etc/passwd",
+	}
+
+	mm.ReportEvent(utils.OpenEventType, event)
+	assert.Empty(t, exp.malwareAlerts)
+}
+
+func TestReportEvent_InvalidEventType(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+
+	event := &utils.StructEvent{
+		EventType:   utils.DnsEventType,
+		ContainerID: "container-1",
+	}
+
+	mm.ReportEvent(utils.DnsEventType, event)
+	assert.Empty(t, exp.malwareAlerts)
+}
+
+func TestReportEvent_UnsupportedEventType(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.ReportEvent("unknown", &utils.StructEvent{})
+	assert.Empty(t, exp.malwareAlerts)
+}
+
+func TestReportFileOpen_SkipsDirectories(t *testing.T) {
+	exp := &trackingExporter{}
+	scanner := &mockMalwareScanner{
+		result: &malwaretypes.GenericMalwareResult{
+			BasicRuntimeAlert: armotypes.BaseRuntimeAlert{AlertName: "should-not-be-reached"},
+			TriggerEvent: &utils.StructEvent{
+				ContainerID: "container-1",
+			},
+			RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
+				ContainerID: "container-1",
+			},
+		},
+	}
+
+	mm := newTestMalwareManager([]malwaremanager.MalwareScanner{scanner}, exp)
+
+	event := &utils.StructEvent{
+		EventType:   utils.OpenEventType,
+		ContainerID: "container-1",
+		Dir:         true,
+		Path:        "/tmp",
+	}
+
+	mm.reportFileOpen(event)
+
+	assert.Empty(t, exp.malwareAlerts)
+}
+
+func TestReportFileOpen_NoScanners(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+
+	event := &utils.StructEvent{
+		EventType:   utils.OpenEventType,
+		ContainerID: "container-1",
+		Path:        "/tmp/test.bin",
+	}
+
+	mm.reportFileOpen(event)
+
+	assert.Empty(t, exp.malwareAlerts)
+}
+
+func TestContainerCallback_AddRemove(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.cfg = config.Config{
+		InitialDelay:        1 * time.Second,
+		MaxJitterPercentage: 0,
+	}
+
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: "test-container-id",
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+
+	_, hasPid := mm.containerIdToPid.Load("test-container-id")
+	assert.True(t, hasPid)
+
+	// Remove container
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	_, hasPid = mm.containerIdToPid.Load("test-container-id")
+	assert.False(t, hasPid)
+}
+
+func TestContainerCallback_HostContainerIgnored(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+
+	hostContainer := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: "host-container-id",
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "",
+				PodName:   "",
+			},
+		},
+	}
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: hostContainer,
+	})
+
+	_, hasPid := mm.containerIdToPid.Load("host-container-id")
+	assert.False(t, hasPid)
+}

--- a/pkg/malwaremanager/v1/types/malwareresult_test.go
+++ b/pkg/malwaremanager/v1/types/malwareresult_test.go
@@ -1,0 +1,190 @@
+package malwaremanager
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/kubescape/node-agent/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenericMalwareResult_Getters(t *testing.T) {
+	gid := uint32(1000)
+	uid := uint32(500)
+	result := &GenericMalwareResult{
+		BasicRuntimeAlert: armotypes.BaseRuntimeAlert{
+			AlertName:      "Trojan.Test",
+			Severity:       10,
+			FixSuggestions: "remove it",
+			MD5Hash:        "abc123",
+			SHA1Hash:       "def456",
+		},
+		RuntimeProcessDetails: armotypes.ProcessTree{
+			ProcessTree: armotypes.Process{
+				Comm: "malicious",
+				Path: "/tmp/malware",
+				PID:  1234,
+				Gid:  &gid,
+				Uid:  &uid,
+			},
+			ContainerID: "container-abc",
+		},
+		MalwareRuntimeAlert: armotypes.MalwareAlert{
+			MalwareDescription: "Trojan.Test description",
+		},
+		RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
+			ContainerID:   "container-abc",
+			ContainerName: "test-container",
+			Namespace:     "default",
+			PodName:       "test-pod",
+		},
+	}
+
+	t.Run("GetBasicRuntimeAlert", func(t *testing.T) {
+		alert := result.GetBasicRuntimeAlert()
+		assert.Equal(t, "Trojan.Test", alert.AlertName)
+		assert.Equal(t, 10, alert.Severity)
+		assert.Equal(t, "remove it", alert.FixSuggestions)
+		assert.Equal(t, "abc123", alert.MD5Hash)
+		assert.Equal(t, "def456", alert.SHA1Hash)
+	})
+
+	t.Run("GetRuntimeProcessDetails", func(t *testing.T) {
+		details := result.GetRuntimeProcessDetails()
+		assert.Equal(t, "malicious", details.ProcessTree.Comm)
+		assert.Equal(t, "/tmp/malware", details.ProcessTree.Path)
+		assert.Equal(t, uint32(1234), details.ProcessTree.PID)
+		assert.Equal(t, "container-abc", details.ContainerID)
+	})
+
+	t.Run("GetMalwareRuntimeAlert", func(t *testing.T) {
+		malwareAlert := result.GetMalwareRuntimeAlert()
+		assert.Equal(t, "Trojan.Test description", malwareAlert.MalwareDescription)
+	})
+
+	t.Run("GetRuntimeAlertK8sDetails", func(t *testing.T) {
+		k8sDetails := result.GetRuntimeAlertK8sDetails()
+		assert.Equal(t, "container-abc", k8sDetails.ContainerID)
+		assert.Equal(t, "test-container", k8sDetails.ContainerName)
+		assert.Equal(t, "default", k8sDetails.Namespace)
+		assert.Equal(t, "test-pod", k8sDetails.PodName)
+	})
+}
+
+func TestGenericMalwareResult_GetTriggerEvent_Nil(t *testing.T) {
+	result := &GenericMalwareResult{}
+	assert.Nil(t, result.GetTriggerEvent())
+}
+
+func TestGenericMalwareResult_Setters(t *testing.T) {
+	result := &GenericMalwareResult{}
+
+	t.Run("SetBasicRuntimeAlert", func(t *testing.T) {
+		alert := armotypes.BaseRuntimeAlert{
+			AlertName: "Updated.Alert",
+			Severity:  5,
+		}
+		result.SetBasicRuntimeAlert(alert)
+		assert.Equal(t, "Updated.Alert", result.GetBasicRuntimeAlert().AlertName)
+		assert.Equal(t, 5, result.GetBasicRuntimeAlert().Severity)
+	})
+
+	t.Run("SetRuntimeProcessDetails", func(t *testing.T) {
+		details := armotypes.ProcessTree{
+			ProcessTree: armotypes.Process{
+				Comm: "newprocess",
+				PID:  5678,
+			},
+			ContainerID: "container-xyz",
+		}
+		result.SetRuntimeProcessDetails(details)
+		assert.Equal(t, "newprocess", result.GetRuntimeProcessDetails().ProcessTree.Comm)
+		assert.Equal(t, uint32(5678), result.GetRuntimeProcessDetails().ProcessTree.PID)
+		assert.Equal(t, "container-xyz", result.GetRuntimeProcessDetails().ContainerID)
+	})
+
+	t.Run("SetMalwareRuntimeAlert", func(t *testing.T) {
+		malwareAlert := armotypes.MalwareAlert{
+			MalwareDescription: "New description",
+		}
+		result.SetMalwareRuntimeAlert(malwareAlert)
+		assert.Equal(t, "New description", result.GetMalwareRuntimeAlert().MalwareDescription)
+	})
+
+	t.Run("SetRuntimeAlertK8sDetails", func(t *testing.T) {
+		k8sDetails := armotypes.RuntimeAlertK8sDetails{
+			ContainerID:   "new-container",
+			ContainerName: "new-name",
+			Namespace:     "kube-system",
+			PodName:       "new-pod",
+			PodNamespace:  "kube-system",
+		}
+		result.SetRuntimeAlertK8sDetails(k8sDetails)
+		assert.Equal(t, "new-container", result.GetRuntimeAlertK8sDetails().ContainerID)
+		assert.Equal(t, "kube-system", result.GetRuntimeAlertK8sDetails().Namespace)
+	})
+
+	t.Run("SetTriggerEvent", func(t *testing.T) {
+		event := &utils.StructEvent{
+			ContainerID: "trigger-container",
+			Namespace:   "trigger-ns",
+			Pod:         "trigger-pod",
+		}
+		result.SetTriggerEvent(event)
+		assert.NotNil(t, result.GetTriggerEvent())
+		assert.Equal(t, "trigger-container", result.GetTriggerEvent().GetContainerID())
+	})
+}
+
+func TestGenericMalwareResult_SetWorkloadDetails(t *testing.T) {
+	tests := []struct {
+		name            string
+		workloadDetails string
+		expectCluster   string
+		expectKind      string
+		expectNamespace string
+		expectName      string
+		expectUnchanged bool
+	}{
+		{
+			name:            "empty workload details is a no-op",
+			workloadDetails: "",
+			expectUnchanged: true,
+		},
+		{
+			name:            "valid wlid extracts cluster, kind, namespace, name",
+			workloadDetails: "wlid://cluster-test/namespace-default/deployment-myapp",
+			expectCluster:   "test",
+			expectKind:      "Deployment",
+			expectNamespace: "default",
+			expectName:      "myapp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &GenericMalwareResult{
+				RuntimeAlertK8sDetails: armotypes.RuntimeAlertK8sDetails{
+					ClusterName:       "original-cluster",
+					WorkloadKind:      "original-kind",
+					WorkloadNamespace: "original-ns",
+					WorkloadName:      "original-name",
+				},
+			}
+
+			result.SetWorkloadDetails(tt.workloadDetails)
+
+			if tt.expectUnchanged {
+				assert.Equal(t, "original-cluster", result.RuntimeAlertK8sDetails.ClusterName)
+				assert.Equal(t, "original-kind", result.RuntimeAlertK8sDetails.WorkloadKind)
+				assert.Equal(t, "original-ns", result.RuntimeAlertK8sDetails.WorkloadNamespace)
+				assert.Equal(t, "original-name", result.RuntimeAlertK8sDetails.WorkloadName)
+			} else {
+				assert.Equal(t, tt.expectCluster, result.RuntimeAlertK8sDetails.ClusterName)
+				assert.Equal(t, tt.expectKind, result.RuntimeAlertK8sDetails.WorkloadKind)
+				assert.Equal(t, tt.expectNamespace, result.RuntimeAlertK8sDetails.WorkloadNamespace)
+				assert.Equal(t, tt.expectName, result.RuntimeAlertK8sDetails.WorkloadName)
+			}
+		})
+	}
+}

--- a/pkg/nodeprofilemanager/v1/nodeprofile_manager_test.go
+++ b/pkg/nodeprofilemanager/v1/nodeprofile_manager_test.go
@@ -1,0 +1,592 @@
+package nodeprofilemanager
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/armotypes"
+	"github.com/armosec/utils-k8s-go/armometadata"
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/kubescape/node-agent/pkg/exporters"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/node-agent/pkg/rulemanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestConfig(url, method string, timeoutSeconds int) config.Config {
+	return config.Config{
+		NodeProfileInterval:    1 * time.Second,
+		EnableRuntimeDetection: true,
+		Exporters: exporters.ExportersConfig{
+			HTTPExporterConfig: &exporters.HTTPExporterConfig{
+				URL:            url,
+				Method:         method,
+				TimeoutSeconds: timeoutSeconds,
+				Headers: []exporters.HTTPKeyValues{
+					{Key: "Content-Type", Value: "application/json"},
+				},
+			},
+		},
+	}
+}
+
+func TestNewNodeProfileManager(t *testing.T) {
+	t.Run("default timeout is 5 seconds", func(t *testing.T) {
+		cfg := newTestConfig("http://localhost", "POST", 0)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+		assert.NotNil(t, npm)
+		assert.Equal(t, 5*time.Second, npm.httpClient.Timeout)
+	})
+
+	t.Run("custom timeout from config", func(t *testing.T) {
+		cfg := newTestConfig("http://localhost", "POST", 10)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+		assert.Equal(t, 10*time.Second, npm.httpClient.Timeout)
+	})
+
+	t.Run("cloud metadata is stored", func(t *testing.T) {
+		cloudMeta := &armotypes.CloudMetadata{
+			Provider: "aws",
+		}
+		cfg := newTestConfig("http://localhost", "POST", 0)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{ClusterName: "test-cluster", AccountID: "test-account"},
+			"node-1",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			cloudMeta,
+		)
+		assert.Equal(t, "node-1", npm.nodeName)
+		assert.Equal(t, "test-cluster", npm.clusterData.ClusterName)
+		assert.Equal(t, cloudMeta, npm.cloudMetadata)
+	})
+}
+
+func TestGetContainerState(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        corev1.ContainerState
+		wantState    string
+		wantStarted  bool
+		wantFinished bool
+		wantExitCode int
+	}{
+		{
+			name: "running container",
+			state: corev1.ContainerState{
+				Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			wantState:   "Running",
+			wantStarted: true,
+		},
+		{
+			name: "terminated container",
+			state: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode:   137,
+					StartedAt:  metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+					FinishedAt: metav1.Time{Time: time.Date(2024, 1, 1, 1, 0, 0, 0, time.UTC)},
+				},
+			},
+			wantState:    "Terminated",
+			wantStarted:  true,
+			wantFinished: true,
+			wantExitCode: 137,
+		},
+		{
+			name: "waiting container",
+			state: corev1.ContainerState{
+				Waiting: &corev1.ContainerStateWaiting{
+					Reason: "CrashLoopBackOff",
+				},
+			},
+			wantState: "Waiting",
+		},
+		{
+			name:      "unknown state (all nil)",
+			state:     corev1.ContainerState{},
+			wantState: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, started, finished, exitCode := getContainerState(tt.state)
+			assert.Equal(t, tt.wantState, state)
+			if tt.wantStarted {
+				assert.False(t, started.IsZero(), "expected non-zero start time")
+			} else {
+				assert.True(t, started.IsZero(), "expected zero start time")
+			}
+			if tt.wantFinished {
+				assert.False(t, finished.IsZero(), "expected non-zero finish time")
+			} else {
+				assert.True(t, finished.IsZero(), "expected zero finish time")
+			}
+			assert.Equal(t, tt.wantExitCode, exitCode)
+		})
+	}
+}
+
+func TestGetPodState(t *testing.T) {
+	tests := []struct {
+		name           string
+		conditions     []corev1.PodCondition
+		wantState      string
+		wantReason     string
+		wantMessage    string
+		wantHasTransit bool
+	}{
+		{
+			name:       "no conditions returns empty",
+			conditions: nil,
+			wantState:  "",
+		},
+		{
+			name: "PodReady true returns state",
+			conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					Reason:             "PodReady",
+					Message:            "All containers ready",
+					LastTransitionTime: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			wantState:      "Ready",
+			wantReason:     "PodReady",
+			wantMessage:    "All containers ready",
+			wantHasTransit: true,
+		},
+		{
+			name: "PodReady false is skipped",
+			conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+					Reason: "ContainersNotReady",
+				},
+			},
+			wantState: "",
+		},
+		{
+			name: "multiple conditions returns first Ready=True",
+			conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					Reason:             "Ready",
+					LastTransitionTime: metav1.Time{Time: time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)},
+				},
+			},
+			wantState:      "Ready",
+			wantReason:     "Ready",
+			wantHasTransit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, reason, message, transitionTime := getPodState(tt.conditions)
+			assert.Equal(t, tt.wantState, state)
+			assert.Equal(t, tt.wantReason, reason)
+			assert.Equal(t, tt.wantMessage, message)
+			if tt.wantHasTransit {
+				assert.False(t, transitionTime.IsZero())
+			} else {
+				assert.True(t, transitionTime.IsZero())
+			}
+		})
+	}
+}
+
+func TestGetProfile(t *testing.T) {
+	cloudMeta := &armotypes.CloudMetadata{Provider: "gcp"}
+
+	k8sCache := &objectcache.K8sObjectCacheMock{
+		PodSpec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx:latest"},
+				{Name: "sidecar", Image: "envoy:v1"},
+			},
+			InitContainers: []corev1.Container{
+				{Name: "init", Image: "busybox:latest"},
+			},
+		},
+		PodStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "app",
+					RestartCount: 2,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+						},
+					},
+				},
+				{
+					Name: "sidecar",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+					},
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "init",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := newTestConfig("http://localhost", "POST", 5)
+	cfg.EnableRuntimeDetection = true
+
+	npm := NewNodeProfileManager(
+		cfg,
+		armometadata.ClusterConfig{AccountID: "acc-123", ClusterName: "cluster-1"},
+		"node-1",
+		k8sCache,
+		rulemanager.CreateRuleManagerMock(),
+		cloudMeta,
+	)
+
+	profile, err := npm.getProfile()
+	require.NoError(t, err)
+	assert.NotNil(t, profile)
+	assert.Equal(t, "Running", profile.CurrentState)
+	assert.True(t, profile.NodeAgentRunning)
+	assert.True(t, profile.RuntimeDetectionEnabled)
+	assert.Equal(t, cloudMeta, profile.CloudMetadata)
+	assert.Len(t, profile.PodStatuses, 1)
+
+	ps := profile.PodStatuses[0]
+	assert.Equal(t, "acc-123", ps.CustomerGUID)
+	assert.Equal(t, "cluster-1", ps.Cluster)
+	assert.Equal(t, "node-1", ps.NodeName)
+	assert.Equal(t, string(corev1.PodRunning), ps.Phase)
+
+	assert.Len(t, ps.Containers, 2)
+	assert.Equal(t, "app", ps.Containers[0].Name)
+	assert.Equal(t, "nginx:latest", ps.Containers[0].Image)
+	assert.Equal(t, "Running", ps.Containers[0].CurrentState)
+	assert.Equal(t, 2, ps.Containers[0].RestartCount)
+
+	assert.Equal(t, "sidecar", ps.Containers[1].Name)
+	assert.Equal(t, "Waiting", ps.Containers[1].CurrentState)
+
+	assert.Len(t, ps.InitContainers, 1)
+	assert.Equal(t, "init", ps.InitContainers[0].Name)
+	assert.Equal(t, "Terminated", ps.InitContainers[0].CurrentState)
+	assert.Equal(t, 0, ps.InitContainers[0].LastStateExitCode)
+}
+
+type localK8sCache struct {
+	objectcache.K8sObjectCacheMock
+	pods []*corev1.Pod
+}
+
+func (c *localK8sCache) GetPods() []*corev1.Pod {
+	return c.pods
+}
+
+func TestGetProfile_AppLabel(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		expectApp string
+	}{
+		{
+			name:      "app label present",
+			labels:    map[string]string{"app": "myapp"},
+			expectApp: "myapp",
+		},
+		{
+			name:      "app.kubernetes.io/name present",
+			labels:    map[string]string{"app.kubernetes.io/name": "myapp2"},
+			expectApp: "myapp2",
+		},
+		{
+			name:      "app takes precedence over app.kubernetes.io/name",
+			labels:    map[string]string{"app": "first", "app.kubernetes.io/name": "second"},
+			expectApp: "first",
+		},
+		{
+			name:      "no app labels",
+			labels:    map[string]string{"version": "v1"},
+			expectApp: "",
+		},
+		{
+			name:      "nil labels",
+			labels:    nil,
+			expectApp: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sCache := &localK8sCache{
+				pods: []*corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels:    tt.labels,
+						},
+					},
+				},
+			}
+			cfg := newTestConfig("http://localhost", "POST", 5)
+			npm := NewNodeProfileManager(
+				cfg,
+				armometadata.ClusterConfig{},
+				"node-1",
+				k8sCache,
+				rulemanager.CreateRuleManagerMock(),
+				nil,
+			)
+
+			profile, err := npm.getProfile()
+			require.NoError(t, err)
+			require.Len(t, profile.PodStatuses, 1)
+			assert.Equal(t, tt.expectApp, profile.PodStatuses[0].App)
+		})
+	}
+}
+
+func TestSendProfile(t *testing.T) {
+	t.Run("successful send", func(t *testing.T) {
+		var receivedBody []byte
+		var receivedContentType string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedContentType = r.Header.Get("Content-Type")
+			var err error
+			receivedBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("failed to read body: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := newTestConfig(server.URL, "POST", 5)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+
+		profile := &armotypes.NodeProfile{
+			CurrentState:     "Running",
+			NodeAgentRunning: true,
+			PodStatuses:      []armotypes.PodStatus{},
+		}
+
+		err := npm.sendProfile(profile)
+		assert.NoError(t, err)
+		assert.Equal(t, "application/json", receivedContentType)
+
+		var crd armotypes.GenericCRD[armotypes.NodeProfile]
+		err = json.Unmarshal(receivedBody, &crd)
+		require.NoError(t, err)
+		assert.Equal(t, "NodeProfiles", crd.Kind)
+		assert.Equal(t, "kubescape.io/v1", crd.ApiVersion)
+		assert.Equal(t, "test-node", crd.Metadata.Name)
+		assert.Equal(t, "Running", crd.Spec.CurrentState)
+		assert.True(t, crd.Spec.NodeAgentRunning)
+	})
+
+	t.Run("non-2xx status code returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		cfg := newTestConfig(server.URL, "POST", 5)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+
+		err := npm.sendProfile(&armotypes.NodeProfile{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "non-2xx status code: 500")
+	})
+
+	t.Run("connection error returns error", func(t *testing.T) {
+		cfg := newTestConfig("http://127.0.0.1:1", "POST", 1)
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+
+		err := npm.sendProfile(&armotypes.NodeProfile{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "send request")
+	})
+
+	t.Run("custom headers are sent", func(t *testing.T) {
+		var receivedHeaders http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPut, r.Method)
+			receivedHeaders = r.Header
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := newTestConfig(server.URL, "PUT", 5)
+		cfg.Exporters.HTTPExporterConfig.Headers = []exporters.HTTPKeyValues{
+			{Key: "Content-Type", Value: "application/json"},
+			{Key: "X-Custom-Header", Value: "test-value"},
+		}
+		npm := NewNodeProfileManager(
+			cfg,
+			armometadata.ClusterConfig{},
+			"test-node",
+			&objectcache.K8sObjectCacheMock{},
+			rulemanager.CreateRuleManagerMock(),
+			nil,
+		)
+
+		err := npm.sendProfile(&armotypes.NodeProfile{})
+		assert.NoError(t, err)
+		assert.Equal(t, "application/json", receivedHeaders.Get("Content-Type"))
+		assert.Equal(t, "test-value", receivedHeaders.Get("X-Custom-Header"))
+	})
+}
+
+func TestGetContainers(t *testing.T) {
+	cfg := newTestConfig("http://localhost", "POST", 5)
+	npm := NewNodeProfileManager(
+		cfg,
+		armometadata.ClusterConfig{},
+		"test-node",
+		&objectcache.K8sObjectCacheMock{},
+		rulemanager.CreateRuleManagerMock(),
+		nil,
+	)
+
+	t.Run("empty containers returns empty slice", func(t *testing.T) {
+		result := npm.getContainers("ns", "pod", nil, nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("containers with matching statuses", func(t *testing.T) {
+		containers := []corev1.Container{
+			{Name: "web", Image: "nginx:1.25"},
+			{Name: "log", Image: "fluentd:v1"},
+		}
+		statuses := map[string]corev1.ContainerStatus{
+			"web": {
+				Name:         "web",
+				RestartCount: 3,
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.Time{Time: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+					},
+				},
+			},
+		}
+
+		result := npm.getContainers("default", "test-pod", containers, statuses)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "web", result[0].Name)
+		assert.Equal(t, "nginx:1.25", result[0].Image)
+		assert.Equal(t, "Running", result[0].CurrentState)
+		assert.Equal(t, 3, result[0].RestartCount)
+		assert.Equal(t, "log", result[1].Name)
+		assert.Equal(t, "Unknown", result[1].CurrentState)
+	})
+}
+
+func TestGetEphemeralContainers(t *testing.T) {
+	cfg := newTestConfig("http://localhost", "POST", 5)
+	npm := NewNodeProfileManager(
+		cfg,
+		armometadata.ClusterConfig{},
+		"test-node",
+		&objectcache.K8sObjectCacheMock{},
+		rulemanager.CreateRuleManagerMock(),
+		nil,
+	)
+
+	t.Run("ephemeral containers", func(t *testing.T) {
+		containers := []corev1.EphemeralContainer{
+			{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:  "debug",
+					Image: "busybox:latest",
+				},
+			},
+		}
+		statuses := map[string]corev1.ContainerStatus{
+			"debug": {
+				Name: "debug",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			},
+		}
+
+		result := npm.getEphemeralContainers("default", "pod", containers, statuses)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "debug", result[0].Name)
+		assert.Equal(t, "busybox:latest", result[0].Image)
+		assert.Equal(t, "Running", result[0].CurrentState)
+	})
+
+	t.Run("empty ephemeral containers", func(t *testing.T) {
+		result := npm.getEphemeralContainers("default", "pod", nil, nil)
+		assert.Nil(t, result)
+	})
+}


### PR DESCRIPTION
Resolves #913

### Description
This PR introduces comprehensive unit tests for three previously untested manager packages: `malwaremanager`, `healthmanager`, and `nodeprofilemanager`. 

These additions provide vital automated coverage around health probes, malware event handling, container lifecycle state, node profile generation, and profile reporting, making future modifications to these components much safer and easier to maintain.

### Changes Made

**1. `pkg/healthmanager`**
- Added tests for `NewHealthManager` initialization.
- Validated liveness probe behaviors (always returns HTTP 200 OK).
- Validated readiness probe behaviors, covering scenarios for a `nil` watcher (HTTP 500), an unready watcher (HTTP 500), and a ready watcher (HTTP 200).
- Verified proper container watcher assignment.

**2. `pkg/malwaremanager`**
- **`v1/malware_manager_test.go`**:
  - Tested manager initialization when ClamAV is not configured.
  - Verified container lifecycle bookkeeping (`containerIdToPid` add/remove interactions and ignoring host containers).
  - Validated supported `Execve` event handling and accurate routing.
  - Asserted proper handling of unsupported event types and valid `Open` events.
  - Asserted file-open filtering skips directories and fast-paths when scanners are disabled.
- **`v1/types/malwareresult_test.go`**:
  - Validated WLID string normalization and extraction logic for exact parsed values (cluster, namespace, kind, and name).
  - Tested basic getters, setters, and event triggers.

**3. `pkg/nodeprofilemanager`**
- Tested manager initialization and config overrides (e.g., custom timeouts).
- Simulated complete node profile construction logic.
- Tested container state interpretation (Running, Terminated, Waiting, Unknown).
- Tested pod state interpretation (PodReady conditions and transitions).
- Validated container and ephemeral-container metadata parsing.
- Verified correct application label parsing priority directly against production `getProfile()` logic.
- Covered HTTP profile submission interactions using isolated test servers (asserting successful requests, non-2xx failures, connection errors, and custom headers).

### Testing
- `go test -v ./pkg/healthmanager/... ./pkg/malwaremanager/... ./pkg/nodeprofilemanager/...` passes completely.
- Verified that these tests successfully compile and pass on Linux environments via cross-compilation checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for health monitoring, including liveness and readiness behavior.
  * Added malware event, file scanning, container mapping, and scanner-availability coverage.
  * Added validation for malware result accessors, setters, and workload metadata parsing.
  * Added comprehensive node profile coverage for metadata collection, container states, profile submission, headers, errors, and ephemeral containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->