### PR TITLE
chore: bump inspektor-gadget fork to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -472,7 +472,7 @@ require (
 	zombiezen.com/go/sqlite v1.4.0 // indirect
 )
 
-replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260819074828-9494a925bd43
+replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260824132042-5bba57473b53
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
 

--- a/go.sum
+++ b/go.sum
@@ -919,8 +919,8 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/matthyx/inspektor-gadget v0.0.0-20260819074828-9494a925bd43 h1:RNn7KJswYAsnFW+gZRIBNRrcQ3BSsyW5dpXR28aRkDE=
-github.com/matthyx/inspektor-gadget v0.0.0-20260819074828-9494a925bd43/go.mod h1:cwCFczq1LJ6Frpur0Vr5Ncic77a9ihki07Xpwzy+ItI=
+github.com/matthyx/inspektor-gadget v0.0.0-20260824132042-5bba57473b53 h1:gFcmFBYF1u5p+T7MPY9WcvBafNIsvpnWNJb93XXhJkA=
+github.com/matthyx/inspektor-gadget v0.0.0-20260824132042-5bba57473b53/go.mod h1:cwCFczq1LJ6Frpur0Vr5Ncic77a9ihki07Xpwzy+ItI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
The fork (matthyx/inspektor-gadget) was reset onto upstream v0.48.1 with its fork-specific commits reapplied and cleaned up; this picks up the corrected datasource pooling implementation (matching upstream PR inspektor-gadget/inspektor-gadget#5295) and the uprobetracer/TLS reattach fixes.

Docs-exempt: pure dependency version bump (go.mod/go.sum only), no behavioral change to this repo's own code

## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying component to a newer version, bringing in the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->