### PR TITLE
fix: prevent malware manager lifecycle race

### DIFF
--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -40,6 +40,8 @@ type containerRegistration struct {
 	done      chan struct{}
 	finished  chan struct{}
 	cancelled bool
+	ctx       context.Context
+	ctxCancel context.CancelFunc
 }
 
 func (r *containerRegistration) cancel() {
@@ -50,6 +52,7 @@ func (r *containerRegistration) cancel() {
 		if r.timer != nil {
 			r.timer.Stop()
 		}
+		r.ctxCancel()
 		close(r.done)
 	}
 }
@@ -113,45 +116,22 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
+		reg := mm.admitContainer(containerID)
+
 		pid := notif.Container.ContainerPid()
 		shim, shimErr := utils.GetProcessStat(int(pid))
 		if shimErr != nil {
 			logger.L().Warning("MalwareManager - failed to get shim process", helpers.Error(shimErr))
 		}
-		go mm.startMalwareManager(notif.Container)
 
-		delay := utils.AddJitter(mm.cfg.InitialDelay, mm.cfg.MaxJitterPercentage)
-		reg := &containerRegistration{
-			timer:    time.NewTimer(delay),
-			done:     make(chan struct{}),
-			finished: make(chan struct{}),
+		var shimPPID uint32
+		if shimErr == nil {
+			shimPPID = uint32(shim.PPID)
 		}
+		mm.publishContainerState(containerID, reg, pid, shimPPID, shimErr == nil)
 
-		// Serialize ADD vs REMOVE for this container.
-		mm.containerLocks.WithLock(containerID, func() {
-			if oldReg, ok := mm.trackedContainers.Load(containerID); ok {
-				oldReg.cancel()
-			}
-			mm.containerIdToPid.Set(containerID, pid)
-			if shimErr == nil {
-				mm.containerIdToShimPid.Set(containerID, uint32(shim.PPID))
-			}
-			mm.trackedContainers.Set(containerID, reg)
-		})
-
-		go func(r *containerRegistration, cID string) {
-			defer close(r.finished)
-			select {
-			case <-r.done:
-				return
-			case <-r.timer.C:
-				r.mu.Lock()
-				if !r.cancelled {
-					mm.scannedFiles.Set(cID, mapset.NewSet[string]())
-				}
-				r.mu.Unlock()
-			}
-		}(reg, containerID)
+		go mm.startMalwareManager(reg, notif.Container)
+		mm.startDelayedInit(reg, containerID)
 
 	case containercollection.EventTypeRemoveContainer:
 		// Serialize ADD vs REMOVE for this container.
@@ -168,26 +148,84 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 	}
 }
 
