### PR TITLE
fix(exporters): keep limiting after the first dropped alert

### DIFF
--- a/docs/features/alert-rate-limit.md
+++ b/docs/features/alert-rate-limit.md
@@ -1,0 +1,43 @@
+# Alert Rate Limit
+
+`maxAlertsPerMinute` (in `httpExporterConfig`, default `100` via `Validate()`) bounds how many
+alerts the HTTP exporter sends to the backend in a one-minute window. Past the bound the
+exporter drops alerts and sends a single `AlertLimitReached` alert to say so.
+
+## How it works
+
+`admitAlert` is called once per send, on both `SendRuleAlert` and `SendMalwareAlert`. It holds
+the exporter's mutex for the whole decision and returns two values:
+
+| | Meaning |
+|---|---|
+| `admitted` | the alert may be sent. False for **every** alert past the limit in the window. |
+| `notify` | send the `AlertLimitReached` alert. True only for the **first** refusal in the window. |
+
+The window is lazy: the first call, and any call more than a minute after the window started,
+resets the counter and starts a new window. A limit of zero or less means no limit — `Validate()`
+already replaces a zero with the default, so that only guards an exporter built by hand.
+
+Every refused alert is counted in `ReportAlertSuppressed(<rule id>, "rate_limit")`.
+
+## Why two return values
+
+The previous implementation returned one boolean, `count > max && !isNotified`, which combined
+both decisions. The first alert past the limit was dropped and set `isNotified`, and that made
+the condition false for every later alert in the same minute — so they were all sent. The
+limiter dropped exactly one alert per minute and let the rest through, which in practice is no
+limit at all.
+
+Two smaller consequences of the same rewrite:
+
+- The old code reset the window with an early `return false` **without counting** the alert that
+  triggered the reset, so the effective limit was `max + 1`.
+- `ReportAlertSuppressed` fired once per minute rather than once per dropped alert, so the
+  suppression metric could not measure the loss.
+
+## What it does not do
+
+The limit is a fixed window, not a sliding one, so a burst at a window boundary can send up to
+`2 × max` in a short span. That is inherent to the design and unchanged.
+
+The limit is per exporter instance. Consumers that share one exporter share one budget.

--- a/pkg/exporters/alert_limit_test.go
+++ b/pkg/exporters/alert_limit_test.go
@@ -1,0 +1,100 @@
+package exporters
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The alert limit used to stop limiting after its first drop: the notified flag
+// cleared the condition, so the exporter dropped one alert per minute and sent
+// every later one. This pins the fixed behaviour — once the limit is spent, every
+// further alert in the window is dropped, and the notice is decided once.
+func TestAlertLimitKeepsLimitingAfterTheFirstDrop(t *testing.T) {
+	e := &HTTPExporter{
+		config:       HTTPExporterConfig{MaxAlertsPerMinute: 1},
+		alertMetrics: &alertMetrics{},
+	}
+
+	admitted, notify := e.admitAlert()
+	assert.True(t, admitted, "the first alert is inside the limit")
+	assert.False(t, notify)
+
+	admitted, notify = e.admitAlert()
+	assert.False(t, admitted, "the second alert is past the limit")
+	assert.True(t, notify, "and it triggers the one notice")
+
+	for i := 0; i < 5; i++ {
+		admitted, notify = e.admitAlert()
+		assert.False(t, admitted, "alert %d must stay dropped inside the window", i+3)
+		assert.False(t, notify, "the notice is sent once per window")
+	}
+}
+
+// A new window admits alerts again.
+func TestAlertLimitResetsWithTheWindow(t *testing.T) {
+	e := &HTTPExporter{
+		config:       HTTPExporterConfig{MaxAlertsPerMinute: 1},
+		alertMetrics: &alertMetrics{},
+	}
+
+	_, _ = e.admitAlert()
+	admitted, _ := e.admitAlert()
+	assert.False(t, admitted)
+
+	e.alertMetrics.Lock()
+	e.alertMetrics.startTime = time.Now().Add(-2 * time.Minute)
+	e.alertMetrics.Unlock()
+
+	admitted, _ = e.admitAlert()
+	assert.True(t, admitted, "a new window must admit alerts again")
+}
+
+// A limit of zero or less means no limit. The constructor replaces a zero with a
+// default, so this guards the hand-built case only.
+func TestAlertLimitZeroMeansNoLimit(t *testing.T) {
+	e := &HTTPExporter{
+		config:       HTTPExporterConfig{MaxAlertsPerMinute: 0},
+		alertMetrics: &alertMetrics{},
+	}
+	for i := 0; i < 10; i++ {
+		admitted, notify := e.admitAlert()
+		assert.True(t, admitted, "alert %d must be admitted when there is no limit", i)
+		assert.False(t, notify)
+	}
+}
+
+// The decision is taken under one mutex, so concurrent senders must never admit
+// more than the limit inside a window. Run with -race.
+func TestAlertLimitUnderConcurrentSenders(t *testing.T) {
+	const limit = 50
+	e := &HTTPExporter{
+		config:       HTTPExporterConfig{MaxAlertsPerMinute: limit},
+		alertMetrics: &alertMetrics{},
+	}
+
+	var admitted, notified atomic.Int64
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				ok, notify := e.admitAlert()
+				if ok {
+					admitted.Add(1)
+				}
+				if notify {
+					notified.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(limit), admitted.Load(), "exactly the limit must be admitted")
+	assert.Equal(t, int64(1), notified.Load(), "the notice must be decided once")
+}

