### PR TITLE
build: switch inspektor-gadget fork from matthyx to kubescape

### DIFF
--- a/docs/features/inspektor-gadget-fork.md
+++ b/docs/features/inspektor-gadget-fork.md
@@ -1,0 +1,33 @@
+# inspektor-gadget fork
+
+node-agent depends on a fork of `inspektor-gadget/inspektor-gadget` via a `replace`
+directive in `go.mod`, instead of the upstream module, because node-agent needs
+changes (e.g. eBPF map manual-fetch triggers, syscall map handling) before they land
+upstream.
+
+## Current fork
+
+The fork is **`github.com/kubescape/inspektor-gadget`**, pinned to a specific commit
+via a pseudo-version:
+
+```
+replace github.com/inspektor-gadget/inspektor-gadget => github.com/kubescape/inspektor-gadget v0.0.0-<timestamp>-<short-sha>
+```
+
+This is an org-owned fork of `inspektor-gadget/inspektor-gadget`, kept as a plain
+mirror of whatever commit node-agent currently needs — it is not meant to diverge
+with its own history. Previously this pointed at a personal fork
+(`matthyx/inspektor-gadget`); that was migrated to the org fork so the dependency
+isn't tied to one contributor's personal account.
+
+## Updating the pin
+
+1. Push (or force-push) the desired commit to `kubescape/inspektor-gadget:main`.
+2. Update the `replace` line in `go.mod` with the new commit's pseudo-version:
+   ```
+   go get github.com/inspektor-gadget/inspektor-gadget@<commit-sha>
+   ```
+3. Run `go mod tidy` and `go build ./...` to confirm `go.sum` and the build are consistent.
+
+The pin is a point-in-time snapshot, not a tracking reference — moving
+`kubescape/inspektor-gadget:main` further does not update `go.mod` automatically.

--- a/go.mod
+++ b/go.mod
@@ -472,7 +472,7 @@ require (
 	zombiezen.com/go/sqlite v1.4.0 // indirect
 )
 
-replace github.com/inspektor-gadget/inspektor-gadget => github.com/matthyx/inspektor-gadget v0.0.0-20260825192450-2b683d258349
+replace github.com/inspektor-gadget/inspektor-gadget => github.com/kubescape/inspektor-gadget v0.0.0-20260826074832-06b0d12baca0
 
 replace github.com/anchore/syft => github.com/kubescape/syft v1.32.0-ks.2
 

--- a/go.sum
+++ b/go.sum
@@ -891,6 +891,8 @@ github.com/kubescape/backend v0.0.39 h1:B1QRfKCSFlzuE+jWOnk/l7EpH71/Q3n14KKq0QSn
 github.com/kubescape/backend v0.0.39/go.mod h1:cMEGP8cXUZgY89YU4GRBGIla9HZW7grZsUtlCwvZgAE=
 github.com/kubescape/go-logger v0.0.32 h1:4mI+XJOV8VFCMewrEE9VIFEIOhzXokYT3nFpNfXf4fM=
 github.com/kubescape/go-logger v0.0.32/go.mod h1:Alj7JBQ8/WCxbXe8Ura6ZheSRK45E0p21M3xeqedX90=
+github.com/kubescape/inspektor-gadget v0.0.0-20260826074832-06b0d12baca0 h1:kJzq1CnGP4kqAdyVWrb9TGlRpniwsIsVVMfo61OuzCQ=
+github.com/kubescape/inspektor-gadget v0.0.0-20260826074832-06b0d12baca0/go.mod h1:cwCFczq1LJ6Frpur0Vr5Ncic77a9ihki07Xpwzy+ItI=
 github.com/kubescape/k8s-interface v0.0.214 h1:j7KP0/5VvYOoQdBGV2+gRM3qnR8PWLAGF8RM/k/DmJ0=
 github.com/kubescape/k8s-interface v0.0.214/go.mod h1:WNYUG93aZ5kDmuaRKFLtVhp18Yc6EfaHdD1gLYtVTN4=
 github.com/kubescape/storage v0.0.303 h1:0nXI6E07lbWsg7iEH04vR4kwiekj//uCQl/La+8j4aM=
@@ -919,8 +921,6 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/matthyx/inspektor-gadget v0.0.0-20260825192450-2b683d258349 h1:9fxhaVRFGjJIOXR0NVU0+hQPI7ixrzYSa/bW1KWYATo=
-github.com/matthyx/inspektor-gadget v0.0.0-20260825192450-2b683d258349/go.mod h1:cwCFczq1LJ6Frpur0Vr5Ncic77a9ihki07Xpwzy+ItI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
## Overview

Repoints node-agent's `inspektor-gadget` dependency from the personal fork
(`matthyx/inspektor-gadget`) to the org-owned fork (`kubescape/inspektor-gadget`),
so the dependency isn't tied to one contributor's personal GitHub account.

- `kubescape/inspektor-gadget:main` was force-pushed to match
  `matthyx/inspektor-gadget:main` (commit `06b0d12b`), which included one extra
  refactor commit beyond what `go.mod` was previously pinned to (same feature,
  no behavior change — see `pkg/operators/ebpf/manualfetch.go`).
- `go.mod`'s `replace` directive now points at `kubescape/inspektor-gadget` with
  a pseudo-version pinned to that commit; `go.sum` updated via `go mod tidy`.
- Added `docs/features/inspektor-gadget-fork.md` documenting which fork is used
  and how to update the pin going forward.

## How to Test

- `go build ./...` and `go mod tidy` run clean against the new replace target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: none | cmds: /clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the Inspektor Gadget dependency, including its source, version pinning, migration details, and update validation steps.

* **Maintenance**
  * Updated the Inspektor Gadget dependency to a newer version from the maintained project fork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->