### PR TITLE
fix(seccomp): drop unrecognized syscall numbers instead of recording "unknown"

### DIFF
--- a/pkg/containerwatcher/v2/tracers/syscall.go
+++ b/pkg/containerwatcher/v2/tracers/syscall.go
@@ -2,6 +2,7 @@ package tracers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/datasource"
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
@@ -140,20 +141,24 @@ func (st *SyscallTracer) callback(event *utils.DatasourceEvent) {
 
 func decodeSyscalls(syscallsBuffer []byte) []string {
 	syscallStrings := make([]string, 0)
+	// Syscall numbers this build cannot resolve to a name are skipped. Recording a
+	// placeholder name would propagate into the application profile and from there
+	// into generated seccomp profiles, where it is not a valid syscall name. The
+	// numbers are collected and logged once per decode to keep this loop cheap.
+	var skipped []int
 	for i := range syscallsBuffer {
 		if syscallsBuffer[i] > 0 {
 			syscallName, exist := syscalls.GetSyscallNameByNumber(i)
 			if !exist {
-				// The syscall number is not known to this build. Recording a placeholder
-				// name would propagate into the application profile and from there into
-				// generated seccomp profiles, where it is not a valid syscall name.
-				// Drop it and keep the number for diagnostics.
-				logger.L().Debug("decodeSyscalls - skipping unrecognized syscall number",
-					helpers.Int("syscallNumber", i))
+				skipped = append(skipped, i)
 				continue
 			}
 			syscallStrings = append(syscallStrings, syscallName)
 		}
+	}
+	if len(skipped) > 0 {
+		logger.L().Debug("decodeSyscalls - skipped syscall numbers with no known name",
+			helpers.String("syscallNumbers", fmt.Sprint(skipped)))
 	}
 	return syscallStrings
 }

--- a/pkg/containerwatcher/v2/tracers/syscall.go
+++ b/pkg/containerwatcher/v2/tracers/syscall.go
@@ -144,7 +144,13 @@ func decodeSyscalls(syscallsBuffer []byte) []string {
 		if syscallsBuffer[i] > 0 {
 			syscallName, exist := syscalls.GetSyscallNameByNumber(i)
 			if !exist {
-				syscallName = "unknown"
+				// The syscall number is not known to this build. Recording a placeholder
+				// name would propagate into the application profile and from there into
+				// generated seccomp profiles, where it is not a valid syscall name.
+				// Drop it and keep the number for diagnostics.
+				logger.L().Debug("decodeSyscalls - skipping unrecognized syscall number",
+					helpers.Int("syscallNumber", i))
+				continue
 			}
 			syscallStrings = append(syscallStrings, syscallName)
 		}

--- a/pkg/containerwatcher/v2/tracers/syscall_decode_test.go
+++ b/pkg/containerwatcher/v2/tracers/syscall_decode_test.go
@@ -1,0 +1,49 @@
+package tracers
+
+import (
+	"testing"
+
+	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/syscalls"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDecodeSyscallsSkipsUnrecognizedNumbers verifies that syscall numbers this build
+// cannot resolve to a name are dropped rather than recorded under a placeholder name.
+// A placeholder propagates into the application profile and from there into generated
+// seccomp profiles, where it is not a valid syscall name.
+func TestDecodeSyscallsSkipsUnrecognizedNumbers(t *testing.T) {
+	// Find a syscall number that this build cannot resolve, to stand in for a
+	// number coming from a newer kernel than the one this binary knows about.
+	unknownNumber := -1
+	for i := len(make([]byte, 512)) - 1; i >= 0; i-- {
+		if _, exist := syscalls.GetSyscallNameByNumber(i); !exist {
+			unknownNumber = i
+			break
+		}
+	}
+	if unknownNumber == -1 {
+		t.Skip("every syscall number in range is resolvable in this build")
+	}
+
+	// Pick a known syscall number so the test also proves valid entries survive.
+	knownNumber, knownName := -1, ""
+	for i := 0; i < unknownNumber; i++ {
+		if name, exist := syscalls.GetSyscallNameByNumber(i); exist {
+			knownNumber, knownName = i, name
+			break
+		}
+	}
+	if knownNumber == -1 {
+		t.Skip("no resolvable syscall number available in this build")
+	}
+
+	buffer := make([]byte, unknownNumber+1)
+	buffer[knownNumber] = 1
+	buffer[unknownNumber] = 1
+
+	got := decodeSyscalls(buffer)
+
+	assert.Contains(t, got, knownName, "resolvable syscalls must still be recorded")
+	assert.NotContains(t, got, "unknown", "unresolvable syscall numbers must not be recorded as a placeholder name")
+	assert.Len(t, got, 1, "only the resolvable syscall should be returned")
+}

--- a/pkg/containerwatcher/v2/tracers/syscall_decode_test.go
+++ b/pkg/containerwatcher/v2/tracers/syscall_decode_test.go
@@ -14,8 +14,9 @@ import (
 func TestDecodeSyscallsSkipsUnrecognizedNumbers(t *testing.T) {
 	// Find a syscall number that this build cannot resolve, to stand in for a
 	// number coming from a newer kernel than the one this binary knows about.
+	const maxSyscallNumberProbed = 511
 	unknownNumber := -1
-	for i := len(make([]byte, 512)) - 1; i >= 0; i-- {
+	for i := maxSyscallNumberProbed; i >= 0; i-- {
 		if _, exist := syscalls.GetSyscallNameByNumber(i); !exist {
 			unknownNumber = i
 			break


### PR DESCRIPTION
Closes #910

## Problem

`decodeSyscalls` names every syscall number it cannot resolve `"unknown"`:

```go
syscallName, exist := syscalls.GetSyscallNameByNumber(i)
if !exist {
    syscallName = "unknown"
}
```

That string is not a diagnostic. It is recorded as a syscall name in the container profile, merged into the application profile, and copied verbatim into the seccomp profiles we generate from that profile. A generated `SeccompProfile` CRD then contains `unknown` in its `SCMP_ACT_ALLOW` name list, where no kernel can match it.

Seen on a live POC cluster, in an applied profile:

```yaml
names:
  - times
  - umask
  - uname
  - unknown      # <- this
  - unlinkat
```

It also makes the profile permanently look wrong in the product: a syscall that is allowed but can never be observed in use keeps a workload from reaching the "optimized" seccomp state.

## Fix

Skip the entry and log the number instead. Profiles then only ever contain names the kernel can match, and the unresolved number is still visible for debugging.

## Test

`TestDecodeSyscallsSkipsUnrecognizedNumbers` picks a syscall number this build cannot resolve plus one it can, and asserts the resolvable name survives while no placeholder is emitted.

Verified on linux/amd64:

```
=== RUN   TestDecodeSyscallsSkipsUnrecognizedNumbers
--- PASS: TestDecodeSyscallsSkipsUnrecognizedNumbers (0.00s)
ok  	github.com/kubescape/node-agent/pkg/containerwatcher/v2/tracers	0.208s
```

With the fix reverted the test fails, so it covers the bug:

```
Error: "[read unknown]" should have 1 item(s), but has 2
```

AI-skills: armosec-shared-rules:docs_find | cmds: /model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unrecognized system calls are no longer displayed as `"unknown"`; they are omitted from decoded results.
  * Added debug logging to identify skipped system call numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->