--- a/pkg/exporters/http_exporter.go
+++ b/pkg/exporters/http_exporter.go
@@ -178,12 +178,14 @@ func (config *HTTPExporterConfig) Validate() error {
 // SendRuleAlert implements the Exporter interface
 func (e *HTTPExporter) SendRuleAlert(failedRule types.RuleFailure) {
 	// Check if alert limit is reached first
-	if e.shouldSendLimitAlert() {
+	if admitted, notify := e.admitAlert(); !admitted {
 		e.metrics.ReportAlertSuppressed(failedRule.GetRuleId(), "rate_limit")
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(e.config.TimeoutSeconds)*time.Second)
-		defer cancel()
-		if err := e.sendAlertLimitReached(ctx); err != nil {
-			logger.L().Warning("HTTPExporter.SendRuleAlert - failed to send alert limit", helpers.Error(err))
+		if notify {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(e.config.TimeoutSeconds)*time.Second)
+			defer cancel()
+			if err := e.sendAlertLimitReached(ctx); err != nil {
+				logger.L().Warning("HTTPExporter.SendRuleAlert - failed to send alert limit", helpers.Error(err))
+			}
 		}
 		return
 	}
@@ -207,12 +209,14 @@ func (e *HTTPExporter) SendRuleAlert(failedRule types.RuleFailure) {
 // SendMalwareAlert implements the Exporter interface
 func (e *HTTPExporter) SendMalwareAlert(malwareResult malwaremanager.MalwareResult) {
 	// Check if alert limit is reached first
-	if e.shouldSendLimitAlert() {
+	if admitted, notify := e.admitAlert(); !admitted {
 		e.metrics.ReportAlertSuppressed(malwareRuleID, "rate_limit")
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(e.config.TimeoutSeconds)*time.Second)
-		defer cancel()
-		if err := e.sendAlertLimitReached(ctx); err != nil {
-			logger.L().Warning("HTTPExporter.SendMalwareAlert - failed to send alert limit", helpers.Error(err))
+		if notify {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(e.config.TimeoutSeconds)*time.Second)
+			defer cancel()
+			if err := e.sendAlertLimitReached(ctx); err != nil {
+				logger.L().Warning("HTTPExporter.SendMalwareAlert - failed to send alert limit", helpers.Error(err))
+			}
 		}
 		return
 	}
@@ -472,21 +476,38 @@ func (e *HTTPExporter) sendHTTPRequest(ctx context.Context, payload interface{})
 	return nil
 }
 
-func (e *HTTPExporter) shouldSendLimitAlert() bool {
+// admitAlert applies the per-minute alert limit to one send.
+//
+// It returns admitted=false for every send past the limit inside the current
+// minute, and notify=true only for the first one.
+//
+// The previous version returned a single value that combined both decisions,
+// which made it stop limiting after the first drop: the notified flag cleared the
+// condition, so the limiter dropped one alert per minute and let every later one
+// through. A limit of zero or less means no limit; the constructor already
+// replaces a zero with a default, so this only guards a hand-built exporter.
+func (e *HTTPExporter) admitAlert() (admitted bool, notify bool) {
 	e.alertMetrics.Lock()
 	defer e.alertMetrics.Unlock()
 
-	if e.alertMetrics.startTime.IsZero() {
-		e.alertMetrics.startTime = time.Now()
+	if e.config.MaxAlertsPerMinute <= 0 {
+		return true, false
 	}
 
-	if time.Since(e.alertMetrics.startTime) > time.Minute {
+	if e.alertMetrics.startTime.IsZero() || time.Since(e.alertMetrics.startTime) > time.Minute {
 		e.resetAlertMetrics()
-		return false
 	}
 
 	e.alertMetrics.count++
-	return e.alertMetrics.count > e.config.MaxAlertsPerMinute && !e.alertMetrics.isNotified
+	if e.alertMetrics.count <= e.config.MaxAlertsPerMinute {
+		return true, false
+	}
+
+	if !e.alertMetrics.isNotified {
+		e.alertMetrics.isNotified = true
+		return false, true
+	}
+	return false, false
 }
 
 func (e *HTTPExporter) resetAlertMetrics() {
@@ -495,11 +516,9 @@ func (e *HTTPExporter) resetAlertMetrics() {
 	e.alertMetrics.isNotified = false
 }
 
+// sendAlertLimitReached sends the one "limit reached" notice per window. The
+// notified flag is set by admitAlert, which is where that decision is made.
 func (e *HTTPExporter) sendAlertLimitReached(ctx context.Context) error {
-	e.alertMetrics.Lock()
-	e.alertMetrics.isNotified = true
-	e.alertMetrics.Unlock()
-
 	alert := armotypes.RuntimeAlert{
 		Message:             "Alert limit reached",
 		HostName:            e.host,
@@ -516,9 +535,13 @@ func (e *HTTPExporter) sendAlertLimitReached(ctx context.Context) error {
 		},
 	}
 
+	e.alertMetrics.Lock()
+	alerts, since := e.alertMetrics.count, e.alertMetrics.startTime
+	e.alertMetrics.Unlock()
+
 	logger.L().Ctx(ctx).Warning("Alert limit reached",
-		helpers.Int("alerts", e.alertMetrics.count),
-		helpers.String("since", e.alertMetrics.startTime.Format(time.RFC3339)))
+		helpers.Int("alerts", alerts),
+		helpers.String("since", since.Format(time.RFC3339)))
 
 	return e.sendAlert(ctx, alert, armotypes.ProcessTree{}, nil)
 }


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->
## Summary

The per-minute alert limit stops limiting after its first drop, so it drops exactly one alert
per minute and sends every later one. In practice there is no limit.

`shouldSendLimitAlert` returns `count > max && !isNotified` — one value carrying two decisions.
The first alert past the limit is dropped and sets `isNotified`, which makes the condition false
for every later alert in that minute, so they are all sent.

## Ticket

None — this repository has no ticket link.

## Changes

- `admitAlert` replaces `shouldSendLimitAlert` and returns the two decisions separately:
  `admitted` is false for every alert past the limit, `notify` is true only for the first one.
- Both call sites drop the alert whenever it is not admitted, and send the `AlertLimitReached`
  notice only on the first. `ReportAlertSuppressed(..., "rate_limit")` now fires for every
  dropped alert instead of once per minute, so that metric becomes usable.
- A limit of zero or less means no limit. `Validate()` already replaces a zero with the default,
  so this only guards an exporter built by hand.
- The window reset no longer swallows the alert that triggers it. The old code returned early
  without counting, so the effective limit was `max + 1`.
- `sendAlertLimitReached` no longer sets the notified flag — `admitAlert` owns that decision —
  and no longer reads `count` and `startTime` without the lock.
- New `docs/features/alert-rate-limit.md`.

## Testing

`go build ./pkg/exporters/` for `GOOS=linux` → pass. New tests in
`pkg/exporters/alert_limit_test.go`: the limiter keeps limiting after its first drop, the window
resets, zero means no limit, and twenty concurrent senders admit exactly the limit while the
notice is decided once. Run on Linux with `-race` → pass, together with the existing
`TestSendRuleAlertRateReached`.

## AI Review

Local review with `armosec-shared-rules:code-review-standards` (Opus, high effort) over the
sibling change in the private agent, which carries the identical fix. Verdict: the limiter logic
is correct, the mutex covers the whole decision, and all call sites are consistent. Its one
finding was about the consequence rather than the code — a real limit can starve one alert kind
when consumers share an exporter — which is why `ReportAlertSuppressed` now counts every drop.

AI-skills: armosec-shared-rules:agent-dispatch-policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert rate limiting so alerts beyond the configured per-minute limit are consistently suppressed.
  * Ensured only one limit-reached notification is emitted per rate-limit window.
  * Added reliable window resets and concurrency-safe enforcement.
  * Nonpositive limits continue to allow unlimited alerts.

* **Documentation**
  * Added documentation covering rate-limit behavior, notifications, metrics, and configuration considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->