### PR TITLE
fix: tighten NOTE-marker detection in check-inspektor-gadget-pin.sh to avoid substring false positives

### DIFF
--- a/scripts/check-inspektor-gadget-pin.sh
+++ b/scripts/check-inspektor-gadget-pin.sh
@@ -97,7 +97,7 @@ while [[ $line_no -ge 1 ]]; do
     fi
 done
 
-if echo "$comment_block" | grep -qiE 'NOTE'; then
+if echo "$comment_block" | grep -qiw 'NOTE'; then
     if echo "$comment_block" | grep -qiE 're-?pin|merged[[:space:]]+SHA'; then
         echo "" >&2
         echo "check-inspektor-gadget-pin: FAIL" >&2


### PR DESCRIPTION
## Overview

`scripts/check-inspektor-gadget-pin.sh` (added in #929) checks for a `NOTE:`-style
comment above the `github.com/inspektor-gadget/inspektor-gadget` replace directive
in `go.mod`, to catch a temporary pin that was never re-pinned to a merged SHA
before the PR merged.

The NOTE-marker detection used:

```bash
if echo "$comment_block" | grep -qiE 'NOTE'; then
```

This is an unanchored, case-insensitive **substring** match. It matches "NOTE"
anywhere in the comment block, including inside unrelated words like
`denote`, `annotate`, or `notebook`. A comment that happens to contain any of
those words -- with no actual `NOTE:` marker present -- would trip this check
and cause a false-positive CI failure on an otherwise-fine PR.

## Fix

Tighten the match to a word-boundary match so it only matches the standalone
word `NOTE` (case-insensitive), not as a substring of other words:

```bash
if echo "$comment_block" | grep -qiw 'NOTE'; then
```

This mirrors the same fix landing in `armosec/private-node-agent`'s copy of
this script (this script was originally ported from there in #929).

## How to Test

Verified locally:

- Real `go.mod` (no NOTE marker on the pin): still exits 0 (PASS), same as
  before the fix.
- Synthetic go.mod with a comment block containing "denote"/"annotate"/
  "notebook" near the replace line, but no real `NOTE:` marker: with the
  pre-fix script this incorrectly FAILs (exit 1); with the fix it correctly
  PASSes (exit 0).
- Synthetic go.mod with a genuine `// NOTE: ... re-pin ... merged SHA`
  comment: still correctly FAILs (exit 1) with the fix in place -- the true
  detection is unaffected.

## Related issues/PRs

- Follows up on #929

## AI Review
Local AI code review ran in this session before the PR was opened (auto-detected by the pr-label hook).

AI-skills: oh-my-claudecode:plan,oh-my-claudecode:ralph,ai-slop-cleaner,code-review | cmds: /oh-my-claudecode:deep-interview