-func (mm *MalwareManager) startMalwareManager(container *containercollection.Container) {
-	// Wait for the shared container data to be available
-	sharedData, err := mm.waitForSharedContainerData(container.Runtime.ContainerID)
+func (mm *MalwareManager) admitContainer(containerID string) *containerRegistration {
+	delay := utils.AddJitter(mm.cfg.InitialDelay, mm.cfg.MaxJitterPercentage)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	reg := &containerRegistration{
+		timer:     time.NewTimer(delay),
+		done:      make(chan struct{}),
+		finished:  make(chan struct{}),
+		ctx:       ctx,
+		ctxCancel: ctxCancel,
+	}
+
+	mm.containerLocks.WithLock(containerID, func() {
+		if oldReg, ok := mm.trackedContainers.Load(containerID); ok {
+			oldReg.cancel()
+		}
+		mm.trackedContainers.Set(containerID, reg)
+	})
+
+	return reg
+}
+
+func (mm *MalwareManager) publishContainerState(containerID string, reg *containerRegistration, pid uint32, shimPPID uint32, hasShim bool) {
+	mm.containerLocks.WithLock(containerID, func() {
+		currentReg, ok := mm.trackedContainers.Load(containerID)
+		if !ok || currentReg != reg || reg.cancelled {
+			return
+		}
+		mm.containerIdToPid.Set(containerID, pid)
+		if hasShim {
+			mm.containerIdToShimPid.Set(containerID, shimPPID)
+		}
+	})
+}
+
+func (mm *MalwareManager) startDelayedInit(reg *containerRegistration, containerID string) {
+	go func(r *containerRegistration, cID string) {
+		defer close(r.finished)
+		select {
+		case <-r.done:
+			return
+		case <-r.timer.C:
+			r.mu.Lock()
+			if !r.cancelled {
+				mm.scannedFiles.Set(cID, mapset.NewSet[string]())
+			}
+			r.mu.Unlock()
+		}
+	}(reg, containerID)
+}
+
+func (mm *MalwareManager) startMalwareManager(reg *containerRegistration, container *containercollection.Container) {
+	containerID := container.Runtime.ContainerID
+	sharedData, err := mm.waitForSharedContainerData(reg.ctx, containerID)
 	if err != nil {
-		logger.L().Error("MalwareManager - failed to get shared container data", helpers.Error(err))
+		if reg.ctx.Err() == nil {
+			logger.L().Error("MalwareManager - failed to get shared container data", helpers.Error(err))
+		}
 		return
 	}
 	podID := utils.CreateK8sPodID(container.K8s.Namespace, container.K8s.PodName)
-	if !mm.podToWlid.Has(podID) {
-		w := sharedData.Wlid
-		if w != "" {
-			mm.podToWlid.Set(podID, w)
-		} else {
-			logger.L().Debug("MalwareManager - failed to get workload identifier", helpers.String("k8s workload", container.K8s.PodName))
+	mm.containerLocks.WithLock(containerID, func() {
+		currentReg, ok := mm.trackedContainers.Load(containerID)
+		if !ok || currentReg != reg || reg.cancelled {
+			return
 		}
-	}
+		if !mm.podToWlid.Has(podID) {
+			w := sharedData.Wlid
+			if w != "" {
+				mm.podToWlid.Set(podID, w)
+			} else {
+				logger.L().Debug("MalwareManager - failed to get workload identifier", helpers.String("k8s workload", container.K8s.PodName))
+			}
+		}
+	})
 }
 
-func (mm *MalwareManager) waitForSharedContainerData(containerID string) (*objectcache.WatchedContainerData, error) {
-	return backoff.Retry(context.Background(), func() (*objectcache.WatchedContainerData, error) {
+func (mm *MalwareManager) waitForSharedContainerData(ctx context.Context, containerID string) (*objectcache.WatchedContainerData, error) {
+	return backoff.Retry(ctx, func() (*objectcache.WatchedContainerData, error) {
 		if sharedData := mm.k8sObjectCache.GetSharedContainerData(containerID); sharedData != nil {
 			return sharedData, nil
 		}

--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubescape/node-agent/pkg/metricsmanager"
 	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/otelsetup"
+	"github.com/kubescape/node-agent/pkg/resourcelocks"
 	"github.com/kubescape/node-agent/pkg/utils"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -67,6 +68,7 @@ type MalwareManager struct {
 	containerIdToShimPid maps.SafeMap[string, uint32]
 	k8sObjectCache       objectcache.K8sObjectCache
 	trackedContainers    maps.SafeMap[string, *containerRegistration]
+	containerLocks       *resourcelocks.ResourceLocks
 }
 
 var _ malwaremanager.MalwareManagerClient = (*MalwareManager)(nil)
@@ -94,6 +96,7 @@ func CreateMalwareManager(cfg config.Config, k8sClient k8sclient.K8sClientInterf
 		clusterName:     clusterName,
 		metrics:         prometheusExporter,
 		k8sObjectCache:  k8sObjectCache,
+		containerLocks:  resourcelocks.New(),
 	}, nil
 }
 
@@ -110,18 +113,12 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
-		mm.containerIdToPid.Set(containerID, notif.Container.ContainerPid())
-		shim, err := utils.GetProcessStat(int(notif.Container.ContainerPid()))
-		if err != nil {
-			logger.L().Warning("RuleManager - failed to get shim process", helpers.Error(err))
-		} else {
-			mm.containerIdToShimPid.Set(containerID, uint32(shim.PPID))
+		pid := notif.Container.ContainerPid()
+		shim, shimErr := utils.GetProcessStat(int(pid))
+		if shimErr != nil {
+			logger.L().Warning("RuleManager - failed to get shim process", helpers.Error(shimErr))
 		}
 		go mm.startMalwareManager(notif.Container)
-
-		if oldReg, ok := mm.trackedContainers.Load(containerID); ok {
-			oldReg.cancel()
-		}
 
 		delay := utils.AddJitter(mm.cfg.InitialDelay, mm.cfg.MaxJitterPercentage)
 		reg := &containerRegistration{
@@ -129,7 +126,18 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 			done:     make(chan struct{}),
 			finished: make(chan struct{}),
 		}
-		mm.trackedContainers.Set(containerID, reg)
+
+		// Serialize ADD vs REMOVE for this container.
+		mm.containerLocks.WithLock(containerID, func() {
+			if oldReg, ok := mm.trackedContainers.Load(containerID); ok {
+				oldReg.cancel()
+			}
+			mm.containerIdToPid.Set(containerID, pid)
+			if shimErr == nil {
+				mm.containerIdToShimPid.Set(containerID, uint32(shim.PPID))
+			}
+			mm.trackedContainers.Set(containerID, reg)
+		})
 
 		go func(r *containerRegistration, cID string) {
 			defer close(r.finished)
@@ -146,14 +154,18 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 		}(reg, containerID)
 
 	case containercollection.EventTypeRemoveContainer:
-		if reg, ok := mm.trackedContainers.Load(containerID); ok {
-			reg.cancel()
-			mm.trackedContainers.Delete(containerID)
-		}
-		mm.containerIdToPid.Delete(containerID)
-		mm.scannedFiles.Delete(containerID)
-		mm.podToWlid.Delete(utils.CreateK8sPodID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName))
-		mm.containerIdToShimPid.Delete(containerID)
+		// Serialize ADD vs REMOVE for this container.
+		mm.containerLocks.WithLock(containerID, func() {
+			if reg, ok := mm.trackedContainers.Load(containerID); ok {
+				reg.cancel()
+				mm.trackedContainers.Delete(containerID)
+			}
+			mm.containerIdToPid.Delete(containerID)
+			mm.scannedFiles.Delete(containerID)
+			mm.podToWlid.Delete(utils.CreateK8sPodID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName))
+			mm.containerIdToShimPid.Delete(containerID)
+		})
+		mm.containerLocks.ReleaseLock(containerID)
 	}
 }
 

--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
@@ -32,6 +33,26 @@ const (
 	maxFileSize                 = 50 * 1024 * 1024 // 50MB
 )
 
+type containerRegistration struct {
+	mu        sync.Mutex
+	timer     *time.Timer
+	done      chan struct{}
+	finished  chan struct{}
+	cancelled bool
+}
+
+func (r *containerRegistration) cancel() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.cancelled {
+		r.cancelled = true
+		if r.timer != nil {
+			r.timer.Stop()
+		}
+		close(r.done)
+	}
+}
+
 type MalwareManager struct {
 	scannedFiles         maps.SafeMap[string, mapset.Set[string]]
 	containerIdToPid     maps.SafeMap[string, uint32]
@@ -45,6 +66,7 @@ type MalwareManager struct {
 	cfg                  config.Config
 	containerIdToShimPid maps.SafeMap[string, uint32]
 	k8sObjectCache       objectcache.K8sObjectCache
+	trackedContainers    maps.SafeMap[string, *containerRegistration]
 }
 
 var _ malwaremanager.MalwareManagerClient = (*MalwareManager)(nil)
@@ -84,35 +106,55 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 		return
 	}
 
-	t := time.NewTicker(utils.AddJitter(mm.cfg.InitialDelay, mm.cfg.MaxJitterPercentage))
+	containerID := notif.Container.Runtime.ContainerID
 
 	switch notif.Type {
 	case containercollection.EventTypeAddContainer:
-		mm.containerIdToPid.Set(notif.Container.Runtime.ContainerID, notif.Container.ContainerPid())
+		mm.containerIdToPid.Set(containerID, notif.Container.ContainerPid())
 		shim, err := utils.GetProcessStat(int(notif.Container.ContainerPid()))
 		if err != nil {
 			logger.L().Warning("RuleManager - failed to get shim process", helpers.Error(err))
 		} else {
-			mm.containerIdToShimPid.Set(notif.Container.Runtime.ContainerID, uint32(shim.PPID))
+			mm.containerIdToShimPid.Set(containerID, uint32(shim.PPID))
 		}
 		go mm.startMalwareManager(notif.Container)
-	case containercollection.EventTypeRemoveContainer:
-		mm.containerIdToPid.Delete(notif.Container.Runtime.ContainerID)
-		t.Stop()
-		mm.scannedFiles.Delete(notif.Container.Runtime.ContainerID)
-		mm.podToWlid.Delete(utils.CreateK8sPodID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName))
-		mm.containerIdToShimPid.Delete(notif.Container.Runtime.ContainerID)
-	}
 
-	go func() {
-		for {
-			select {
-			case <-t.C:
-				mm.scannedFiles.Set(notif.Container.Runtime.ContainerID, mapset.NewSet[string]())
-				return
-			}
+		if oldReg, ok := mm.trackedContainers.Load(containerID); ok {
+			oldReg.cancel()
 		}
-	}()
+
+		delay := utils.AddJitter(mm.cfg.InitialDelay, mm.cfg.MaxJitterPercentage)
+		reg := &containerRegistration{
+			timer:    time.NewTimer(delay),
+			done:     make(chan struct{}),
+			finished: make(chan struct{}),
+		}
+		mm.trackedContainers.Set(containerID, reg)
+
+		go func(r *containerRegistration, cID string) {
+			defer close(r.finished)
+			select {
+			case <-r.done:
+				return
+			case <-r.timer.C:
+				r.mu.Lock()
+				if !r.cancelled {
+					mm.scannedFiles.Set(cID, mapset.NewSet[string]())
+				}
+				r.mu.Unlock()
+			}
+		}(reg, containerID)
+
+	case containercollection.EventTypeRemoveContainer:
+		if reg, ok := mm.trackedContainers.Load(containerID); ok {
+			reg.cancel()
+			mm.trackedContainers.Delete(containerID)
+		}
+		mm.containerIdToPid.Delete(containerID)
+		mm.scannedFiles.Delete(containerID)
+		mm.podToWlid.Delete(utils.CreateK8sPodID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName))
+		mm.containerIdToShimPid.Delete(containerID)
+	}
 }
 
 func (mm *MalwareManager) startMalwareManager(container *containercollection.Container) {

--- a/pkg/malwaremanager/v1/malware_manager.go
+++ b/pkg/malwaremanager/v1/malware_manager.go
@@ -116,7 +116,7 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 		pid := notif.Container.ContainerPid()
 		shim, shimErr := utils.GetProcessStat(int(pid))
 		if shimErr != nil {
-			logger.L().Warning("RuleManager - failed to get shim process", helpers.Error(shimErr))
+			logger.L().Warning("MalwareManager - failed to get shim process", helpers.Error(shimErr))
 		}
 		go mm.startMalwareManager(notif.Container)
 
@@ -165,7 +165,6 @@ func (mm *MalwareManager) ContainerCallback(notif containercollection.PubSubEven
 			mm.podToWlid.Delete(utils.CreateK8sPodID(notif.Container.K8s.Namespace, notif.Container.K8s.PodName))
 			mm.containerIdToShimPid.Delete(containerID)
 		})
-		mm.containerLocks.ReleaseLock(containerID)
 	}
 }
 

--- a/pkg/malwaremanager/v1/malware_manager_test.go
+++ b/pkg/malwaremanager/v1/malware_manager_test.go
@@ -2,6 +2,7 @@ package malwaremanager
 
 import (
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kubescape/node-agent/pkg/malwaremanager"
 	"github.com/kubescape/node-agent/pkg/metricsmanager"
 	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/node-agent/pkg/resourcelocks"
 	"github.com/kubescape/node-agent/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +49,7 @@ func newTestMalwareManager(scanners []malwaremanager.MalwareScanner, exp exporte
 		clusterName:     "test-cluster",
 		metrics:         metricsmanager.NewMetricsMock(),
 		k8sObjectCache:  &objectcache.K8sObjectCacheMock{},
+		containerLocks:  resourcelocks.New(),
 	}
 }
 
@@ -455,4 +458,134 @@ func TestContainerCallback_RapidRemoveAddNoLeakOrResurrection(t *testing.T) {
 
 	_, ok = mm.trackedContainers.Load("rapid-container-id")
 	assert.False(t, ok)
+}
+
+// TestContainerCallback_RemoveAddInterleaveRace is a deterministic regression test
+// for the race described in issue #917 / PR #926:
+//
+//	REMOVE loads registration A
+//	ADD publishes registration B
+//	old REMOVE continues and deletes B
+//
+// The per-container lifecycle lock must prevent this interleaving. This test
+// exercises real ContainerCallback calls with goroutine synchronization to
+// force REMOVE and ADD to contend on the same container ID concurrently, then
+// verifies the final state is correct regardless of scheduling order.
+func TestContainerCallback_RemoveAddInterleaveRace(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.cfg = config.Config{
+		InitialDelay:        1 * time.Millisecond,
+		MaxJitterPercentage: 0,
+	}
+
+	containerID := "interleave-race-container"
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: containerID,
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	// Step 1: ADD creates registration A.
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+	regA, ok := mm.trackedContainers.Load(containerID)
+	require.True(t, ok)
+
+	// Wait for registration A's timer goroutine to complete so that
+	// scannedFiles is populated — this is state that a buggy REMOVE
+	// would incorrectly delete.
+	select {
+	case <-regA.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for registration A timer")
+	}
+	_, hasScanned := mm.scannedFiles.Load(containerID)
+	require.True(t, hasScanned, "scannedFiles should exist after A's timer fires")
+
+	// Step 2: Fire REMOVE and ADD concurrently for the same container ID.
+	// Under the lifecycle lock, these serialize. Whichever runs first,
+	// the final state must be consistent:
+	// - If REMOVE runs first: it removes A, then ADD creates B.
+	// - If ADD runs first: it supersedes A with B, then REMOVE removes B.
+	// Either way, the lifecycle lock ensures no partial interleaving.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	ready := make(chan struct{}) // start both goroutines together
+
+	go func() {
+		defer wg.Done()
+		<-ready
+		mm.ContainerCallback(containercollection.PubSubEvent{
+			Type:      containercollection.EventTypeRemoveContainer,
+			Container: container,
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-ready
+		mm.ContainerCallback(containercollection.PubSubEvent{
+			Type:      containercollection.EventTypeAddContainer,
+			Container: container,
+		})
+	}()
+
+	close(ready) // release both goroutines simultaneously
+	wg.Wait()
+
+	// Step 3: Verify final state is self-consistent.
+	// Because both callbacks serialized under the lock, exactly one of
+	// two orderings happened. We verify the invariant that holds for both:
+	//   If a registration exists, it must not be cancelled, and its timer
+	//   goroutine must be runnable. If no registration exists, all
+	//   per-container state must be cleaned up.
+	if regFinal, ok := mm.trackedContainers.Load(containerID); ok {
+		// ADD ran last — registration B is live.
+		// Use pointer comparison to avoid reflect.DeepEqual racing with
+		// the timer goroutine's mutex operations.
+		assert.True(t, regA != regFinal, "must be a new registration, not the old one")
+
+		// Wait for the timer goroutine to finish before reading
+		// mutex-protected fields, so we don't race on regFinal.mu.
+		select {
+		case <-regFinal.finished:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for final registration timer")
+		}
+
+		regFinal.mu.Lock()
+		cancelled := regFinal.cancelled
+		regFinal.mu.Unlock()
+		assert.False(t, cancelled, "the final registration must not be cancelled")
+
+		// The PID state should be present (set by ADD inside the lock).
+		_, hasPid := mm.containerIdToPid.Load(containerID)
+		assert.True(t, hasPid, "containerIdToPid should be present for live container")
+	} else {
+		// REMOVE ran last — everything is cleaned up.
+		_, hasPid := mm.containerIdToPid.Load(containerID)
+		assert.False(t, hasPid, "containerIdToPid should be cleaned up after REMOVE")
+
+		_, hasScanned := mm.scannedFiles.Load(containerID)
+		assert.False(t, hasScanned, "scannedFiles should be cleaned up after REMOVE")
+	}
+
+	// Step 4: The critical invariant — registration A must always be cancelled,
+	// regardless of ordering. Both REMOVE-first and ADD-first paths cancel A.
+	regA.mu.Lock()
+	aCancelled := regA.cancelled
+	regA.mu.Unlock()
+	assert.True(t, aCancelled, "original registration A must always be cancelled")
 }

--- a/pkg/malwaremanager/v1/malware_manager_test.go
+++ b/pkg/malwaremanager/v1/malware_manager_test.go
@@ -589,3 +589,247 @@ func TestContainerCallback_RemoveAddInterleaveRace(t *testing.T) {
 	regA.mu.Unlock()
 	assert.True(t, aCancelled, "original registration A must always be cancelled")
 }
+
+// delayedSharedDataCache is a K8sObjectCache that blocks GetSharedContainerData
+// until the gate channel is closed, then returns the pre-set data. This allows
+// tests to control exactly when startMalwareManager's backoff succeeds.
+type delayedSharedDataCache struct {
+	objectcache.K8sObjectCacheMock
+	gate chan struct{}
+	data *objectcache.WatchedContainerData
+}
+
+func (d *delayedSharedDataCache) GetSharedContainerData(_ string) *objectcache.WatchedContainerData {
+	select {
+	case <-d.gate:
+		return d.data
+	default:
+		return nil
+	}
+}
+
+// TestStartMalwareManager_CancelledBeforeSharedData verifies that when a
+// container is removed before waitForSharedContainerData returns, the
+// startMalwareManager goroutine does not write stale podToWlid state.
+func TestStartMalwareManager_CancelledBeforeSharedData(t *testing.T) {
+	gate := make(chan struct{})
+	cache := &delayedSharedDataCache{
+		gate: gate,
+		data: &objectcache.WatchedContainerData{Wlid: "wlid://test/workload"},
+	}
+
+	exp := &trackingExporter{}
+	mm := &MalwareManager{
+		cfg:             config.Config{InitialDelay: 10 * time.Minute, MaxJitterPercentage: 0},
+		malwareScanners: nil,
+		exporter:        exp,
+		nodeName:        "test-node",
+		clusterName:     "test-cluster",
+		metrics:         metricsmanager.NewMetricsMock(),
+		k8sObjectCache:  cache,
+		containerLocks:  resourcelocks.New(),
+	}
+
+	containerID := "cancel-before-shared"
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: containerID,
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	// ADD the container — startMalwareManager is now blocked in backoff
+	// because gate is still open (GetSharedContainerData returns nil).
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+
+	reg, ok := mm.trackedContainers.Load(containerID)
+	require.True(t, ok)
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	close(gate)
+
+	select {
+	case <-reg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for registration goroutine to finish")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	podID := "default/test-pod"
+	assert.False(t, mm.podToWlid.Has(podID), "podToWlid must not be set after REMOVE")
+}
+
+// TestStartMalwareManager_RemoveDuringBackoff verifies that a REMOVE during
+// active backoff retry causes the startMalwareManager goroutine to exit
+// without writing podToWlid, even when shared data becomes available between
+// the context cancellation and the write.
+func TestStartMalwareManager_RemoveDuringBackoff(t *testing.T) {
+	gate := make(chan struct{})
+	cache := &delayedSharedDataCache{
+		gate: gate,
+		data: &objectcache.WatchedContainerData{Wlid: "wlid://test/workload2"},
+	}
+
+	exp := &trackingExporter{}
+	mm := &MalwareManager{
+		cfg:             config.Config{InitialDelay: 10 * time.Minute, MaxJitterPercentage: 0},
+		malwareScanners: nil,
+		exporter:        exp,
+		nodeName:        "test-node",
+		clusterName:     "test-cluster",
+		metrics:         metricsmanager.NewMetricsMock(),
+		k8sObjectCache:  cache,
+		containerLocks:  resourcelocks.New(),
+	}
+
+	containerID := "remove-during-backoff"
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: containerID,
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "ns1",
+				PodName:   "pod1",
+			},
+		},
+	}
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+
+	reg, ok := mm.trackedContainers.Load(containerID)
+	require.True(t, ok)
+
+	time.Sleep(50 * time.Millisecond)
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	// Unblock the gate — data would be available now, but the context is cancelled
+	// so the goroutine must not write to podToWlid.
+	close(gate)
+
+	select {
+	case <-reg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for registration goroutine to finish")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	podID := "ns1/pod1"
+	assert.False(t, mm.podToWlid.Has(podID), "podToWlid must not be set after REMOVE during backoff")
+
+	_, hasPid := mm.containerIdToPid.Load(containerID)
+	assert.False(t, hasPid, "containerIdToPid should be cleaned up")
+
+	_, hasScanned := mm.scannedFiles.Load(containerID)
+	assert.False(t, hasScanned, "scannedFiles should be cleaned up")
+
+	_, hasReg := mm.trackedContainers.Load(containerID)
+	assert.False(t, hasReg, "trackedContainers should be cleaned up")
+}
+
+// TestContainerCallback_RemoveDuringAddPrePublication verifies the race condition
+// where REMOVE is processed after an ADD has admitted its registration but before
+// the ADD callback completes its pre-publication slow work. When the ADD resumes,
+// it must not recreate PID/shim mappings, scannedFiles, podToWlid, or registration state.
+func TestContainerCallback_RemoveDuringAddPrePublication(t *testing.T) {
+	exp := &trackingExporter{}
+	cache := &delayedSharedDataCache{
+		gate: make(chan struct{}),
+		data: &objectcache.WatchedContainerData{Wlid: "wlid://test/workload"},
+	}
+	close(cache.gate)
+
+	mm := &MalwareManager{
+		cfg: config.Config{
+			InitialDelay:        10 * time.Minute,
+			MaxJitterPercentage: 0,
+		},
+		malwareScanners: nil,
+		exporter:        exp,
+		nodeName:        "test-node",
+		clusterName:     "test-cluster",
+		metrics:         metricsmanager.NewMetricsMock(),
+		k8sObjectCache:  cache,
+		containerLocks:  resourcelocks.New(),
+	}
+
+	containerID := "pre-publication-race-container"
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: containerID,
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	reg := mm.admitContainer(containerID)
+	require.NotNil(t, reg)
+
+	storedReg, ok := mm.trackedContainers.Load(containerID)
+	require.True(t, ok)
+	require.Equal(t, reg, storedReg)
+
+	mm.startDelayedInit(reg, containerID)
+	go mm.startMalwareManager(reg, container)
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	mm.publishContainerState(containerID, reg, 12345, 1, true)
+
+	select {
+	case <-reg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for registration goroutine to finish")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, hasReg := mm.trackedContainers.Load(containerID)
+	assert.False(t, hasReg, "trackedContainers must be absent")
+
+	_, hasPid := mm.containerIdToPid.Load(containerID)
+	assert.False(t, hasPid, "containerIdToPid must be absent")
+
+	_, hasShimPid := mm.containerIdToShimPid.Load(containerID)
+	assert.False(t, hasShimPid, "containerIdToShimPid must be absent")
+
+	_, hasScanned := mm.scannedFiles.Load(containerID)
+	assert.False(t, hasScanned, "scannedFiles must be absent")
+
+	podID := "default/test-pod"
+	assert.False(t, mm.podToWlid.Has(podID), "podToWlid must be absent")
+}

--- a/pkg/malwaremanager/v1/malware_manager_test.go
+++ b/pkg/malwaremanager/v1/malware_manager_test.go
@@ -269,3 +269,190 @@ func TestContainerCallback_HostContainerIgnored(t *testing.T) {
 	_, hasPid := mm.containerIdToPid.Load("host-container-id")
 	assert.False(t, hasPid)
 }
+
+func TestContainerCallback_RemoveCancelsPendingInit(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.cfg = config.Config{
+		InitialDelay:        10 * time.Minute,
+		MaxJitterPercentage: 0,
+	}
+
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: "pending-container-id",
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+
+	reg, hasReg := mm.trackedContainers.Load("pending-container-id")
+	require.True(t, hasReg)
+	require.NotNil(t, reg)
+	_, hasScanned := mm.scannedFiles.Load("pending-container-id")
+	assert.False(t, hasScanned)
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	select {
+	case <-reg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for registration goroutine to finish")
+	}
+
+	_, hasReg = mm.trackedContainers.Load("pending-container-id")
+	assert.False(t, hasReg)
+
+	reg.mu.Lock()
+	cancelled := reg.cancelled
+	reg.mu.Unlock()
+	assert.True(t, cancelled)
+
+	_, hasScanned = mm.scannedFiles.Load("pending-container-id")
+	assert.False(t, hasScanned)
+}
+
+func TestContainerCallback_NormalDelayedInit(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.cfg = config.Config{
+		InitialDelay:        1 * time.Millisecond,
+		MaxJitterPercentage: 0,
+	}
+
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: "normal-container-id",
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+
+	reg, ok := mm.trackedContainers.Load("normal-container-id")
+	require.True(t, ok)
+
+	select {
+	case <-reg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for normal delayed init")
+	}
+
+	// Verify scannedFiles is initialized
+	scanned, hasScanned := mm.scannedFiles.Load("normal-container-id")
+	assert.True(t, hasScanned)
+	assert.NotNil(t, scanned)
+
+	// Verify removal cleans up scannedFiles and trackedContainers
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	_, hasReg := mm.trackedContainers.Load("normal-container-id")
+	assert.False(t, hasReg)
+
+	_, hasScanned = mm.scannedFiles.Load("normal-container-id")
+	assert.False(t, hasScanned)
+}
+
+func TestContainerCallback_RapidRemoveAddNoLeakOrResurrection(t *testing.T) {
+	exp := &trackingExporter{}
+	mm := newTestMalwareManager(nil, exp)
+	mm.cfg = config.Config{
+		InitialDelay:        10 * time.Minute,
+		MaxJitterPercentage: 0,
+	}
+
+	container := &containercollection.Container{
+		Runtime: containercollection.RuntimeMetadata{
+			BasicRuntimeMetadata: igtypes.BasicRuntimeMetadata{
+				ContainerID: "rapid-container-id",
+			},
+		},
+		K8s: containercollection.K8sMetadata{
+			BasicK8sMetadata: igtypes.BasicK8sMetadata{
+				Namespace: "default",
+				PodName:   "test-pod",
+			},
+		},
+	}
+
+	// 1. First Add
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+	firstReg, ok := mm.trackedContainers.Load("rapid-container-id")
+	require.True(t, ok)
+
+	// 2. Remove
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	select {
+	case <-firstReg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first registration goroutine should finish on remove")
+	}
+
+	firstReg.mu.Lock()
+	firstCancelled := firstReg.cancelled
+	firstReg.mu.Unlock()
+	assert.True(t, firstCancelled)
+
+	// 3. Second Add
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeAddContainer,
+		Container: container,
+	})
+	secondReg, ok := mm.trackedContainers.Load("rapid-container-id")
+	require.True(t, ok)
+	require.NotEqual(t, firstReg, secondReg, "re-Add must create a fresh, distinct registration")
+
+	secondReg.mu.Lock()
+	secondCancelled := secondReg.cancelled
+	secondReg.mu.Unlock()
+	assert.False(t, secondCancelled)
+
+	// 4. Final Remove
+	mm.ContainerCallback(containercollection.PubSubEvent{
+		Type:      containercollection.EventTypeRemoveContainer,
+		Container: container,
+	})
+
+	select {
+	case <-secondReg.finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second registration goroutine should finish on remove")
+	}
+
+	_, ok = mm.trackedContainers.Load("rapid-container-id")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Fixes #917.

`MalwareManager.ContainerCallback` could leave delayed initialization running after a container was removed, allowing `scannedFiles` state to be recreated for a container that no longer existed.

### Changes

- Track delayed initialization with a per-container registration.
- Create the delayed timer only for `EventTypeAddContainer`.
- Cancel the specific registration when `EventTypeRemoveContainer` is received.
- Synchronize cancellation and delayed `scannedFiles` initialization with a per-registration mutex.
- Use a one-shot timer instead of the previous ticker lifecycle.
- Add deterministic regression tests covering:
  - cancellation before delayed initialization
  - normal delayed initialization
  - rapid remove/add lifecycle transitions

### Validation

- `go vet ./pkg/malwaremanager/...`
- `go test -race -count=5 ./pkg/malwaremanager/...`
- `go test -count=1 ./pkg/healthmanager/... ./pkg/malwaremanager/... ./pkg/nodeprofilemanager/...`
- `go test -race ./pkg/healthmanager/... ./pkg/nodeprofilemanager/...`

Closes #917.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container registration handling during rapid additions and removals.
  * Prevented canceled or outdated registrations from initializing unexpectedly.
  * Ensured delayed scan-cache initialization completes independently for each container.
  * Improved cleanup when containers are removed or re-added quickly.
  * Improved consistency during concurrent container updates.
  * Prevented stale registration state from resurfacing after a container is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->