### PR TITLE
feat(objectcache): carry a content checksum for conditional container-profile fetches

### DIFF
--- a/docs/features/container-profile-conditional-fetch-contract.md
+++ b/docs/features/container-profile-conditional-fetch-contract.md
@@ -1,0 +1,114 @@
+# Container Profile Conditional-Fetch Contract
+
+`storage.ProfileClient` fetches a container's learned `ContainerProfile` by name:
+
+```go
+GetContainerProfile(ctx context.Context, namespace, name string) (*v1beta1.ContainerProfile, error)
+```
+
+A remote implementation of this interface can often answer "the body you already have is still current" far more cheaply than it can re-stream an identical profile. That answer needs two things the signature above has no room for: a **validator** the caller sends, and a way to say **"unchanged"** instead of returning a body.
+
+This document describes the vocabulary node-agent exports so a remote implementer can do that, and the guard the reconciler applies before it ever asks. It covers only node-agent's half — the transport that carries the signal off-node is the implementer's concern.
+
+## Why the signal travels out-of-band
+
+`ProfileClient` has a second implementer with no concept of a remote checksum: the in-cluster CRD/aggregated-API client at `pkg/storage/v1/storage.go` (`var _ storage.ProfileClient = (*Storage)(nil)`). Adding a parameter or a return value for a capability only one implementer has would touch every implementer, every mock, and the six-odd test files that declare conformance.
+
+So the request travels on the `context.Context` and the response as a sentinel `error` plus an `ObjectMeta` annotation. The interface signature is unchanged, and the in-cluster implementer changes by **zero lines** — it never attaches a checksum, never returns the sentinel, and behaves exactly as before.
+
+A narrower optional interface discovered by type assertion was considered and rejected: a type assertion fails *silently* when an implementer drifts out of conformance (the fast path just quietly stops engaging), and it does not survive the wrapper layers this call already passes through. A context value and a wrapped error propagate through wrappers for free.
+
+## The exported vocabulary
+
+All four symbols live in `pkg/storage/checksum.go`, next to the interface they extend. That package imports no client library of any kind, which is what keeps `pkg/objectcache` free of transport dependencies.
+
+| Symbol | Type | Value / signature |
+|---|---|---|
+| `storage.ContainerProfileChecksumAnnotationKey` | `const string` | `"backend.kubescape.io/container-profile-checksum"` |
+| `storage.ErrProfileUnchanged` | `var error` | `errors.New("container profile unchanged")` |
+| `storage.WithKnownChecksum` | `func` | `(ctx context.Context, checksum string) context.Context` |
+| `storage.KnownChecksumFromContext` | `func` | `(ctx context.Context) string` |
+
+The context key is an unexported `knownChecksumKey struct{}`, so no other package can collide with it or forge a value.
+
+### Request: `WithKnownChecksum`
+
+The reconciler attaches the checksum of the profile it already holds to the context of a single `GetContainerProfile` call. An implementer reads it with `KnownChecksumFromContext`; `""` (the value for a bare context) means **send the body unconditionally**. An implementer that ignores the value entirely is always correct — it just returns the body, as today.
+
+The checksum is attached **per call, never to a shared parent context**. It is a claim about one specific object, and `refreshOneEntry` fetches two different objects from contexts derived from the same parent.
+
+### Response: `ErrProfileUnchanged`
+
+An implementer that confirmed the caller's checksum still matches returns `(nil, ErrProfileUnchanged)` — no profile, because none was transferred. The reconciler matches it with `errors.Is`, so it may be wrapped.
+
+Returning this sentinel for a request that carried **no** checksum is a protocol violation: it claims a match against a validator the caller never supplied. Implementers must reject that case with a distinct, loud error rather than the sentinel, so a client cache can never be frozen on the basis of nothing.
+
+### Response: the checksum annotation
+
+On a **normal** fetch, an implementer stamps the profile's current checksum onto `ObjectMeta.Annotations` under `ContainerProfileChecksumAnnotationKey`. This is the only channel back through the unchanged signature, and it is what lets an entry acquire the validator it will offer on a later tick. Without it the whole mechanism is permanently inert.
+
+The key is namespaced under `backend.kubescape.io` specifically so it cannot collide with the learning-lifecycle annotations in `k8s-interface/instanceidhandler/v1/helpers` that this cache reads for status and completion (`StatusMetadataKey`, `CompletionMetadataKey`).
+
+### Cross-repo key agreement
+
+The annotation key is a **string contract between repositories**, and it fails silently rather than loudly if the two sides disagree — nothing errors, the cache simply never observes a checksum and every fetch stays unconditional.
+
+The remote implementer today is `armosec/private-node-agent`'s backend adapter (`pkg/backend/storage.go`), which wraps `kubescape/backend`'s `StorageClient`. That client stamps its own constant, `backendv1.ContainerProfileChecksumAnnotationKey`, whose value is the identical string `"backend.kubescape.io/container-profile-checksum"`. The adapter is responsible for translating the backend's vocabulary onto node-agent's — re-keying the annotation if the two ever diverge, and mapping the backend's own unchanged-sentinel onto `storage.ErrProfileUnchanged` so `errors.Is` matches here.
+
+Treat the value as frozen. Changing it on one side only is not a compile error.
+
+## Where the validator is stored
+
+`CachedContainerProfile.Checksum` (`pkg/objectcache/containerprofilecache/containerprofilecache.go`) holds the content checksum of the **learned** CP at last load, read via `checksumOfCP` (`reconciler.go`, mirroring `rvOfCP`). It is best-effort: empty whenever the source supplied no annotation, which is always the case for the in-cluster implementer.
+
+Two properties are easy to get wrong and are both covered by tests in `reconciler_checksum_test.go`:
+
+- **Both construction sites populate it.** `rebuildEntryFromSources` is the obvious one, but `buildEntry` (reached from `tryPopulateEntry` and the pending-promotion retry) matters more. A profile that never changes is built once by `buildEntry` and thereafter always returns at `refreshOneEntry`'s fast-skip, never reaching `rebuildEntryFromSources`. Populating only the rebuild path would leave `Checksum` empty forever for exactly the steady-state profiles this exists for — with every test still green.
+- **It tracks the learned CP, never an adopted authored one.** On the adoption path `tryPopulateEntry` repoints `cp` at the authored profile *before* calling `buildEntry`, so the value is corrected after the call from a checksum captured beforehand — the same shape as the existing `entry.RV = learnedRV` correction, and for the same reason: the validator is offered back on a `GET` of the learned slug, so it must describe that object.
+
+## The five-conjunct guard
+
+`refreshOneEntry` does more than refresh the learned CP: it also re-fetches the user-authored CP, propagates projection-spec changes, and refreshes the entry's cached lifecycle state. A conditional fetch is only legitimate when the body is genuinely not needed for any of that. So the checksum is offered only when all five hold:
+
+```go
+e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == currentSpecHash && e.Checksum != "" &&
+    e.State != nil && e.State.Status == helpersv1.Completed && e.State.Completion == helpersv1.Full
+```
+
+| Conjunct | Why |
+|---|---|
+| `e.UserCPRef == nil` | An authored CP is re-fetched and re-adopted this tick, so the body is needed regardless. |
+| `e.UserCPRV == ""` | `UserCPRef == nil` alone does not establish the fast-skip's `rvsMatchCP(userDefinedCP, e.UserCPRV)`, which with no authored CP present reduces to `rvsMatchCP(nil, e.UserCPRV)` — true only for `""`. Without this, an entry in the `authoredJustDropped` shape (an authored RV on record but no authored CP any more) could skip that handling. |
+| `e.SpecHash == currentSpecHash` | The projection spec moved, so the entry must be re-projected from a real body even if the content is identical. |
+| `e.Checksum != ""` | Nothing to validate against. Sending `""` would mean "unconditional" anyway, and a server answering "unchanged" to it would be the protocol violation described above. |
+| state is `Completed` + `Full` | The lifecycle annotations sit **outside** the content checksum, so a profile finishing its learning period presents an unchanged checksum. Without this conjunct the entry would answer "unchanged" on that tick *and every later one* — the checksum stays valid indefinitely — so the rebuild that refreshes `e.State` would never run and the cached state would freeze permanently. |
+
+Each conjunct has its own negative test asserting that no checksum is sent when it fails.
+
+### Why the state conjunct is not optional
+
+`entry.State` is not internal bookkeeping. `pkg/rulemanager/rule_manager.go`'s `HasFinalApplicationProfile` gates on `state.Status == helpersv1.Completed && state.Completion == helpersv1.Full`, and `pkg/rulemanager/ruleadapters/creator.go` stamps `FailOnProfile` and the reported profile status onto every alert built from it. A frozen state would make a finished profile keep alerting as partial forever.
+
+Note the asymmetry with `e.RV` below: RV staleness self-corrects at the next unconditional fetch, whereas a frozen state has no next unconditional fetch — the condition that caused it also perpetuates it. That is why one is accepted and the other is guarded against.
+
+The predicate is `Completed` + `Full` rather than `isTerminalCPStatus` (which also admits `TooLarge`) deliberately: it is the exact state rulemanager treats as final, and the only one from which no further lifecycle transition is expected. A `TooLarge` profile simply keeps fetching bodies — a lost optimization, not a correctness risk.
+
+`currentSpecHash` is snapshotted **once, above the fetch**, and reused for both the guard and the later fast-skip, so the two decisions cannot disagree within a tick. The trade-off: a projection-spec swap landing *during* the fetch is noticed on the next tick rather than this one. That is self-healing — the next tick's `e.SpecHash != currentSpecHash` comparison forces the rebuild regardless.
+
+## Handling the sentinel
+
+`refreshOneEntry` matches `errors.Is(cpErr, storage.ErrProfileUnchanged)` **before** the `apierrors.IsNotFound` check and returns with the cache entry left completely untouched.
+
+The explicit branch is load-bearing, not cosmetic. Without it, a sentinel that also carries a not-found shape would fall into the not-found path, which sets `cp = nil`, finds no authored CP either, and **evicts the entry**. A sentinel that does not carry a not-found shape would instead land in the generic transient-error path — which happens to keep the entry, but logs it as a fetch failure, making a successful optimization indistinguishable from a broken connection.
+
+### Accepted freshness divergence
+
+A checksum match proves the **content** is byte-identical. It does not prove `ResourceVersion` equality: RV can bump on a metadata-only write, and annotations are outside the content checksum. On a sentinel response the client never sees the new object, so **`e.RV` keeps its previous value**.
+
+This one is deliberate and accepted. Every consumer downstream of this cache reads the projected *content*; `e.RV` serves only as a change detector for the next tick, where a stale-but-lower RV is conservative — it can cause an extra rebuild, never a missed one. Including annotations in the checksum would defeat the optimization entirely, since the learning pipeline rewrites them continuously. The behavior is pinned by a test that asserts the staleness *positively*, so it reads as intended rather than as a defect waiting to be found.
+
+The cached `State` is a different matter and is **not** allowed to go stale: the guard's state conjunct keeps an entry on the unconditional path until its lifecycle has finished, precisely because that staleness would be permanent rather than bounded. See "Why the state conjunct is not optional" above.
+
+## Current status in this repo
+
+No in-tree `ProfileClient` implementer returns `ErrProfileUnchanged`, so within node-agent alone this is a contract with no observable behavior change: the guard evaluates, `e.Checksum` stays empty for the in-cluster client, and every fetch is unconditional exactly as before. The vocabulary exists so an out-of-tree implementer can opt in without any change to the interface or to the in-cluster client.

--- a/docs/features/container-profile-conditional-fetch-contract.md
+++ b/docs/features/container-profile-conditional-fetch-contract.md
@@ -41,11 +41,13 @@ The checksum is attached **per call, never to a shared parent context**. It is a
 
 An implementer that confirmed the caller's checksum still matches returns `(nil, ErrProfileUnchanged)` — no profile, because none was transferred. The reconciler matches it with `errors.Is`, so it may be wrapped.
 
-Returning this sentinel for a request that carried **no** checksum is a protocol violation: it claims a match against a validator the caller never supplied. Implementers must reject that case with a distinct, loud error rather than the sentinel, so a client cache can never be frozen on the basis of nothing.
+Returning this sentinel for a request that carried **no** checksum is a protocol violation: it claims a match against a validator the caller never supplied. The reconciler tracks `validatorOffered` for the exact call and accepts the sentinel only when that flag is true. An unsolicited sentinel is logged as a warning, counted as `protocol_error`, and handled like a transient failure: the existing entry stays in place, but the response does not consume an unchanged allowance or clear a forced-revalidation debt.
 
 ### Response: the checksum annotation
 
 On a **normal** fetch, an implementer stamps the profile's current checksum onto `ObjectMeta.Annotations` under `ContainerProfileChecksumAnnotationKey`. This is the only channel back through the unchanged signature, and it is what lets an entry acquire the validator it will offer on a later tick. Without it the whole mechanism is permanently inert.
+
+The canonical remote validator is `sha256:<64 lowercase hexadecimal characters>`. Node-agent treats the complete value as opaque: it neither parses nor prefixes it, and compares/returns it byte-for-byte. The backend's API boundary owns conversion from a raw stored SHA-256 value into this canonical wire form. Keeping normalization at that boundary prevents different `ProfileClient` adapters from inventing incompatible validators.
 
 The key is namespaced under `backend.kubescape.io` specifically so it cannot collide with the learning-lifecycle annotations in `k8s-interface/instanceidhandler/v1/helpers` that this cache reads for status and completion (`StatusMetadataKey`, `CompletionMetadataKey`).
 
@@ -65,39 +67,43 @@ Two properties are easy to get wrong and are both covered by tests in `reconcile
 
 - **Both construction sites populate it.** `rebuildEntryFromSources` is the obvious one, but `buildEntry` (reached from `tryPopulateEntry` and the pending-promotion retry) matters more. A profile that never changes is built once by `buildEntry` and thereafter always returns at `refreshOneEntry`'s fast-skip, never reaching `rebuildEntryFromSources`. Populating only the rebuild path would leave `Checksum` empty forever for exactly the steady-state profiles this exists for — with every test still green.
 - **It tracks the learned CP, never an adopted authored one.** On the adoption path `tryPopulateEntry` repoints `cp` at the authored profile *before* calling `buildEntry`, so the value is corrected after the call from a checksum captured beforehand — the same shape as the existing `entry.RV = learnedRV` correction, and for the same reason: the validator is offered back on a `GET` of the learned slug, so it must describe that object.
+- **It participates in fast-skip invalidation.** Matching ResourceVersions are not sufficient for remote objects, where RV may remain empty or unchanged across different bodies. `checksumOfCP(cp) == e.Checksum` must also hold. This rebuilds on changed content and on first checksum acquisition even when both RV values match.
 
-## The five-conjunct guard
+Each entry also carries an unexported consecutive-unchanged count. Ten valid `ErrProfileUnchanged` responses may be accepted in sequence. The next otherwise-eligible refresh suppresses the validator and forces a body. Only a successful learned-profile body resets the count, including a byte-identical body that later takes the fast-skip; transport errors and unsolicited sentinels leave the force-due state intact. This bounds exposure to an incorrectly accepted or stale remote validator to ten refresh intervals without adding public configuration.
 
-`refreshOneEntry` does more than refresh the learned CP: it also re-fetches the user-authored CP, propagates projection-spec changes, and refreshes the entry's cached lifecycle state. A conditional fetch is only legitimate when the body is genuinely not needed for any of that. So the checksum is offered only when all five hold:
+## Validator eligibility and forced revalidation
+
+`refreshOneEntry` does more than refresh the learned CP: it also re-fetches the user-authored CP, propagates projection-spec changes, and refreshes the entry's cached lifecycle state. A conditional fetch is only legitimate when the body is genuinely not needed for any of that. The reconciler first snapshots the projection-spec hash and computes eligibility:
 
 ```go
-e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == currentSpecHash && e.Checksum != "" &&
+validatorEligible := e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == preFetchSpecHash &&
     e.State != nil && e.State.Status == helpersv1.Completed && e.State.Completion == helpersv1.Full
 ```
 
-| Conjunct | Why |
+| Condition | Why |
 |---|---|
 | `e.UserCPRef == nil` | An authored CP is re-fetched and re-adopted this tick, so the body is needed regardless. |
 | `e.UserCPRV == ""` | `UserCPRef == nil` alone does not establish the fast-skip's `rvsMatchCP(userDefinedCP, e.UserCPRV)`, which with no authored CP present reduces to `rvsMatchCP(nil, e.UserCPRV)` — true only for `""`. Without this, an entry in the `authoredJustDropped` shape (an authored RV on record but no authored CP any more) could skip that handling. |
-| `e.SpecHash == currentSpecHash` | The projection spec moved, so the entry must be re-projected from a real body even if the content is identical. |
-| `e.Checksum != ""` | Nothing to validate against. Sending `""` would mean "unconditional" anyway, and a server answering "unchanged" to it would be the protocol violation described above. |
-| state is `Completed` + `Full` | The lifecycle annotations sit **outside** the content checksum, so a profile finishing its learning period presents an unchanged checksum. Without this conjunct the entry would answer "unchanged" on that tick *and every later one* — the checksum stays valid indefinitely — so the rebuild that refreshes `e.State` would never run and the cached state would freeze permanently. |
+| `e.SpecHash == preFetchSpecHash` | The projection spec moved before the request, so the entry must be re-projected from a real body even if the content is identical. |
+| state is `Completed` + `Full` | The lifecycle annotations sit **outside** the content checksum, so a profile finishing its learning period presents an unchanged checksum. Without this condition the entry could keep answering "unchanged", preventing the rebuild that refreshes `e.State`. |
 
-Each conjunct has its own negative test asserting that no checksum is sent when it fails.
+Request mode is then selected from a closed set. A missing checksum takes `missing`; a present checksum with failed eligibility takes `ineligible`; an eligible entry at the ten-response bound takes `forced_revalidation`; otherwise the checksum is attached and the mode is `offered`. Only the last case sets `validatorOffered`.
+
+Every condition has a negative test asserting that no checksum is sent when it fails, and the forced-revalidation tests pin the ten-response boundary and recovery behavior.
 
 ### Why the state conjunct is not optional
 
-`entry.State` is not internal bookkeeping. `pkg/rulemanager/rule_manager.go`'s `HasFinalApplicationProfile` gates on `state.Status == helpersv1.Completed && state.Completion == helpersv1.Full`, and `pkg/rulemanager/ruleadapters/creator.go` stamps `FailOnProfile` and the reported profile status onto every alert built from it. A frozen state would make a finished profile keep alerting as partial forever.
+`entry.State` is not internal bookkeeping. `pkg/rulemanager/rule_manager.go`'s `HasFinalApplicationProfile` gates on `state.Status == helpersv1.Completed && state.Completion == helpersv1.Full`, and `pkg/rulemanager/ruleadapters/creator.go` stamps `FailOnProfile` and the reported profile status onto every alert built from it. Delaying that state transition would make a finished profile keep alerting as partial until the forced body arrives.
 
-Note the asymmetry with `e.RV` below: RV staleness self-corrects at the next unconditional fetch, whereas a frozen state has no next unconditional fetch — the condition that caused it also perpetuates it. That is why one is accepted and the other is guarded against.
+State staleness has a more direct effect than RV staleness: `e.RV` is bookkeeping, while `e.State` changes whether rulemanager considers the profile final and how alerts are stamped. Forced revalidation bounds both, but the state guard keeps lifecycle transitions immediate rather than delaying them for as many as ten refresh intervals.
 
 The predicate is `Completed` + `Full` rather than `isTerminalCPStatus` (which also admits `TooLarge`) deliberately: it is the exact state rulemanager treats as final, and the only one from which no further lifecycle transition is expected. A `TooLarge` profile simply keeps fetching bodies — a lost optimization, not a correctness risk.
 
-`currentSpecHash` is snapshotted **once, above the fetch**, and reused for both the guard and the later fast-skip, so the two decisions cannot disagree within a tick. The trade-off: a projection-spec swap landing *during* the fetch is noticed on the next tick rather than this one. That is self-healing — the next tick's `e.SpecHash != currentSpecHash` comparison forces the rebuild regardless.
+The spec hash has two snapshots with deliberately different roles. `preFetchSpecHash` decides whether a validator may be offered. Immediately before the fast-skip, `postFetchSpecHash` is read again; the skip requires `e.SpecHash == postFetchSpecHash`. A projection-spec replacement that lands during a body fetch therefore rebuilds the entry under the new spec instead of preserving the old projection. If a spec replacement overlaps a valid unchanged response, its nudge is retained by the trailing-edge scheduler described below and the following pass fetches the body because the entry is then ineligible.
 
 ## Handling the sentinel
 
-`refreshOneEntry` matches `errors.Is(cpErr, storage.ErrProfileUnchanged)` **before** the `apierrors.IsNotFound` check and returns with the cache entry left completely untouched.
+`refreshOneEntry` checks `errors.Is(cpErr, storage.ErrProfileUnchanged)` before `apierrors.IsNotFound`, but accepts it only when `validatorOffered` is true for that exact request. A valid response keeps the same cache-entry pointer, leaves its projected data, RV, and checksum unchanged, increments the consecutive-unchanged count, and records the `unchanged` outcome. An unsolicited response records `protocol_error` and follows the transient-failure policy without advancing or resetting that count.
 
 The explicit branch is load-bearing, not cosmetic. Without it, a sentinel that also carries a not-found shape would fall into the not-found path, which sets `cp = nil`, finds no authored CP either, and **evicts the entry**. A sentinel that does not carry a not-found shape would instead land in the generic transient-error path — which happens to keep the entry, but logs it as a fetch failure, making a successful optimization indistinguishable from a broken connection.
 
@@ -105,10 +111,29 @@ The explicit branch is load-bearing, not cosmetic. Without it, a sentinel that a
 
 A checksum match proves the **content** is byte-identical. It does not prove `ResourceVersion` equality: RV can bump on a metadata-only write, and annotations are outside the content checksum. On a sentinel response the client never sees the new object, so **`e.RV` keeps its previous value**.
 
-This one is deliberate and accepted. Every consumer downstream of this cache reads the projected *content*; `e.RV` serves only as a change detector for the next tick, where a stale-but-lower RV is conservative — it can cause an extra rebuild, never a missed one. Including annotations in the checksum would defeat the optimization entirely, since the learning pipeline rewrites them continuously. The behavior is pinned by a test that asserts the staleness *positively*, so it reads as intended rather than as a defect waiting to be found.
+This one is deliberate and bounded. Every consumer downstream of this cache reads the projected *content*; `e.RV` serves only as a change detector. The forced full-body request after ten valid unchanged responses refreshes RV and state even if the content checksum remains stable. Including annotations in the checksum would defeat the optimization entirely, since the learning pipeline rewrites them continuously. Tests pin both the temporary RV staleness and the revalidation bound.
 
-The cached `State` is a different matter and is **not** allowed to go stale: the guard's state conjunct keeps an entry on the unconditional path until its lifecycle has finished, precisely because that staleness would be permanent rather than bounded. See "Why the state conjunct is not optional" above.
+The cached `State` still stays on the unconditional path until it is `Completed` + `Full`; this avoids waiting up to ten intervals for a learning-lifecycle transition that directly affects enforcement.
+
+## Refresh scheduling
+
+Periodic ticks and projection-spec nudges both call `scheduleRefresh`. It is a trailing-edge single-flight scheduler: the first request starts one worker, requests arriving during a pass set a pending bit, and the worker drains that bit with one more pass after the active pass finishes. Multiple overlapping requests coalesce, but none can be stranded.
+
+A mutex protects both pending state and worker ownership. In particular, checking that no trailing work remains and marking the worker idle are one atomic handoff. This closes the race where a request could otherwise arrive after the final pending check but before an atomic in-progress flag was cleared. Ticker handling still performs eviction and pending-entry retry work before it schedules refresh; only the profile-refresh pass is consolidated.
+
+This matters for spec changes: a nudge received while a ticker-owned refresh is blocked must revisit entries that the active pass already processed under the old spec. One scheduler test blocks the second profile fetch, nudges after the first was processed, and verifies a single non-overlapping trailing pass rebuilds both entries under the new spec. A second test places a request at the final pending/idle handoff and verifies it always produces another pass.
+
+## Metrics
+
+The following counters are always on; they are not gated by `profileProjection.detailedMetricsEnabled`:
+
+| Metric | Attribute | Closed values |
+|---|---|---|
+| `node_agent.profile.conditional_fetch.requests.total` | `mode` | `offered`, `missing`, `ineligible`, `forced_revalidation` |
+| `node_agent.profile.conditional_fetch.responses.total` | `outcome` | `body`, `unchanged`, `not_found`, `error`, `protocol_error` |
+
+They intentionally carry no container, namespace, profile name, checksum, or error-text attributes. `missing` makes an annotation-key mismatch or adapter omission visible; `protocol_error` makes an unsolicited sentinel visible; and `forced_revalidation` shows that the safety bound is active.
 
 ## Current status in this repo
 
-No in-tree `ProfileClient` implementer returns `ErrProfileUnchanged`, so within node-agent alone this is a contract with no observable behavior change: the guard evaluates, `e.Checksum` stays empty for the in-cluster client, and every fetch is unconditional exactly as before. The vocabulary exists so an out-of-tree implementer can opt in without any change to the interface or to the in-cluster client.
+No in-tree `ProfileClient` implementer returns `ErrProfileUnchanged`. The in-cluster client supplies no checksum annotation, so its refreshes remain unconditional and are observed as `mode="missing", outcome="body"`. Checksum-aware invalidation and the unified scheduler still apply to every implementation; an out-of-tree remote adapter can opt into body omission without changing the interface.

--- a/pkg/metricsmanager/metrics_manager_interface.go
+++ b/pkg/metricsmanager/metrics_manager_interface.go
@@ -26,6 +26,12 @@ type MetricsManager interface {
 	ReportContainerProfileCacheHit(hit bool)
 	ReportContainerProfileReconcilerDuration(phase string, duration time.Duration)
 	ReportContainerProfileReconcilerEviction(reason string)
+	// ReportContainerProfileConditionalFetchRequest counts the closed request modes:
+	// offered, missing, ineligible, and forced_revalidation.
+	ReportContainerProfileConditionalFetchRequest(mode string)
+	// ReportContainerProfileConditionalFetchResponse counts the closed outcomes:
+	// body, unchanged, not_found, error, and protocol_error.
+	ReportContainerProfileConditionalFetchResponse(outcome string)
 	// ReportContainerProfileSplit counts chunks halved after a transport-level size rejection.
 	ReportContainerProfileSplit()
 	// ReportContainerProfileChunkDropped counts chunks discarded because they could not be

--- a/pkg/metricsmanager/metrics_manager_mock.go
+++ b/pkg/metricsmanager/metrics_manager_mock.go
@@ -13,11 +13,13 @@ import (
 var _ MetricsManager = (*MetricsMock)(nil)
 
 type MetricsMock struct {
-	FailedEventCounter   atomic.Int32
-	RuleProcessedCounter maps.SafeMap[string, int]
-	RuleAlertCounter     maps.SafeMap[string, int]
-	EventCounter         maps.SafeMap[utils.EventType, int]
-	RuleEvaluationTime   maps.SafeMap[string, time.Duration] // key: "ruleID:eventType"
+	FailedEventCounter                     atomic.Int32
+	RuleProcessedCounter                   maps.SafeMap[string, int]
+	RuleAlertCounter                       maps.SafeMap[string, int]
+	EventCounter                           maps.SafeMap[utils.EventType, int]
+	RuleEvaluationTime                     maps.SafeMap[string, time.Duration] // key: "ruleID:eventType"
+	ProfileConditionalFetchRequestCounter  maps.SafeMap[string, int]
+	ProfileConditionalFetchResponseCounter maps.SafeMap[string, int]
 }
 
 func NewMetricsMock() *MetricsMock {
@@ -35,6 +37,8 @@ func (m *MetricsMock) Destroy() {
 	m.RuleAlertCounter.Clear()
 	m.EventCounter.Clear()
 	m.RuleEvaluationTime.Clear()
+	m.ProfileConditionalFetchRequestCounter.Clear()
+	m.ProfileConditionalFetchResponseCounter.Clear()
 }
 
 func (m *MetricsMock) ReportFailedEvent() {
@@ -73,29 +77,35 @@ func (m *MetricsMock) SetContainerProfileCacheEntries(_ string, _ float64)      
 func (m *MetricsMock) ReportContainerProfileCacheHit(_ bool)                              {}
 func (m *MetricsMock) ReportContainerProfileReconcilerDuration(_ string, _ time.Duration) {}
 func (m *MetricsMock) ReportContainerProfileReconcilerEviction(_ string)                  {}
-func (m *MetricsMock) ReportContainerProfileSplit()                                       {}
-func (m *MetricsMock) ReportContainerProfileChunkDropped(_ string)                        {}
-func (m *MetricsMock) IncMissingProfileDataRequired(_ string)                             {}
-func (m *MetricsMock) IncProjectionUndeclaredLiteral(_ string)                            {}
-func (m *MetricsMock) SetProjectionStaleEntries(_ float64)                                {}
-func (m *MetricsMock) SetProjectionUndeclaredRules(_ float64)                             {}
-func (m *MetricsMock) IncProjectionSpecCompile()                                          {}
-func (m *MetricsMock) IncProjectionSpecHashChange()                                       {}
-func (m *MetricsMock) SetProjectionSpecPatterns(_, _ string, _ float64)                   {}
-func (m *MetricsMock) SetProjectionSpecAllField(_ string, _ bool)                         {}
-func (m *MetricsMock) ObserveProjectionApplyDuration(_ time.Duration)                     {}
-func (m *MetricsMock) IncProjectionReconcileTriggered(_ string)                           {}
-func (m *MetricsMock) IncHelperCall(_ string)                                             {}
-func (m *MetricsMock) IncUserDefinedProfileUnresolved(_ string)                           {}
-func (m *MetricsMock) IncUserDefinedProfileAdopted(_ string)                              {}
-func (m *MetricsMock) SetProjectionUndeclaredRulesDetail(_ []string)                      {}
-func (m *MetricsMock) ObserveProfileRawSize(_ float64)                                    {}
-func (m *MetricsMock) ObserveProfileProjectedSize(_ float64)                              {}
-func (m *MetricsMock) ObserveProfileEntriesRaw(_ string, _ float64)                       {}
-func (m *MetricsMock) ObserveProfileEntriesRetained(_ string, _ float64)                  {}
-func (m *MetricsMock) ObserveProfileRetentionRatio(_ string, _ float64)                   {}
-func (m *MetricsMock) ReportSBOMScan(_ string)                                            {}
-func (m *MetricsMock) ObserveSBOMScanDuration(_ string, _ time.Duration)                  {}
-func (m *MetricsMock) ReportSBOMScannerRestart()                                          {}
-func (m *MetricsMock) SetSBOMScannerReady(_ bool)                                         {}
-func (m *MetricsMock) ReportAlertSuppressed(_, _ string)                                  {}
+func (m *MetricsMock) ReportContainerProfileConditionalFetchRequest(mode string) {
+	m.ProfileConditionalFetchRequestCounter.Set(mode, m.ProfileConditionalFetchRequestCounter.Get(mode)+1)
+}
+func (m *MetricsMock) ReportContainerProfileConditionalFetchResponse(outcome string) {
+	m.ProfileConditionalFetchResponseCounter.Set(outcome, m.ProfileConditionalFetchResponseCounter.Get(outcome)+1)
+}
+func (m *MetricsMock) ReportContainerProfileSplit()                      {}
+func (m *MetricsMock) ReportContainerProfileChunkDropped(_ string)       {}
+func (m *MetricsMock) IncMissingProfileDataRequired(_ string)            {}
+func (m *MetricsMock) IncProjectionUndeclaredLiteral(_ string)           {}
+func (m *MetricsMock) SetProjectionStaleEntries(_ float64)               {}
+func (m *MetricsMock) SetProjectionUndeclaredRules(_ float64)            {}
+func (m *MetricsMock) IncProjectionSpecCompile()                         {}
+func (m *MetricsMock) IncProjectionSpecHashChange()                      {}
+func (m *MetricsMock) SetProjectionSpecPatterns(_, _ string, _ float64)  {}
+func (m *MetricsMock) SetProjectionSpecAllField(_ string, _ bool)        {}
+func (m *MetricsMock) ObserveProjectionApplyDuration(_ time.Duration)    {}
+func (m *MetricsMock) IncProjectionReconcileTriggered(_ string)          {}
+func (m *MetricsMock) IncHelperCall(_ string)                            {}
+func (m *MetricsMock) IncUserDefinedProfileUnresolved(_ string)          {}
+func (m *MetricsMock) IncUserDefinedProfileAdopted(_ string)             {}
+func (m *MetricsMock) SetProjectionUndeclaredRulesDetail(_ []string)     {}
+func (m *MetricsMock) ObserveProfileRawSize(_ float64)                   {}
+func (m *MetricsMock) ObserveProfileProjectedSize(_ float64)             {}
+func (m *MetricsMock) ObserveProfileEntriesRaw(_ string, _ float64)      {}
+func (m *MetricsMock) ObserveProfileEntriesRetained(_ string, _ float64) {}
+func (m *MetricsMock) ObserveProfileRetentionRatio(_ string, _ float64)  {}
+func (m *MetricsMock) ReportSBOMScan(_ string)                           {}
+func (m *MetricsMock) ObserveSBOMScanDuration(_ string, _ time.Duration) {}
+func (m *MetricsMock) ReportSBOMScannerRestart()                         {}
+func (m *MetricsMock) SetSBOMScannerReady(_ bool)                        {}
+func (m *MetricsMock) ReportAlertSuppressed(_, _ string)                 {}

--- a/pkg/metricsmanager/metrics_manager_noop.go
+++ b/pkg/metricsmanager/metrics_manager_noop.go
@@ -29,6 +29,8 @@ func (m *MetricsNoop) SetContainerProfileCacheEntries(_ string, _ float64)      
 func (m *MetricsNoop) ReportContainerProfileCacheHit(_ bool)                              {}
 func (m *MetricsNoop) ReportContainerProfileReconcilerDuration(_ string, _ time.Duration) {}
 func (m *MetricsNoop) ReportContainerProfileReconcilerEviction(_ string)                  {}
+func (m *MetricsNoop) ReportContainerProfileConditionalFetchRequest(_ string)             {}
+func (m *MetricsNoop) ReportContainerProfileConditionalFetchResponse(_ string)            {}
 func (m *MetricsNoop) ReportContainerProfileSplit()                                       {}
 func (m *MetricsNoop) ReportContainerProfileChunkDropped(_ string)                        {}
 func (m *MetricsNoop) IncMissingProfileDataRequired(_ string)                             {}

--- a/pkg/metricsmanager/otel/otel_metrics_manager.go
+++ b/pkg/metricsmanager/otel/otel_metrics_manager.go
@@ -35,13 +35,15 @@ type OTELMetricsManager struct {
 	dedupEventsTotal    metric.Int64Counter
 
 	// ContainerProfile cache
-	profileLegacyLoadTotal   metric.Int64Counter
-	profileCacheEntries      metric.Float64Gauge
-	profileCacheHitTotal     metric.Int64Counter
-	reconcilerDuration       metric.Float64Histogram
-	reconcilerEvictionsTotal metric.Int64Counter
-	profileSplitTotal        metric.Int64Counter
-	profileChunkDroppedTotal metric.Int64Counter
+	profileLegacyLoadTotal                metric.Int64Counter
+	profileCacheEntries                   metric.Float64Gauge
+	profileCacheHitTotal                  metric.Int64Counter
+	reconcilerDuration                    metric.Float64Histogram
+	reconcilerEvictionsTotal              metric.Int64Counter
+	profileConditionalFetchRequestsTotal  metric.Int64Counter
+	profileConditionalFetchResponsesTotal metric.Int64Counter
+	profileSplitTotal                     metric.Int64Counter
+	profileChunkDroppedTotal              metric.Int64Counter
 
 	// Rule projection — always-on
 	projMissingDeclTotal   metric.Int64Counter
@@ -187,6 +189,10 @@ func NewOTELMetricsManager(ownContainerID, ownPodUID string, hostCgroupMounted b
 		"ContainerProfile reconciler phase duration", "s", defBuckets)
 	m.reconcilerEvictionsTotal = mustCounter("node_agent.profile.reconciler.evictions.total",
 		"ContainerProfile cache evictions by reason")
+	m.profileConditionalFetchRequestsTotal = mustCounter("node_agent.profile.conditional_fetch.requests.total",
+		"ContainerProfile conditional-fetch requests by validator mode")
+	m.profileConditionalFetchResponsesTotal = mustCounter("node_agent.profile.conditional_fetch.responses.total",
+		"ContainerProfile conditional-fetch responses by outcome")
 	m.profileSplitTotal = mustCounter("node_agent.profile.split.total",
 		"ContainerProfile chunks halved after a transport-level size rejection")
 	m.profileChunkDroppedTotal = mustCounter("node_agent.profile.chunk.dropped.total",
@@ -383,6 +389,18 @@ func (m *OTELMetricsManager) ReportContainerProfileReconcilerDuration(phase stri
 func (m *OTELMetricsManager) ReportContainerProfileReconcilerEviction(reason string) {
 	m.reconcilerEvictionsTotal.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("reason", reason),
+	))
+}
+
+func (m *OTELMetricsManager) ReportContainerProfileConditionalFetchRequest(mode string) {
+	m.profileConditionalFetchRequestsTotal.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("mode", mode),
+	))
+}
+
+func (m *OTELMetricsManager) ReportContainerProfileConditionalFetchResponse(outcome string) {
+	m.profileConditionalFetchResponsesTotal.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("outcome", outcome),
 	))
 }
 

--- a/pkg/metricsmanager/otel/otel_metrics_manager_test.go
+++ b/pkg/metricsmanager/otel/otel_metrics_manager_test.go
@@ -1,0 +1,74 @@
+package otelmetrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestContainerProfileConditionalFetchMetrics(t *testing.T) {
+	previousProvider := otel.GetMeterProvider()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() {
+		err := provider.Shutdown(context.Background())
+		otel.SetMeterProvider(previousProvider)
+		assert.NoError(t, err)
+	})
+
+	manager := NewOTELMetricsManager("", "", false)
+	requestModes := []string{"offered", "missing", "ineligible", "forced_revalidation"}
+	responseOutcomes := []string{"body", "unchanged", "not_found", "error", "protocol_error"}
+	for _, mode := range requestModes {
+		manager.ReportContainerProfileConditionalFetchRequest(mode)
+	}
+	for _, outcome := range responseOutcomes {
+		manager.ReportContainerProfileConditionalFetchResponse(outcome)
+	}
+
+	var resourceMetrics metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &resourceMetrics))
+	assertCounterAttributeValues(t, resourceMetrics,
+		"node_agent.profile.conditional_fetch.requests.total", "mode", requestModes)
+	assertCounterAttributeValues(t, resourceMetrics,
+		"node_agent.profile.conditional_fetch.responses.total", "outcome", responseOutcomes)
+}
+
+func assertCounterAttributeValues(
+	t *testing.T,
+	resourceMetrics metricdata.ResourceMetrics,
+	metricName string,
+	attributeKey attribute.Key,
+	want []string,
+) {
+	t.Helper()
+
+	seen := make(map[string]int64, len(want))
+	for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
+		for _, exportedMetric := range scopeMetrics.Metrics {
+			if exportedMetric.Name != metricName {
+				continue
+			}
+			sum, ok := exportedMetric.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s must export as an int64 sum", metricName)
+			for _, point := range sum.DataPoints {
+				attributes := point.Attributes.ToSlice()
+				require.Len(t, attributes, 1, "%s must have only its closed-cardinality attribute", metricName)
+				assert.Equal(t, attributeKey, attributes[0].Key)
+				seen[attributes[0].Value.AsString()] = point.Value
+			}
+		}
+	}
+
+	require.Len(t, seen, len(want), "%s must export every expected label value", metricName)
+	for _, value := range want {
+		assert.Equal(t, int64(1), seen[value], "%s{%s=%q}", metricName, attributeKey, value)
+	}
+}

--- a/pkg/objectcache/containerprofilecache/containerprofilecache.go
+++ b/pkg/objectcache/containerprofilecache/containerprofilecache.go
@@ -84,6 +84,15 @@ type CachedContainerProfile struct {
 	RV       string // ContainerProfile resourceVersion at last load
 	UserCPRV string // user-defined ContainerProfile (label-referenced) RV at last load, "" if not used
 
+	// Checksum is the content checksum of the learned CP at last load, read
+	// from storage.ContainerProfileChecksumAnnotationKey. Best-effort: empty
+	// when the source supplies none, which is always the case for the
+	// in-cluster CRD-backed client. The reconciler offers it back to the source
+	// as a conditional-fetch validator; an empty value simply means every fetch
+	// is unconditional. Like RV, it tracks the LEARNED CP (the object CPName
+	// points at), never an adopted authored one.
+	Checksum string
+
 	// terminatedSeenAt is set by the reconciler the first time it observes the
 	// container Terminated; eviction happens on a later tick once the removal
 	// grace has elapsed. Accessed only from the reconciler goroutine.
@@ -456,8 +465,13 @@ func (c *ContainerProfileCacheImpl) tryPopulateEntry(
 	// transient error, freezing the entry so authored-CP edits are never picked
 	// up (review finding on node-agent#864).
 	learnedRV := ""
+	learnedChecksum := ""
 	if cp != nil {
 		learnedRV = cp.ResourceVersion
+		// Captured here for the same reason as learnedRV: entry.Checksum is a
+		// validator for the object entry.CPName points at (the learned slug),
+		// so it must be read before cp is repointed at the authored profile.
+		learnedChecksum = checksumOfCP(cp)
 	}
 
 	// A user-defined ContainerProfile is authoritative for this container: it is
@@ -496,6 +510,10 @@ func (c *ContainerProfileCacheImpl) tryPopulateEntry(
 	// (the learned slug), so leaving the authored RV here makes the permanent 404
 	// on that slug look transient and freezes the entry. Track the learned RV.
 	entry.RV = learnedRV
+	// Same correction for the conditional-fetch validator: buildEntry derived it
+	// from the adopted (possibly authored) cp, but it is offered back on a GET of
+	// the learned slug, so it must describe the learned CP or nothing.
+	entry.Checksum = learnedChecksum
 	// WorkloadName is the synthesize-name source refreshOneEntry uses when it
 	// rebuilds an entry whose consolidated CP is not yet in storage.
 	entry.WorkloadName = workloadName
@@ -555,6 +573,7 @@ func (c *ContainerProfileCacheImpl) buildEntry(
 		WorkloadID:    sharedData.Wlid + "/" + sharedData.InstanceID.GetTemplateHash(),
 		CPName:        cp.Name,
 		RV:            cp.ResourceVersion,
+		Checksum:      checksumOfCP(cp),
 	}
 	if pod != nil {
 		entry.PodUID = string(pod.UID)

--- a/pkg/objectcache/containerprofilecache/containerprofilecache.go
+++ b/pkg/objectcache/containerprofilecache/containerprofilecache.go
@@ -93,6 +93,12 @@ type CachedContainerProfile struct {
 	// points at), never an adopted authored one.
 	Checksum string
 
+	// consecutiveUnchanged counts valid ErrProfileUnchanged responses since the
+	// last successful learned-profile body. After the bounded allowance the next
+	// otherwise-eligible refresh suppresses the validator and forces a full body.
+	// It is accessed only while holding this entry's container lock.
+	consecutiveUnchanged int
+
 	// terminatedSeenAt is set by the reconciler the first time it observes the
 	// container Terminated; eviction happens on a later tick once the removal
 	// grace has elapsed. Accessed only from the reconciler goroutine.
@@ -122,9 +128,17 @@ type ContainerProfileCacheImpl struct {
 	k8sObjectCache objectcache.K8sObjectCache
 	metricsManager metricsmanager.MetricsManager
 
-	reconcileEvery    time.Duration
-	rpcBudget         time.Duration
-	refreshInProgress atomic.Bool
+	reconcileEvery time.Duration
+	rpcBudget      time.Duration
+
+	// refreshMu protects the trailing-edge single-flight scheduler. A refresh
+	// request always sets refreshPending. The active worker clears it before each
+	// pass and keeps draining until no request arrived during the preceding pass.
+	// Checking pending and handing ownership back are atomic under this mutex, so
+	// a request cannot get stranded in the final handoff race.
+	refreshMu         sync.Mutex
+	refreshInProgress bool
+	refreshPending    bool
 
 	// removalGrace is how long an entry stays resolvable after the container's
 	// remove callback. Events emitted during the container's life are still in
@@ -142,7 +156,6 @@ type ContainerProfileCacheImpl struct {
 	currentSpec    *objectcache.RuleProjectionSpec
 	specGeneration atomic.Int64  // bumped on each distinct spec hash change
 	nudge          chan struct{} // buffered cap 1; signals reconciler on spec change
-	refreshPending atomic.Bool   // set when a nudge arrives while refresh is running
 }
 
 // NewContainerProfileCache creates a new ContainerProfileCacheImpl.

--- a/pkg/objectcache/containerprofilecache/reconciler.go
+++ b/pkg/objectcache/containerprofilecache/reconciler.go
@@ -18,6 +18,7 @@ package containerprofilecache
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/kubescape/go-logger"
@@ -25,6 +26,7 @@ import (
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/node-agent/pkg/objectcache"
 	"github.com/kubescape/node-agent/pkg/objectcache/callstackcache"
+	"github.com/kubescape/node-agent/pkg/storage"
 	"github.com/kubescape/node-agent/pkg/utils"
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -331,6 +333,56 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 
 	ns := e.Namespace
 
+	// Snapshot the projection spec ONCE, before the fetch, and reuse it for both
+	// the conditional-fetch guard below and the fast-skip further down. The
+	// guard needs it pre-fetch, and reading it twice could straddle a concurrent
+	// SetProjectionSpec and let the two decisions disagree within one tick.
+	// Consequence: a spec swap landing DURING the fetch is now noticed on the
+	// next tick rather than this one. That is self-healing — the next tick's
+	// e.SpecHash != currentSpecHash comparison forces the rebuild regardless.
+	currentSpecHash := ""
+	if spec := c.snapshotSpec(); spec != nil {
+		currentSpecHash = spec.Hash
+	}
+
+	// Offer the stored checksum as a conditional-fetch validator only when an
+	// "unchanged" answer would have led to the fast-skip below anyway — i.e.
+	// when the body is genuinely not needed for anything else this tick:
+	//   - UserCPRef == nil: no authored CP to re-fetch and re-adopt.
+	//   - UserCPRV == "": no authored RV on record either. Without this,
+	//     an entry in the authoredJustDropped shape (a recorded authored RV but
+	//     no authored CP any more) could skip that handling. It mirrors
+	//     rvsMatchCP(nil, e.UserCPRV) in the fast-skip, which is true only for "".
+	//   - SpecHash == currentSpecHash: the projection would be identical.
+	//   - Checksum != "": we actually hold a validator to offer.
+	//   - State is already terminal: see below.
+	//
+	// The state conjunct is not redundant with the others. e.State is derived
+	// from the StatusMetadataKey/CompletionMetadataKey ANNOTATIONS, which sit
+	// outside the content checksum — so a lifecycle flip (partial -> full)
+	// leaves the checksum matching. Without this conjunct such an entry would
+	// answer "unchanged" on that tick AND on every later one (its checksum
+	// stays valid indefinitely), so the rebuild that refreshes e.State would
+	// never fire and the cached state would freeze permanently. That is not
+	// the bounded one-fetch staleness accepted for e.RV: it never self-corrects.
+	// It matters because e.State is not internal bookkeeping — rulemanager gates
+	// HasFinalApplicationProfile on Completed+Full and stamps FailOnProfile on
+	// every alert from it, so a frozen state keeps alerting a completed profile
+	// as partial forever.
+	//
+	// Requiring Completed+Full (rather than isTerminalCPStatus, which also
+	// admits TooLarge) is deliberate: it is the exact predicate rulemanager
+	// treats as final, and it is the only state from which no further lifecycle
+	// transition is expected. A TooLarge profile simply keeps fetching bodies.
+	//
+	// Attached per call, never to the shared ctx: the authored-CP fetch below
+	// derives from the same ctx and must never carry the learned CP's checksum.
+	cpCtx := ctx
+	if e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == currentSpecHash && e.Checksum != "" &&
+		e.State != nil && e.State.Status == helpersv1.Completed && e.State.Completion == helpersv1.Full {
+		cpCtx = storage.WithKnownChecksum(ctx, e.Checksum)
+	}
+
 	// Re-fetch all sources. CP fetch errors (including 404) are treated as
 	// "not available right now" — mirroring tryPopulateEntry's behavior. We
 	// leave cp=nil and rely on the RV-match fast-skip below to preserve the
@@ -339,11 +391,24 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 	// while the storage-side consolidated CP remains unpublished.
 	var cp *v1beta1.ContainerProfile
 	var cpErr error
-	_ = c.refreshRPC(ctx, func(rctx context.Context) error {
+	_ = c.refreshRPC(cpCtx, func(rctx context.Context) error {
 		cp, cpErr = c.storageClient.GetContainerProfile(rctx, ns, e.CPName)
 		return cpErr
 	})
 	if cpErr != nil {
+		// Checked before IsNotFound: an implementation is free to return a
+		// sentinel that also carries a not-found shape, and "unchanged" is the
+		// more specific claim. The source verified our checksum still matches
+		// and sent no body, so the entry we hold is known-good — leave it
+		// entirely alone. Deliberately does NOT refresh e.RV or e.Checksum:
+		// there is no fresh object to read them from, so e.RV may lag a
+		// metadata-only write until the next unconditional fetch.
+		if errors.Is(cpErr, storage.ErrProfileUnchanged) {
+			logger.L().Debug("refreshOneEntry: CP unchanged (checksum match); keeping cached entry without rebuild",
+				helpers.String("containerID", id),
+				helpers.String("cpName", e.CPName))
+			return
+		}
 		if !apierrors.IsNotFound(cpErr) {
 			logger.L().Debug("refreshOneEntry: CP fetch failed transiently; keeping cached entry",
 				helpers.String("containerID", id),
@@ -413,11 +478,9 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 	// this avoids spurious rebuilds when an optional source is still missing,
 	// as long as it was also missing at the last build. Also skip when the
 	// projection spec hash matches: if neither the data nor the spec changed,
-	// the projected output would be identical.
-	currentSpecHash := ""
-	if spec := c.snapshotSpec(); spec != nil {
-		currentSpecHash = spec.Hash
-	}
+	// the projected output would be identical. currentSpecHash is the value
+	// hoisted above the fetch — deliberately not re-read here, so the guard and
+	// this comparison cannot disagree within a tick.
 	if rvsMatchCP(cp, e.RV) &&
 		rvsMatchCP(userDefinedCP, e.UserCPRV) &&
 		e.SpecHash == currentSpecHash {
@@ -510,6 +573,7 @@ func (c *ContainerProfileCacheImpl) rebuildEntryFromSources(
 		WorkloadName:     prev.WorkloadName,
 		RV:               rvOfCP(cp),
 		UserCPRV:         rvOfCP(userDefinedCP),
+		Checksum:         checksumOfCP(cp),
 		terminatedSeenAt: prev.terminatedSeenAt,
 	}
 	if userDefinedCP != nil {
@@ -539,6 +603,16 @@ func rvOfCP(o *v1beta1.ContainerProfile) string {
 		return ""
 	}
 	return o.ResourceVersion
+}
+
+// checksumOfCP returns the content checksum a ProfileClient stamped on the
+// object, or "" when the object is absent or the source supplied none (the
+// in-cluster CRD-backed client never does). Mirrors rvOfCP.
+func checksumOfCP(o *v1beta1.ContainerProfile) string {
+	if o == nil {
+		return ""
+	}
+	return o.Annotations[storage.ContainerProfileChecksumAnnotationKey]
 }
 
 // observeMemoryMetrics records per-field entry counts, retention ratios, and

--- a/pkg/objectcache/containerprofilecache/reconciler.go
+++ b/pkg/objectcache/containerprofilecache/reconciler.go
@@ -4,10 +4,10 @@
 // loop. Each tick it:
 //  1. reconcileOnce: evicts cache entries whose pod is gone or whose
 //     container is no longer Running.
-//  2. refreshAllEntries (single-flight via atomic flag): re-fetches the
+//  2. refreshAllEntries (trailing-edge single-flight): re-fetches the
 //     consolidated ContainerProfile and any label-referenced user-defined
-//     ContainerProfile, then rebuilds the projection iff any resourceVersion
-//     changed. Fast-skip when every RV matches what's already cached.
+//     ContainerProfile, then rebuilds the projection iff a source or the
+//     projection spec changed. Fast-skip only when RVs, checksum, and spec match.
 //
 // RPC cost @ 300 containers / 30s cadence steady-state: up to 2 gets per entry
 // per tick (consolidated CP + label-referenced user-defined CP). At 300 entries
@@ -33,13 +33,29 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+const maxConsecutiveUnchangedResponses = 10
+
+const (
+	conditionalFetchModeOffered            = "offered"
+	conditionalFetchModeMissing            = "missing"
+	conditionalFetchModeIneligible         = "ineligible"
+	conditionalFetchModeForcedRevalidation = "forced_revalidation"
+
+	conditionalFetchOutcomeBody          = "body"
+	conditionalFetchOutcomeUnchanged     = "unchanged"
+	conditionalFetchOutcomeNotFound      = "not_found"
+	conditionalFetchOutcomeError         = "error"
+	conditionalFetchOutcomeProtocolError = "protocol_error"
+)
+
 // tickLoop drives the reconciler. Each tick it evicts terminated containers,
 // retries pending entries, and refreshes all cached entries. Pending-entry
 // retries are also triggered immediately via NotifyContainerCompleted when the
 // containerprofilemanager writes a CP with status="completed".
 //
-// Refresh runs on a single-flight goroutine guarded by refreshInProgress so a
-// slow refresh never stacks.
+// Refresh requests from both ticker and nudge paths share one trailing-edge
+// single-flight scheduler, so a request received during any active pass causes
+// one more pass after it finishes without stacking concurrent refreshes.
 func (c *ContainerProfileCacheImpl) tickLoop(ctx context.Context) {
 	if c.reconcileEvery == 0 {
 		c.reconcileEvery = defaultReconcileInterval
@@ -55,22 +71,12 @@ func (c *ContainerProfileCacheImpl) tickLoop(ctx context.Context) {
 			return
 		case <-c.nudge:
 			// Spec changed — re-project all entries immediately without
-			// waiting for the next periodic tick. Use trailing-edge consolidation:
-			// mark pending so that if a refresh is already running it will
-			// re-run once after it finishes, preventing entries from staying on
-			// an old spec for up to one full reconcile interval.
+			// waiting for the next periodic tick. The shared scheduler preserves
+			// this request when either trigger already owns the active refresh.
 			if c.cfg.ProfileProjection.DetailedMetricsEnabled {
 				c.metricsManager.IncProjectionReconcileTriggered("nudge")
 			}
-			c.refreshPending.Store(true)
-			if c.refreshInProgress.CompareAndSwap(false, true) {
-				go func() {
-					defer c.refreshInProgress.Store(false)
-					for c.refreshPending.Swap(false) {
-						c.refreshAllEntries(ctx)
-					}
-				}()
-			}
+			c.scheduleRefresh(ctx)
 		case <-ticker.C:
 			if c.cfg.ProfileProjection.DetailedMetricsEnabled {
 				c.metricsManager.IncProjectionReconcileTriggered("tick")
@@ -95,13 +101,41 @@ func (c *ContainerProfileCacheImpl) tickLoop(ctx context.Context) {
 					helpers.Int("pending_after", pendingAfter))
 			}
 			c.metricsManager.ReportContainerProfileReconcilerDuration("evict", time.Since(start))
-			if c.refreshInProgress.CompareAndSwap(false, true) {
-				go func() {
-					defer c.refreshInProgress.Store(false)
-					c.refreshAllEntries(ctx)
-				}()
-			}
+			c.scheduleRefresh(ctx)
 		}
+	}
+}
+
+// scheduleRefresh records a refresh request and, when needed, starts the sole
+// refresh worker. Multiple requests during one pass collapse into one trailing
+// pass. The pending check and ownership handoff happen under the same mutex so
+// a request cannot land between them and remain stranded.
+func (c *ContainerProfileCacheImpl) scheduleRefresh(ctx context.Context) {
+	c.refreshMu.Lock()
+	c.refreshPending = true
+	if c.refreshInProgress {
+		c.refreshMu.Unlock()
+		return
+	}
+	c.refreshInProgress = true
+	c.refreshMu.Unlock()
+
+	go c.runScheduledRefreshes(ctx)
+}
+
+func (c *ContainerProfileCacheImpl) runScheduledRefreshes(ctx context.Context) {
+	for {
+		c.refreshMu.Lock()
+		if !c.refreshPending || ctx.Err() != nil {
+			c.refreshPending = false
+			c.refreshInProgress = false
+			c.refreshMu.Unlock()
+			return
+		}
+		c.refreshPending = false
+		c.refreshMu.Unlock()
+
+		c.refreshAllEntries(ctx)
 	}
 }
 
@@ -263,8 +297,8 @@ func containerDeclaredInSpec(pod *corev1.Pod, name string) bool {
 }
 
 // refreshAllEntries re-fetches the learned CP + the user-authored CP for each
-// cache entry and updates the projection if any ResourceVersion changed.
-// Fast-skip when RV + UserCPRV both match (delta #4). Exposed for tests.
+// cache entry and updates the projection if a source or projection spec changed.
+// Fast-skip only when both source RVs, learned checksum, and spec hash match.
 func (c *ContainerProfileCacheImpl) refreshAllEntries(ctx context.Context) {
 	start := time.Now()
 	defer func() {
@@ -312,8 +346,8 @@ func (c *ContainerProfileCacheImpl) refreshAllEntries(ctx context.Context) {
 // refreshOneEntry refreshes a single cache entry under the per-container lock.
 // Re-fetches ALL sources the entry was originally built from (the consolidated
 // ContainerProfile and any label-referenced user-defined ContainerProfile) and
-// rebuilds the projection if ANY ResourceVersion changed. Keeping the existing
-// entry on fetch errors is fine: the next tick will retry.
+// rebuilds the projection if a source RV/checksum or projection spec changed.
+// Keeping the existing entry on fetch errors is fine: the next tick will retry.
 //
 // Rebuild on refresh mirrors tryPopulateEntry: a label-referenced user-defined
 // CP, when present, REPLACES the learned CP as the authoritative base.
@@ -333,16 +367,13 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 
 	ns := e.Namespace
 
-	// Snapshot the projection spec ONCE, before the fetch, and reuse it for both
-	// the conditional-fetch guard below and the fast-skip further down. The
-	// guard needs it pre-fetch, and reading it twice could straddle a concurrent
-	// SetProjectionSpec and let the two decisions disagree within one tick.
-	// Consequence: a spec swap landing DURING the fetch is now noticed on the
-	// next tick rather than this one. That is self-healing — the next tick's
-	// e.SpecHash != currentSpecHash comparison forces the rebuild regardless.
-	currentSpecHash := ""
+	// Snapshot the projection spec before the fetch only to decide whether it is
+	// safe to offer the current body checksum. The fast-skip takes a fresh
+	// snapshot after the fetch so a spec replacement that lands while the RPC is
+	// in flight cannot preserve a projection built under the old spec.
+	preFetchSpecHash := ""
 	if spec := c.snapshotSpec(); spec != nil {
-		currentSpecHash = spec.Hash
+		preFetchSpecHash = spec.Hash
 	}
 
 	// Offer the stored checksum as a conditional-fetch validator only when an
@@ -353,39 +384,53 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 	//     an entry in the authoredJustDropped shape (a recorded authored RV but
 	//     no authored CP any more) could skip that handling. It mirrors
 	//     rvsMatchCP(nil, e.UserCPRV) in the fast-skip, which is true only for "".
-	//   - SpecHash == currentSpecHash: the projection would be identical.
+	//   - SpecHash == preFetchSpecHash: the projection would be identical.
 	//   - Checksum != "": we actually hold a validator to offer.
 	//   - State is already terminal: see below.
 	//
 	// The state conjunct is not redundant with the others. e.State is derived
 	// from the StatusMetadataKey/CompletionMetadataKey ANNOTATIONS, which sit
 	// outside the content checksum — so a lifecycle flip (partial -> full)
-	// leaves the checksum matching. Without this conjunct such an entry would
-	// answer "unchanged" on that tick AND on every later one (its checksum
-	// stays valid indefinitely), so the rebuild that refreshes e.State would
-	// never fire and the cached state would freeze permanently. That is not
-	// the bounded one-fetch staleness accepted for e.RV: it never self-corrects.
-	// It matters because e.State is not internal bookkeeping — rulemanager gates
-	// HasFinalApplicationProfile on Completed+Full and stamps FailOnProfile on
-	// every alert from it, so a frozen state keeps alerting a completed profile
-	// as partial forever.
+	// leaves the checksum matching. Without this conjunct the transition would
+	// remain invisible until the forced full-body request, up to ten refresh
+	// intervals later. That delay is unacceptable because e.State is not internal
+	// bookkeeping — rulemanager gates HasFinalApplicationProfile on Completed+Full
+	// and stamps FailOnProfile on every alert from it.
 	//
 	// Requiring Completed+Full (rather than isTerminalCPStatus, which also
 	// admits TooLarge) is deliberate: it is the exact predicate rulemanager
 	// treats as final, and it is the only state from which no further lifecycle
 	// transition is expected. A TooLarge profile simply keeps fetching bodies.
 	//
+	// Even when eligible, at most maxConsecutiveUnchangedResponses validators are
+	// offered in a row. The next request forces a body so a stale or incorrectly
+	// accepted remote validator cannot pin the enforced projection indefinitely.
+	//
 	// Attached per call, never to the shared ctx: the authored-CP fetch below
 	// derives from the same ctx and must never carry the learned CP's checksum.
+	validatorEligible := e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == preFetchSpecHash &&
+		e.State != nil && e.State.Status == helpersv1.Completed && e.State.Completion == helpersv1.Full
+	validatorOffered := false
+	requestMode := conditionalFetchModeMissing
 	cpCtx := ctx
-	if e.UserCPRef == nil && e.UserCPRV == "" && e.SpecHash == currentSpecHash && e.Checksum != "" &&
-		e.State != nil && e.State.Status == helpersv1.Completed && e.State.Completion == helpersv1.Full {
+	switch {
+	case e.Checksum == "":
+		// No validator is available, regardless of whether the other eligibility
+		// conditions currently hold.
+	case !validatorEligible:
+		requestMode = conditionalFetchModeIneligible
+	case e.consecutiveUnchanged >= maxConsecutiveUnchangedResponses:
+		requestMode = conditionalFetchModeForcedRevalidation
+	default:
+		requestMode = conditionalFetchModeOffered
+		validatorOffered = true
 		cpCtx = storage.WithKnownChecksum(ctx, e.Checksum)
 	}
+	c.metricsManager.ReportContainerProfileConditionalFetchRequest(requestMode)
 
 	// Re-fetch all sources. CP fetch errors (including 404) are treated as
 	// "not available right now" — mirroring tryPopulateEntry's behavior. We
-	// leave cp=nil and rely on the RV-match fast-skip below to preserve the
+	// leave cp=nil and rely on the RV/checksum fast-skip below to preserve the
 	// existing entry when nothing has changed. This is what lets refresh
 	// pick up workload-level AP/NN transitions ("ready" -> "completed") even
 	// while the storage-side consolidated CP remains unpublished.
@@ -395,32 +440,43 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 		cp, cpErr = c.storageClient.GetContainerProfile(rctx, ns, e.CPName)
 		return cpErr
 	})
-	if cpErr != nil {
-		// Checked before IsNotFound: an implementation is free to return a
-		// sentinel that also carries a not-found shape, and "unchanged" is the
-		// more specific claim. The source verified our checksum still matches
-		// and sent no body, so the entry we hold is known-good — leave it
-		// entirely alone. Deliberately does NOT refresh e.RV or e.Checksum:
-		// there is no fresh object to read them from, so e.RV may lag a
-		// metadata-only write until the next unconditional fetch.
-		if errors.Is(cpErr, storage.ErrProfileUnchanged) {
-			logger.L().Debug("refreshOneEntry: CP unchanged (checksum match); keeping cached entry without rebuild",
+	switch {
+	case cpErr == nil:
+		c.metricsManager.ReportContainerProfileConditionalFetchResponse(conditionalFetchOutcomeBody)
+		// A successful body re-establishes the cache from source truth even when
+		// the later fast-skip finds it byte-identical. It is the only event that
+		// clears a forced-revalidation debt.
+		if cp != nil {
+			e.consecutiveUnchanged = 0
+		}
+	case errors.Is(cpErr, storage.ErrProfileUnchanged):
+		if !validatorOffered {
+			c.metricsManager.ReportContainerProfileConditionalFetchResponse(conditionalFetchOutcomeProtocolError)
+			logger.L().Warning("refreshOneEntry: source returned unchanged without an offered checksum; keeping cached entry as a transient failure",
 				helpers.String("containerID", id),
 				helpers.String("cpName", e.CPName))
 			return
 		}
-		if !apierrors.IsNotFound(cpErr) {
-			logger.L().Debug("refreshOneEntry: CP fetch failed transiently; keeping cached entry",
-				helpers.String("containerID", id),
-				helpers.String("cpName", e.CPName),
-				helpers.Error(cpErr))
-			return
-		}
+		c.metricsManager.ReportContainerProfileConditionalFetchResponse(conditionalFetchOutcomeUnchanged)
+		e.consecutiveUnchanged++
+		logger.L().Debug("refreshOneEntry: CP unchanged (checksum match); keeping cached entry without rebuild",
+			helpers.String("containerID", id),
+			helpers.String("cpName", e.CPName))
+		return
+	case apierrors.IsNotFound(cpErr):
+		c.metricsManager.ReportContainerProfileConditionalFetchResponse(conditionalFetchOutcomeNotFound)
 		logger.L().Debug("refreshOneEntry: CP not available (NotFound or no prior CP); dropping learned base",
 			helpers.String("containerID", id),
 			helpers.String("cpName", e.CPName),
 			helpers.Error(cpErr))
 		cp = nil
+	default:
+		c.metricsManager.ReportContainerProfileConditionalFetchResponse(conditionalFetchOutcomeError)
+		logger.L().Debug("refreshOneEntry: CP fetch failed transiently; keeping cached entry",
+			helpers.String("containerID", id),
+			helpers.String("cpName", e.CPName),
+			helpers.Error(cpErr))
+		return
 	}
 	// Re-fetch the user-defined ContainerProfile (migrated "new way") FIRST, when
 	// the entry was built from one. It is the authoritative base and the only
@@ -474,16 +530,18 @@ func (c *ContainerProfileCacheImpl) refreshOneEntry(ctx context.Context, id stri
 			helpers.String("status", cp.Annotations[helpersv1.StatusMetadataKey]))
 		return
 	}
-	// Fast-skip when nothing changed. We match "absent" (nil) with empty RV:
-	// this avoids spurious rebuilds when an optional source is still missing,
-	// as long as it was also missing at the last build. Also skip when the
-	// projection spec hash matches: if neither the data nor the spec changed,
-	// the projected output would be identical. currentSpecHash is the value
-	// hoisted above the fetch — deliberately not re-read here, so the guard and
-	// this comparison cannot disagree within a tick.
+	// Fast-skip when neither source content nor the projection spec changed.
+	// ResourceVersion alone is insufficient for remote profiles: the backend may
+	// leave it empty or unchanged while returning a different body. Checksum also
+	// detects first-time validator acquisition on an otherwise identical object.
+	postFetchSpecHash := ""
+	if spec := c.snapshotSpec(); spec != nil {
+		postFetchSpecHash = spec.Hash
+	}
 	if rvsMatchCP(cp, e.RV) &&
+		checksumOfCP(cp) == e.Checksum &&
 		rvsMatchCP(userDefinedCP, e.UserCPRV) &&
-		e.SpecHash == currentSpecHash {
+		e.SpecHash == postFetchSpecHash {
 		return
 	}
 
@@ -505,7 +563,7 @@ func rvsMatchCP(obj *v1beta1.ContainerProfile, rv string) bool {
 // label-referenced user-defined CP, when present, REPLACES the learned CP (or
 // the synthesized base) as the authoritative base.
 //
-// Called by the reconciler when any input ResourceVersion has changed.
+// Called by the reconciler when a source RV/checksum or projection spec changed.
 func (c *ContainerProfileCacheImpl) rebuildEntryFromSources(
 	id string,
 	prev *CachedContainerProfile,
@@ -560,21 +618,22 @@ func (c *ContainerProfileCacheImpl) rebuildEntryFromSources(
 	}
 
 	newEntry := &CachedContainerProfile{
-		Projected:        projectedCP,
-		SpecHash:         projectedCP.SpecHash,
-		State:            &objectcache.ProfileState{Completion: effectiveCP.Annotations[helpersv1.CompletionMetadataKey], Status: effectiveCP.Annotations[helpersv1.StatusMetadataKey], Name: effectiveCP.Name},
-		CallStackTree:    tree,
-		ContainerName:    prev.ContainerName,
-		PodName:          prev.PodName,
-		Namespace:        prev.Namespace,
-		PodUID:           podUID,
-		WorkloadID:       prev.WorkloadID,
-		CPName:           prev.CPName,
-		WorkloadName:     prev.WorkloadName,
-		RV:               rvOfCP(cp),
-		UserCPRV:         rvOfCP(userDefinedCP),
-		Checksum:         checksumOfCP(cp),
-		terminatedSeenAt: prev.terminatedSeenAt,
+		Projected:            projectedCP,
+		SpecHash:             projectedCP.SpecHash,
+		State:                &objectcache.ProfileState{Completion: effectiveCP.Annotations[helpersv1.CompletionMetadataKey], Status: effectiveCP.Annotations[helpersv1.StatusMetadataKey], Name: effectiveCP.Name},
+		CallStackTree:        tree,
+		ContainerName:        prev.ContainerName,
+		PodName:              prev.PodName,
+		Namespace:            prev.Namespace,
+		PodUID:               podUID,
+		WorkloadID:           prev.WorkloadID,
+		CPName:               prev.CPName,
+		WorkloadName:         prev.WorkloadName,
+		RV:                   rvOfCP(cp),
+		UserCPRV:             rvOfCP(userDefinedCP),
+		Checksum:             checksumOfCP(cp),
+		consecutiveUnchanged: prev.consecutiveUnchanged,
+		terminatedSeenAt:     prev.terminatedSeenAt,
 	}
 	if userDefinedCP != nil {
 		// The user-authored CP is authoritative and complete by definition (no

--- a/pkg/objectcache/containerprofilecache/reconciler_checksum_test.go
+++ b/pkg/objectcache/containerprofilecache/reconciler_checksum_test.go
@@ -1,0 +1,721 @@
+package containerprofilecache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/node-agent/pkg/objectcache"
+	"github.com/kubescape/node-agent/pkg/storage"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// recordedFetch is one observed GetContainerProfile call: the object name asked
+// for, and the conditional-fetch validator the caller attached to that call's
+// context (empty when none was attached).
+type recordedFetch struct {
+	name     string
+	checksum string
+}
+
+// checksumRecordingClient is a storage.ProfileClient that records the known
+// checksum carried by EACH call's context. Recording per call (rather than per
+// client) is what makes the negative assertions possible: the authored-CP fetch
+// and the learned-CP fetch derive from the same parent context, so a design that
+// attached the checksum to that shared context instead of per call would show up
+// here as the authored fetch seeing a non-empty value.
+type checksumRecordingClient struct {
+	mu sync.Mutex
+
+	// learned is served for any name not present in authored. learnedErr, when
+	// set, is returned instead (still after recording the call).
+	learned    *v1beta1.ContainerProfile
+	learnedErr error
+
+	// authored maps an object name to the authored CP served for it. Names in
+	// this map are never served the learned CP.
+	authored map[string]*v1beta1.ContainerProfile
+
+	fetches []recordedFetch
+}
+
+var _ storage.ProfileClient = (*checksumRecordingClient)(nil)
+
+func (c *checksumRecordingClient) GetContainerProfile(ctx context.Context, _, name string) (*v1beta1.ContainerProfile, error) {
+	c.mu.Lock()
+	c.fetches = append(c.fetches, recordedFetch{name: name, checksum: storage.KnownChecksumFromContext(ctx)})
+	authored, isAuthored := c.authored[name]
+	c.mu.Unlock()
+
+	if isAuthored {
+		return authored, nil
+	}
+	if c.learnedErr != nil {
+		return nil, c.learnedErr
+	}
+	if c.learned != nil {
+		return c.learned, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "containerprofiles"}, name)
+}
+
+// checksumsFor returns the validators observed on every call for `name`, in
+// call order. A name never fetched yields an empty slice.
+func (c *checksumRecordingClient) checksumsFor(name string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []string
+	for _, f := range c.fetches {
+		if f.name == name {
+			out = append(out, f.checksum)
+		}
+	}
+	return out
+}
+
+func (c *checksumRecordingClient) fetchCount(name string) int {
+	return len(c.checksumsFor(name))
+}
+
+// assertNoChecksumOnAuthoredFetches is the standing per-call-site invariant: no
+// fetch of a name registered as an authored CP may ever carry a validator. The
+// learned CP's checksum describes the learned object only; offering it on an
+// authored fetch would let a source answer "unchanged" for the wrong object.
+func (c *checksumRecordingClient) assertNoChecksumOnAuthoredFetches(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, f := range c.fetches {
+		if _, isAuthored := c.authored[f.name]; isAuthored {
+			assert.Empty(t, f.checksum, "authored-CP fetch of %q must never carry a known checksum", f.name)
+		}
+	}
+}
+
+// learnedCPWithChecksum builds a terminal-status learned ContainerProfile
+// carrying `checksum` under the cross-repo checksum annotation key. A checksum
+// of "" produces a profile with no checksum annotation at all (the shape the
+// in-cluster CRD-backed client always returns).
+func learnedCPWithChecksum(name, rv, checksum string) *v1beta1.ContainerProfile {
+	annotations := map[string]string{
+		helpersv1.StatusMetadataKey:     helpersv1.Completed,
+		helpersv1.CompletionMetadataKey: helpersv1.Full,
+	}
+	if checksum != "" {
+		annotations[storage.ContainerProfileChecksumAnnotationKey] = checksum
+	}
+	return &v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "default", ResourceVersion: rv,
+			Annotations: annotations,
+		},
+		Spec: v1beta1.ContainerProfileSpec{Execs: []v1beta1.ExecCalls{{Path: "/bin/learned"}}},
+	}
+}
+
+// authoredCPWithChecksum is authoredCP plus a checksum annotation, used to prove
+// the adoption path never adopts the AUTHORED object's checksum as the entry's
+// validator.
+func authoredCPWithChecksum(name, execPath, rv, checksum string) *v1beta1.ContainerProfile {
+	cp := authoredCP(name, execPath, rv)
+	cp.Annotations[storage.ContainerProfileChecksumAnnotationKey] = checksum
+	return cp
+}
+
+// seedChecksumEntry installs a cache entry directly, bypassing addContainer, so
+// each conjunct of the conditional-fetch guard can be varied independently.
+func seedChecksumEntry(c *ContainerProfileCacheImpl, id string, cp *v1beta1.ContainerProfile, checksum, specHash string) *CachedContainerProfile {
+	e := &CachedContainerProfile{
+		Projected: Apply(nil, cp, nil),
+		// Mirrors what both real construction sites store, so a test can tell
+		// whether the cached State was re-derived from a fresh body.
+		State: &objectcache.ProfileState{
+			Name:       cp.Name,
+			Status:     cp.Annotations[helpersv1.StatusMetadataKey],
+			Completion: cp.Annotations[helpersv1.CompletionMetadataKey],
+		},
+		ContainerName: "nginx",
+		PodName:       "nginx-abc",
+		Namespace:     "default",
+		PodUID:        "uid-1",
+		CPName:        cp.Name,
+		RV:            cp.ResourceVersion,
+		Checksum:      checksum,
+		SpecHash:      specHash,
+	}
+	c.entries.Set(id, e)
+	return e
+}
+
+// ---------------------------------------------------------------------------
+// D4 — anti-inertness: the population path must store a validator
+// ---------------------------------------------------------------------------
+
+// TestPopulatePathStoresChecksum_AntiInertness is the test that proves the
+// optimization is not dead code.
+//
+// A profile that never changes is built ONCE by tryPopulateEntry/buildEntry and
+// thereafter always returns at refreshOneEntry's fast-skip, so it never reaches
+// rebuildEntryFromSources. If only rebuildEntryFromSources populated Checksum,
+// such an entry would hold "" forever, the guard's `e.Checksum != ""` conjunct
+// would never hold, and no conditional fetch would EVER be requested for exactly
+// the steady-state population this work targets — while every test stayed green.
+//
+// This test therefore asserts both halves: (a) the entry carries a validator
+// immediately after population, and (b) the very next reconcile tick actually
+// offers it. It fails if buildEntry's Checksum population is reverted.
+func TestPopulatePathStoresChecksum_AntiInertness(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-learned")
+	client := &checksumRecordingClient{learned: learned}
+	c, k8s := newTestCache(t, client)
+
+	id := "cid-antiinert"
+	primeSharedData(t, k8s, id, "wlid://cluster-a/namespace-default/deployment-nginx")
+	require.NoError(t, c.addContainer(eventContainer(id), context.Background()))
+
+	entry, ok := c.entries.Load(id)
+	require.True(t, ok, "container must be promoted out of pending")
+	require.Equal(t, 0, c.pending.Len())
+
+	// (a) populated without any rebuild ever having run.
+	assert.Equal(t, "sum-learned", entry.Checksum,
+		"an entry built only via tryPopulateEntry/buildEntry must carry the learned CP's checksum")
+
+	// (b) eligible on the next tick: unchanged profile, unchanged spec.
+	client.mu.Lock()
+	client.fetches = nil
+	client.mu.Unlock()
+
+	c.refreshAllEntries(context.Background())
+
+	sent := client.checksumsFor(entry.CPName)
+	require.Len(t, sent, 1, "exactly one learned-CP fetch on the tick")
+	assert.Equal(t, "sum-learned", sent[0],
+		"the tick after population must offer the stored validator; an empty value here means the optimization is inert")
+
+	// Nothing changed, so the entry must have been fast-skipped, not rebuilt.
+	after, ok := c.entries.Load(id)
+	require.True(t, ok)
+	assert.Same(t, entry, after, "an unchanged profile must fast-skip, not rebuild")
+}
+
+// TestPopulatePathStoresNoChecksumWhenSourceSuppliesNone pins the best-effort
+// contract: a source that stamps no annotation (every in-cluster CRD client)
+// leaves the validator empty, and the guard then declines to request a
+// conditional fetch rather than sending "".
+func TestPopulatePathStoresNoChecksumWhenSourceSuppliesNone(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "")
+	client := &checksumRecordingClient{learned: learned}
+	c, k8s := newTestCache(t, client)
+
+	id := "cid-nosum"
+	primeSharedData(t, k8s, id, "wlid://cluster-a/namespace-default/deployment-nginx")
+	require.NoError(t, c.addContainer(eventContainer(id), context.Background()))
+
+	entry, ok := c.entries.Load(id)
+	require.True(t, ok)
+	assert.Empty(t, entry.Checksum, "no annotation on the object means no stored validator")
+
+	client.mu.Lock()
+	client.fetches = nil
+	client.mu.Unlock()
+	c.refreshAllEntries(context.Background())
+
+	for _, sum := range client.checksumsFor(entry.CPName) {
+		assert.Empty(t, sum, "no validator held means none offered")
+	}
+}
+
+// TestAdoptionPathStoresLearnedChecksumNotAuthored covers the correction that
+// mirrors the existing entry.RV = learnedRV fix. On the adoption path
+// tryPopulateEntry repoints cp at the authored profile BEFORE calling
+// buildEntry, so buildEntry's literal sees the authored object. entry.Checksum
+// is offered back on a GET of the LEARNED slug, so adopting the authored
+// object's checksum would plant a validator describing the wrong object.
+func TestAdoptionPathStoresLearnedChecksumNotAuthored(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-learned")
+	authored := authoredCPWithChecksum("authored-cp-nginx", "/bin/authored", "a1", "sum-authored")
+	client := &checksumRecordingClient{
+		learned:  learned,
+		authored: map[string]*v1beta1.ContainerProfile{"authored-cp-nginx": authored},
+	}
+	c, k8s := newTestCache(t, client)
+
+	id := "cid-adopt"
+	primeSharedData(t, k8s, id, "wlid://cluster-a/namespace-default/deployment-nginx")
+	ev := eventContainer(id)
+	ev.K8s.PodLabels = map[string]string{helpersv1.UserDefinedProfileMetadataKey: "authored-cp"}
+	require.NoError(t, c.addContainer(ev, context.Background()))
+
+	entry, ok := c.entries.Load(id)
+	require.True(t, ok)
+	require.NotNil(t, entry.UserCPRef, "the authored CP must have been adopted for this test to mean anything")
+	assert.Equal(t, "a1", entry.UserCPRV)
+	assert.Equal(t, "sum-learned", entry.Checksum,
+		"the validator must describe the LEARNED CP (the object CPName points at), never the adopted authored one")
+	assert.Equal(t, "1", entry.RV, "the existing learned-RV correction still holds")
+}
+
+// TestAdoptionPathWithNoLearnedCPStoresEmptyChecksum is the same correction in
+// its other shape: learning is suppressed for user-defined containers, so there
+// is often no learned CP at all. The validator must then be empty rather than
+// falling back to the authored object's.
+func TestAdoptionPathWithNoLearnedCPStoresEmptyChecksum(t *testing.T) {
+	authored := authoredCPWithChecksum("authored-cp-nginx", "/bin/authored", "a1", "sum-authored")
+	client := &checksumRecordingClient{
+		learnedErr: apierrors.NewNotFound(schema.GroupResource{Resource: "containerprofiles"}, "learned"),
+		authored:   map[string]*v1beta1.ContainerProfile{"authored-cp-nginx": authored},
+	}
+	c, k8s := newTestCache(t, client)
+
+	id := "cid-adopt-nolearned"
+	primeSharedData(t, k8s, id, "wlid://cluster-a/namespace-default/deployment-nginx")
+	ev := eventContainer(id)
+	ev.K8s.PodLabels = map[string]string{helpersv1.UserDefinedProfileMetadataKey: "authored-cp"}
+	require.NoError(t, c.addContainer(ev, context.Background()))
+
+	entry, ok := c.entries.Load(id)
+	require.True(t, ok)
+	require.NotNil(t, entry.UserCPRef)
+	assert.Empty(t, entry.Checksum, "no learned CP means no learned validator")
+	assert.Empty(t, entry.RV, "matches the existing learned-RV invariant")
+}
+
+// ---------------------------------------------------------------------------
+// The guard — each conjunct must independently suppress the offer
+// ---------------------------------------------------------------------------
+
+// TestGuardOffersChecksumWhenAllConjunctsHold is the positive control the four
+// negative tests below are read against.
+func TestGuardOffersChecksumWhenAllConjunctsHold(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	assert.Equal(t, []string{"sum-1"}, client.checksumsFor("learned-cp"))
+}
+
+// TestGuardDeclinesWhenAuthoredCPPresent — UserCPRef != nil. The body is needed
+// regardless (the authored CP is re-fetched and re-adopted this tick), so no
+// conditional fetch is requested even though a validator is held. The authored
+// CP must still be refreshed.
+func TestGuardDeclinesWhenAuthoredCPPresent(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	authored := authoredCP("authored-cp", "/bin/authored", "a1")
+	client := &checksumRecordingClient{
+		learned:  learned,
+		authored: map[string]*v1beta1.ContainerProfile{"authored-cp": authored},
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	e := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+	e.UserCPRef = &namespacedName{Namespace: "default", Name: "authored-cp"}
+
+	c.refreshAllEntries(context.Background())
+
+	for _, sum := range client.checksumsFor("learned-cp") {
+		assert.Empty(t, sum, "an entry with an authored CP needs the body anyway; it must not ask for a conditional fetch")
+	}
+	assert.Equal(t, 1, client.fetchCount("authored-cp"), "the authored CP must still be refreshed on this tick")
+	client.assertNoChecksumOnAuthoredFetches(t)
+}
+
+// TestGuardDeclinesWhenAuthoredRVRecordedButNoAuthoredCP — UserCPRV != "" with
+// UserCPRef == nil, the authoredJustDropped shape. UserCPRef == nil alone does
+// NOT establish the fast-skip's rvsMatchCP(userDefinedCP, e.UserCPRV) conjunct:
+// with no authored CP present that call reduces to rvsMatchCP(nil, e.UserCPRV),
+// which is true only for "". Without this conjunct such an entry could take the
+// unchanged path and skip its authoredJustDropped handling.
+func TestGuardDeclinesWhenAuthoredRVRecordedButNoAuthoredCP(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	e := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+	e.UserCPRV = "a1" // recorded from a previous tick; UserCPRef is nil now
+
+	c.refreshAllEntries(context.Background())
+
+	for _, sum := range client.checksumsFor("learned-cp") {
+		assert.Empty(t, sum, "the authoredJustDropped shape must not request a conditional fetch")
+	}
+}
+
+// TestGuardDeclinesWhenSpecHashChanged — the projection spec moved, so the entry
+// must be re-projected from a real body regardless of whether the content
+// changed. No validator is offered, and the rebuild still happens.
+func TestGuardDeclinesWhenSpecHashChanged(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	c.SetProjectionSpec(execsAllSpec("spec-v2"))
+	seedChecksumEntry(c, "cid", learned, "sum-1", "spec-v1")
+
+	c.refreshAllEntries(context.Background())
+
+	for _, sum := range client.checksumsFor("learned-cp") {
+		assert.Empty(t, sum, "a changed projection spec needs the body; no conditional fetch")
+	}
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Equal(t, "spec-v2", after.SpecHash, "the rebuild must still happen and adopt the new spec")
+}
+
+// TestGuardDeclinesWhenNoStoredChecksum — nothing to validate against. An empty
+// value must not be sent: to a source, "" means "send unconditionally", and
+// answering "unchanged" to it would be a protocol violation.
+func TestGuardDeclinesWhenNoStoredChecksum(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", learned, "", "")
+
+	c.refreshAllEntries(context.Background())
+
+	assert.Equal(t, []string{""}, client.checksumsFor("learned-cp"))
+}
+
+// TestChecksumIsAttachedPerCallSiteNotToSharedContext proves R2's defense.
+//
+// Both GetContainerProfile call sites in refreshOneEntry derive from the same
+// parent context; attaching the validator to that context instead of to the
+// learned call would send the learned CP's checksum on the authored CP's fetch,
+// and a source could legitimately answer "unchanged" for the wrong object.
+//
+// The guard makes the literal "same entry, both call sites, one
+// carrying a checksum" shape unreachable — an entry with an authored CP never
+// offers a validator at all. The reachable equivalent is asserted instead: two
+// entries refreshed in ONE tick, one offering a validator and one performing an
+// authored fetch. If the validator lived on shared state rather than a per-call
+// context, it would leak onto the authored fetch here.
+func TestChecksumIsAttachedPerCallSiteNotToSharedContext(t *testing.T) {
+	learnedA := learnedCPWithChecksum("learned-a", "1", "sum-a")
+	learnedB := learnedCPWithChecksum("learned-b", "1", "sum-b")
+	authored := authoredCP("authored-b", "/bin/authored", "a1")
+	client := &checksumRecordingClient{
+		learned:  learnedA, // served for any non-authored name, including learned-b
+		authored: map[string]*v1beta1.ContainerProfile{"authored-b": authored},
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+
+	seedChecksumEntry(c, "cid-a", learnedA, "sum-a", "") // guard passes
+	eB := seedChecksumEntry(c, "cid-b", learnedB, "sum-b", "")
+	eB.UserCPRef = &namespacedName{Namespace: "default", Name: "authored-b"} // guard fails
+
+	c.refreshAllEntries(context.Background())
+
+	assert.Equal(t, []string{"sum-a"}, client.checksumsFor("learned-a"),
+		"the guard-passing entry's learned fetch carries its own validator")
+	for _, sum := range client.checksumsFor("learned-b") {
+		assert.Empty(t, sum, "the authored-CP entry's learned fetch must carry nothing")
+	}
+	require.Equal(t, 1, client.fetchCount("authored-b"))
+	client.assertNoChecksumOnAuthoredFetches(t)
+}
+
+// conditionalChecksumClient behaves like a real conditional source: when the
+// caller offers a validator equal to the profile's CURRENT content checksum it
+// answers ErrProfileUnchanged and sends no body; otherwise it returns the
+// profile. This is what makes the state-freeze regression observable — a
+// recording-only client would hand back a body regardless and hide it.
+type conditionalChecksumClient struct {
+	mu       sync.Mutex
+	cp       *v1beta1.ContainerProfile
+	offered  []string
+	unchange int
+}
+
+var _ storage.ProfileClient = (*conditionalChecksumClient)(nil)
+
+func (c *conditionalChecksumClient) GetContainerProfile(ctx context.Context, _, _ string) (*v1beta1.ContainerProfile, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	offered := storage.KnownChecksumFromContext(ctx)
+	c.offered = append(c.offered, offered)
+	if offered != "" && offered == c.cp.Annotations[storage.ContainerProfileChecksumAnnotationKey] {
+		c.unchange++
+		return nil, storage.ErrProfileUnchanged
+	}
+	return c.cp, nil
+}
+
+func (c *conditionalChecksumClient) lastOffered() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.offered) == 0 {
+		return ""
+	}
+	return c.offered[len(c.offered)-1]
+}
+
+// TestGuardDeclinesWhileStateNotYetTerminal is the regression test for the
+// cached-state freeze.
+//
+// e.State comes from the status/completion ANNOTATIONS, which sit outside the
+// content checksum. So a profile finishing its learning period — partial ->
+// full, byte-identical content — presents a checksum that still matches. If the
+// guard ignored the cached state, that tick would be answered "unchanged", the
+// rebuild that refreshes e.State would never run, and because the checksum stays
+// valid the SAME thing would happen on every later tick: the state freezes at
+// partial permanently, and rulemanager keeps reporting a completed profile as
+// incomplete.
+//
+// The walkthrough below covers all three phases: declined while learning,
+// state correctly picked up when it terminalizes, and the shortcut engaging
+// afterwards so the steady-state win is genuinely preserved.
+func TestGuardDeclinesWhileStateNotYetTerminal(t *testing.T) {
+	// A profile still learning: non-terminal state, but a validator already
+	// stored from a previous fetch.
+	learning := &v1beta1.ContainerProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "learned-cp", Namespace: "default", ResourceVersion: "1",
+			Annotations: map[string]string{
+				helpersv1.StatusMetadataKey:                   helpersv1.Completed,
+				helpersv1.CompletionMetadataKey:               helpersv1.Partial,
+				storage.ContainerProfileChecksumAnnotationKey: "sum-1",
+			},
+		},
+		Spec: v1beta1.ContainerProfileSpec{Execs: []v1beta1.ExecCalls{{Path: "/bin/learned"}}},
+	}
+	client := &conditionalChecksumClient{cp: learning}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", learning, "sum-1", "")
+
+	// Phase 1 — still partial: no validator offered, so a body is fetched.
+	c.refreshAllEntries(context.Background())
+	assert.Empty(t, client.lastOffered(), "a non-terminal cached state must not take the conditional shortcut")
+	assert.Zero(t, client.unchange)
+
+	// Phase 2 — the learning period completes. This is a METADATA-ONLY write:
+	// the RV moves and the completion flips, but the content checksum is
+	// unchanged, which is exactly what makes the freeze possible.
+	learning.ResourceVersion = "2"
+	learning.Annotations[helpersv1.CompletionMetadataKey] = helpersv1.Full
+
+	c.refreshAllEntries(context.Background())
+	assert.Empty(t, client.lastOffered(), "the cached state is still partial at guard time; the body is still needed")
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Equal(t, helpersv1.Full, after.State.Completion,
+		"the completion flip MUST reach the cache; freezing here is what rulemanager would report as a permanently-partial profile")
+	assert.Equal(t, helpersv1.Completed, after.State.Status)
+
+	// Phase 3 — now genuinely terminal, so the shortcut engages and the source
+	// gets to answer "unchanged". The optimization is preserved, not disabled.
+	c.refreshAllEntries(context.Background())
+	assert.Equal(t, "sum-1", client.lastOffered(), "a Completed+Full entry must still use the conditional shortcut")
+	assert.Equal(t, 1, client.unchange, "the source answered unchanged exactly once, on the terminal tick")
+
+	final, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, after, final, "the unchanged answer keeps the entry as-is")
+}
+
+// TestGuardDeclinesForTooLargeState pins the deliberate narrowness of the state
+// conjunct: TooLarge is terminal for the learned-status gate, but it is not the
+// Completed+Full predicate rulemanager treats as final, so such an entry keeps
+// fetching bodies rather than risking a frozen state.
+func TestGuardDeclinesForTooLargeState(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	learned.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
+	learned.Annotations[helpersv1.CompletionMetadataKey] = helpersv1.Partial
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	for _, sum := range client.checksumsFor("learned-cp") {
+		assert.Empty(t, sum, "a TooLarge/partial entry must not take the conditional shortcut")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sentinel handling
+// ---------------------------------------------------------------------------
+
+// TestSentinelKeepsEntryPointerIdentical — on ErrProfileUnchanged the entry the
+// caller already holds is known-good, so refreshOneEntry must leave it entirely
+// alone. Identity, not equality, is the assertion that discriminates:
+// rebuildEntryFromSources always constructs a FRESH literal, so an equal-but-new
+// pointer would mean a rebuild happened.
+func TestSentinelKeepsEntryPointerIdentical(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: storage.ErrProfileUnchanged}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok, "the entry must not be evicted")
+	assert.Same(t, before, after, "the sentinel must not rebuild the entry")
+	assert.Equal(t, "sum-1", after.Checksum, "the stored validator is left untouched")
+	assert.Equal(t, []string{"sum-1"}, client.checksumsFor("learned-cp"),
+		"the sentinel is only legitimate in reply to a request that carried a validator")
+}
+
+// TestSentinelLeavesResourceVersionIntentionallyStale pins the one accepted
+// divergence of the conditional path from the body-fetching path.
+//
+// A checksum match proves the CONTENT is byte-identical; it says nothing about
+// ResourceVersion. RV can bump on a metadata-only write (e.g. a status-annotation
+// flip), and annotations are outside the content checksum — so on a sentinel
+// response the client never sees the new RV and e.RV stays at its old value.
+//
+// This is deliberate, not a bug: every consumer downstream of this cache reads
+// the projected CONTENT, and e.RV only serves as a change detector for the next
+// tick, where a stale-but-lower RV is conservative (it can cause an extra
+// rebuild, never a missed one). Asserted POSITIVELY so the behavior is pinned as
+// intended rather than rediscovered later as a defect.
+func TestSentinelLeavesResourceVersionIntentionallyStale(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: storage.ErrProfileUnchanged}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	// Simulate a metadata-only write on the server: the object's RV moved but
+	// its content checksum did not, so the source still answers "unchanged".
+	learned.ResourceVersion = "2"
+	learned.Annotations[helpersv1.StatusMetadataKey] = helpersv1.TooLarge
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, before, after)
+	assert.Equal(t, "1", after.RV,
+		"e.RV is INTENDED to lag a metadata-only write until the next unconditional fetch")
+	assert.Equal(t, helpersv1.Completed, after.State.Status,
+		"the learned-status gate is likewise not re-evaluated on the sentinel path")
+}
+
+// TestSentinelIsNotSwallowedByTheNotFoundPath pins that the sentinel is handled
+// EXPLICITLY rather than left to the pre-existing error handling (D3).
+//
+// Scope, stated precisely, because it is narrower than "the branch is first":
+// verified by deliberately breaking the code, this test fails when the sentinel
+// branch is absent (the error's not-found shape then sets cp = nil, no authored
+// CP is found either, and the entry is EVICTED), and it passes with the branch
+// present. It does NOT distinguish the branch sitting before the IsNotFound
+// check from it sitting just after — both return early with the entry intact.
+// Ordering is kept as written for clarity, not because this test enforces it.
+//
+// Note also that a bare storage.ErrProfileUnchanged would NOT be caught by this
+// test's mechanism at all: it falls into the generic transient-error path, which
+// also keeps the entry, so the two are indistinguishable by behavior alone (they
+// differ only in the log line emitted). That is exactly why the fixture below is
+// built to satisfy the not-found predicate too — it is the one shape where the
+// missing branch has a visible consequence.
+func TestSentinelIsNotSwallowedByTheNotFoundPath(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	both := fmt.Errorf("%w: %w",
+		storage.ErrProfileUnchanged,
+		apierrors.NewNotFound(schema.GroupResource{Resource: "containerprofiles"}, "learned-cp"))
+	require.True(t, errors.Is(both, storage.ErrProfileUnchanged), "fixture must satisfy the sentinel predicate")
+	require.True(t, apierrors.IsNotFound(both), "fixture must also satisfy the not-found predicate")
+
+	client := &checksumRecordingClient{learnedErr: both}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok, "not-found won the ordering: the entry was evicted instead of kept")
+	assert.Same(t, before, after)
+}
+
+// TestNonSentinelErrorIsNotMistakenForUnchanged — an unrelated transport failure
+// must fall through to the existing transient-error handling, which also keeps
+// the entry. Guards against a too-broad match (e.g. a string comparison).
+func TestNonSentinelErrorIsNotMistakenForUnchanged(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: errors.New("container profile unchanged-ish: connection reset")}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, before, after, "a transient error also keeps the entry, by the pre-existing path")
+}
+
+// ---------------------------------------------------------------------------
+// Rebuild path
+// ---------------------------------------------------------------------------
+
+// TestRebuildRefreshesStoredChecksum — a genuine content change must roll the
+// stored validator forward, or the next tick would offer a checksum describing
+// the previous body.
+func TestRebuildRefreshesStoredChecksum(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: learned}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	// Content changed on the server: new RV, new checksum, new body.
+	learned.ResourceVersion = "2"
+	learned.Annotations[storage.ContainerProfileChecksumAnnotationKey] = "sum-2"
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Equal(t, "sum-2", after.Checksum, "a rebuild must adopt the fresh validator")
+	assert.Equal(t, "2", after.RV)
+}
+
+// TestRebuildStoresLearnedChecksumNotAuthored — the rebuild path's counterpart
+// to the adoption-path correction: Checksum tracks the learned CP even when an
+// authored CP replaces it as the projection base.
+func TestRebuildStoresLearnedChecksumNotAuthored(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-learned")
+	authored := authoredCPWithChecksum("authored-cp", "/bin/authored", "a1", "sum-authored")
+	client := &checksumRecordingClient{
+		learned:  learned,
+		authored: map[string]*v1beta1.ContainerProfile{"authored-cp": authored},
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	e := seedChecksumEntry(c, "cid", learned, "", "")
+	e.UserCPRef = &namespacedName{Namespace: "default", Name: "authored-cp"}
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.NotSame(t, e, after, "an authored CP appearing must rebuild the entry")
+	assert.Equal(t, "sum-learned", after.Checksum,
+		"the validator tracks the learned CP even when an authored CP is the projection base")
+}
+
+// ---------------------------------------------------------------------------
+// Context vocabulary
+// ---------------------------------------------------------------------------
+
+func TestKnownChecksumContextRoundTrip(t *testing.T) {
+	assert.Empty(t, storage.KnownChecksumFromContext(context.Background()),
+		"a bare context must report no validator, never panic")
+
+	ctx := storage.WithKnownChecksum(context.Background(), "sum-1")
+	assert.Equal(t, "sum-1", storage.KnownChecksumFromContext(ctx))
+
+	// The parent is not mutated: attaching per call is what keeps the authored
+	// fetch clean.
+	assert.Empty(t, storage.KnownChecksumFromContext(context.Background()))
+}

--- a/pkg/objectcache/containerprofilecache/reconciler_checksum_test.go
+++ b/pkg/objectcache/containerprofilecache/reconciler_checksum_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	helpersv1 "github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
 	"github.com/kubescape/node-agent/pkg/objectcache"
@@ -302,12 +304,15 @@ func TestAdoptionPathWithNoLearnedCPStoresEmptyChecksum(t *testing.T) {
 func TestGuardOffersChecksumWhenAllConjunctsHold(t *testing.T) {
 	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
 	client := &checksumRecordingClient{learned: learned}
-	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
 	seedChecksumEntry(c, "cid", learned, "sum-1", "")
 
 	c.refreshAllEntries(context.Background())
 
 	assert.Equal(t, []string{"sum-1"}, client.checksumsFor("learned-cp"))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeOffered))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeBody))
 }
 
 // TestGuardDeclinesWhenAuthoredCPPresent — UserCPRef != nil. The body is needed
@@ -360,7 +365,8 @@ func TestGuardDeclinesWhenAuthoredRVRecordedButNoAuthoredCP(t *testing.T) {
 func TestGuardDeclinesWhenSpecHashChanged(t *testing.T) {
 	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
 	client := &checksumRecordingClient{learned: learned}
-	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
 	c.SetProjectionSpec(execsAllSpec("spec-v2"))
 	seedChecksumEntry(c, "cid", learned, "sum-1", "spec-v1")
 
@@ -372,6 +378,69 @@ func TestGuardDeclinesWhenSpecHashChanged(t *testing.T) {
 	after, ok := c.entries.Load("cid")
 	require.True(t, ok)
 	assert.Equal(t, "spec-v2", after.SpecHash, "the rebuild must still happen and adopt the new spec")
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeIneligible))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeBody))
+}
+
+type blockingSpecProfileClient struct {
+	cp      *v1beta1.ContainerProfile
+	entered chan struct{}
+	release chan struct{}
+}
+
+var _ storage.ProfileClient = (*blockingSpecProfileClient)(nil)
+
+func (c *blockingSpecProfileClient) GetContainerProfile(ctx context.Context, _, _ string) (*v1beta1.ContainerProfile, error) {
+	select {
+	case c.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-c.release:
+		return c.cp, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// TestSpecReplacementDuringFetchRebuildsUnderPostFetchSpec verifies the two
+// spec snapshots have distinct jobs: the pre-fetch value controls validator
+// eligibility, while the post-fetch value prevents a stale fast-skip.
+func TestSpecReplacementDuringFetchRebuildsUnderPostFetchSpec(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "")
+	client := &blockingSpecProfileClient{
+		cp:      learned,
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	c.SetProjectionSpec(execsAllSpec("spec-v1"))
+	before := seedChecksumEntry(c, "cid", learned, "", "spec-v1")
+
+	done := make(chan struct{})
+	go func() {
+		c.refreshAllEntries(context.Background())
+		close(done)
+	}()
+	select {
+	case <-client.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refresh did not enter the profile fetch")
+	}
+
+	c.SetProjectionSpec(execsAllSpec("spec-v2"))
+	close(client.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refresh did not finish after releasing the profile fetch")
+	}
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.NotSame(t, before, after)
+	assert.Equal(t, "spec-v2", after.SpecHash)
+	assert.Equal(t, "spec-v2", after.Projected.SpecHash)
 }
 
 // TestGuardDeclinesWhenNoStoredChecksum — nothing to validate against. An empty
@@ -380,12 +449,15 @@ func TestGuardDeclinesWhenSpecHashChanged(t *testing.T) {
 func TestGuardDeclinesWhenNoStoredChecksum(t *testing.T) {
 	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
 	client := &checksumRecordingClient{learned: learned}
-	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
 	seedChecksumEntry(c, "cid", learned, "", "")
 
 	c.refreshAllEntries(context.Background())
 
 	assert.Equal(t, []string{""}, client.checksumsFor("learned-cp"))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeMissing))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeBody))
 }
 
 // TestChecksumIsAttachedPerCallSiteNotToSharedContext proves R2's defense.
@@ -452,6 +524,12 @@ func (c *conditionalChecksumClient) GetContainerProfile(ctx context.Context, _, 
 	return c.cp, nil
 }
 
+func (c *conditionalChecksumClient) offeredChecksums() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.offered...)
+}
+
 func (c *conditionalChecksumClient) lastOffered() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -467,11 +545,9 @@ func (c *conditionalChecksumClient) lastOffered() string {
 // e.State comes from the status/completion ANNOTATIONS, which sit outside the
 // content checksum. So a profile finishing its learning period — partial ->
 // full, byte-identical content — presents a checksum that still matches. If the
-// guard ignored the cached state, that tick would be answered "unchanged", the
-// rebuild that refreshes e.State would never run, and because the checksum stays
-// valid the SAME thing would happen on every later tick: the state freezes at
-// partial permanently, and rulemanager keeps reporting a completed profile as
-// incomplete.
+// guard ignored the cached state, the transition would remain invisible until
+// the forced full-body request, up to ten refresh intervals later. That delay
+// changes rule enforcement and is therefore not an acceptable optimization.
 //
 // The walkthrough below covers all three phases: declined while learning,
 // state correctly picked up when it terminalizes, and the shortcut engaging
@@ -511,7 +587,7 @@ func TestGuardDeclinesWhileStateNotYetTerminal(t *testing.T) {
 	after, ok := c.entries.Load("cid")
 	require.True(t, ok)
 	assert.Equal(t, helpersv1.Full, after.State.Completion,
-		"the completion flip MUST reach the cache; freezing here is what rulemanager would report as a permanently-partial profile")
+		"the completion flip must reach the cache immediately rather than waiting for forced revalidation")
 	assert.Equal(t, helpersv1.Completed, after.State.Status)
 
 	// Phase 3 — now genuinely terminal, so the shortcut engages and the source
@@ -556,7 +632,8 @@ func TestGuardDeclinesForTooLargeState(t *testing.T) {
 func TestSentinelKeepsEntryPointerIdentical(t *testing.T) {
 	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
 	client := &checksumRecordingClient{learnedErr: storage.ErrProfileUnchanged}
-	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
 	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
 
 	c.refreshAllEntries(context.Background())
@@ -567,6 +644,32 @@ func TestSentinelKeepsEntryPointerIdentical(t *testing.T) {
 	assert.Equal(t, "sum-1", after.Checksum, "the stored validator is left untouched")
 	assert.Equal(t, []string{"sum-1"}, client.checksumsFor("learned-cp"),
 		"the sentinel is only legitimate in reply to a request that carried a validator")
+	assert.Equal(t, 1, after.consecutiveUnchanged)
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeOffered))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeUnchanged))
+}
+
+// TestUnsolicitedSentinelIsProtocolError proves that ErrProfileUnchanged is
+// trusted only when this exact request offered a checksum. The existing entry
+// is retained as on any transient failure, but the answer is neither counted
+// as a cache hit nor allowed to advance the consecutive-unchanged budget.
+func TestUnsolicitedSentinelIsProtocolError(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: storage.ErrProfileUnchanged}
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
+	before := seedChecksumEntry(c, "cid", learned, "", "")
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, before, after)
+	assert.Zero(t, after.consecutiveUnchanged)
+	assert.Equal(t, []string{""}, client.checksumsFor("learned-cp"))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeMissing))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeProtocolError))
+	assert.Zero(t, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeUnchanged))
 }
 
 // TestSentinelLeavesResourceVersionIntentionallyStale pins the one accepted
@@ -646,7 +749,8 @@ func TestSentinelIsNotSwallowedByTheNotFoundPath(t *testing.T) {
 func TestNonSentinelErrorIsNotMistakenForUnchanged(t *testing.T) {
 	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
 	client := &checksumRecordingClient{learnedErr: errors.New("container profile unchanged-ish: connection reset")}
-	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
 	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
 
 	c.refreshAllEntries(context.Background())
@@ -654,11 +758,156 @@ func TestNonSentinelErrorIsNotMistakenForUnchanged(t *testing.T) {
 	after, ok := c.entries.Load("cid")
 	require.True(t, ok)
 	assert.Same(t, before, after, "a transient error also keeps the entry, by the pre-existing path")
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeOffered))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeError))
+}
+
+// TestNotFoundResponseMetric pins the remaining response outcome. The existing
+// eviction behavior is unchanged: without an authored replacement, a missing
+// learned profile removes the cache entry.
+func TestNotFoundResponseMetric(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: apierrors.NewNotFound(
+		schema.GroupResource{Resource: "containerprofiles"}, "learned-cp")}
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
+	seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	c.refreshAllEntries(context.Background())
+
+	_, ok := c.entries.Load("cid")
+	assert.False(t, ok)
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeNotFound))
+}
+
+// TestConsecutiveUnchangedResponsesForceFullBody bounds how long the cache can
+// rely exclusively on a remote validator. Ten valid unchanged answers are
+// accepted; the next eligible refresh omits the validator, accepts a body, and
+// resets the budget so conditional requests can resume.
+func TestConsecutiveUnchangedResponsesForceFullBody(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &conditionalChecksumClient{cp: learned}
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
+	before := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+
+	for range maxConsecutiveUnchangedResponses {
+		c.refreshAllEntries(context.Background())
+	}
+	entry, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, before, entry)
+	assert.Equal(t, maxConsecutiveUnchangedResponses, entry.consecutiveUnchanged)
+
+	c.refreshAllEntries(context.Background())
+
+	afterBody, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.Same(t, before, afterBody, "a byte-identical forced body may still take the post-fetch fast-skip")
+	assert.Zero(t, afterBody.consecutiveUnchanged, "the successful body clears the forced-revalidation debt")
+
+	c.refreshAllEntries(context.Background())
+	assert.Equal(t, 1, afterBody.consecutiveUnchanged, "conditional requests resume after the successful body")
+
+	offered := client.offeredChecksums()
+	require.Len(t, offered, maxConsecutiveUnchangedResponses+2)
+	for i := range maxConsecutiveUnchangedResponses {
+		assert.Equal(t, "sum-1", offered[i])
+	}
+	assert.Empty(t, offered[maxConsecutiveUnchangedResponses], "the eleventh refresh must force a body")
+	assert.Equal(t, "sum-1", offered[maxConsecutiveUnchangedResponses+1], "the validator is offered again after reset")
+	assert.Equal(t, maxConsecutiveUnchangedResponses+1,
+		metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeOffered))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeForcedRevalidation))
+	assert.Equal(t, maxConsecutiveUnchangedResponses+1,
+		metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeUnchanged))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeBody))
+}
+
+// TestForcedRevalidationRemainsDueAcrossFailures ensures only a successful
+// body resets the counter. A transport error or an unsolicited unchanged
+// sentinel on the validator-suppressed request leaves the entry force-due.
+func TestForcedRevalidationRemainsDueAcrossFailures(t *testing.T) {
+	learned := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learnedErr: assertErr{}}
+	metrics := newCountingMetrics()
+	c := newReconcilerCache(t, client, newControllableK8sCache(), metrics)
+	entry := seedChecksumEntry(c, "cid", learned, "sum-1", "")
+	entry.consecutiveUnchanged = maxConsecutiveUnchangedResponses
+
+	c.refreshAllEntries(context.Background())
+	assert.Equal(t, maxConsecutiveUnchangedResponses, entry.consecutiveUnchanged)
+
+	client.mu.Lock()
+	client.learnedErr = storage.ErrProfileUnchanged
+	client.mu.Unlock()
+	c.refreshAllEntries(context.Background())
+	assert.Equal(t, maxConsecutiveUnchangedResponses, entry.consecutiveUnchanged)
+
+	client.mu.Lock()
+	client.learnedErr = nil
+	client.learned = learned
+	client.mu.Unlock()
+	c.refreshAllEntries(context.Background())
+	assert.Zero(t, entry.consecutiveUnchanged)
+
+	assert.Equal(t, []string{"", "", ""}, client.checksumsFor("learned-cp"),
+		"every retry remains an unconditional forced revalidation until a body succeeds")
+	assert.Equal(t, 3, metrics.ProfileConditionalFetchRequestCounter.Get(conditionalFetchModeForcedRevalidation))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeError))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeProtocolError))
+	assert.Equal(t, 1, metrics.ProfileConditionalFetchResponseCounter.Get(conditionalFetchOutcomeBody))
 }
 
 // ---------------------------------------------------------------------------
 // Rebuild path
 // ---------------------------------------------------------------------------
+
+// TestChecksumChangeRebuildsDespiteMatchingResourceVersion covers remote
+// profiles whose ResourceVersion is empty or unchanged while the returned body
+// and checksum move. The checksum is a co-equal fast-skip guard, not merely the
+// validator sent on the request.
+func TestChecksumChangeRebuildsDespiteMatchingResourceVersion(t *testing.T) {
+	for _, rv := range []string{"", "1"} {
+		t.Run(fmt.Sprintf("rv_%q", rv), func(t *testing.T) {
+			oldCP := learnedCPWithChecksum("learned-cp", rv, "sum-1")
+			freshCP := learnedCPWithChecksum("learned-cp", rv, "sum-2")
+			freshCP.Spec.Execs[0].Path = "/bin/fresh"
+			client := &checksumRecordingClient{learned: freshCP}
+			c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+			before := seedChecksumEntry(c, "cid", oldCP, "sum-1", "")
+
+			c.refreshAllEntries(context.Background())
+
+			after, ok := c.entries.Load("cid")
+			require.True(t, ok)
+			assert.NotSame(t, before, after, "changed content must rebuild even when ResourceVersion still matches")
+			assert.Equal(t, "sum-2", after.Checksum)
+			_, hasFresh := after.Projected.Execs.Values["/bin/fresh"]
+			assert.True(t, hasFresh, "the rebuilt projection must contain the fresh body")
+		})
+	}
+}
+
+// TestFirstChecksumAcquisitionRebuildsEmptyChecksumEntry ensures a legacy or
+// in-cluster-shaped entry acquires the first validator even when body and
+// ResourceVersion otherwise match. Fast-skipping here would leave the
+// optimization inert for that entry's lifetime.
+func TestFirstChecksumAcquisitionRebuildsEmptyChecksumEntry(t *testing.T) {
+	oldCP := learnedCPWithChecksum("learned-cp", "1", "")
+	freshCP := learnedCPWithChecksum("learned-cp", "1", "sum-1")
+	client := &checksumRecordingClient{learned: freshCP}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	before := seedChecksumEntry(c, "cid", oldCP, "", "")
+
+	c.refreshAllEntries(context.Background())
+
+	after, ok := c.entries.Load("cid")
+	require.True(t, ok)
+	assert.NotSame(t, before, after, "first checksum acquisition must invalidate an empty-checksum entry")
+	assert.Equal(t, "sum-1", after.Checksum)
+	assert.Equal(t, "1", after.RV)
+}
 
 // TestRebuildRefreshesStoredChecksum — a genuine content change must roll the
 // stored validator forward, or the next tick would offer a checksum describing
@@ -702,6 +951,186 @@ func TestRebuildStoresLearnedChecksumNotAuthored(t *testing.T) {
 	assert.NotSame(t, e, after, "an authored CP appearing must rebuild the entry")
 	assert.Equal(t, "sum-learned", after.Checksum,
 		"the validator tracks the learned CP even when an authored CP is the projection base")
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+
+type blockingFetchClient struct {
+	profiles  map[string]*v1beta1.ContainerProfile
+	blockCall int
+	entered   chan struct{}
+	release   chan struct{}
+
+	mu        sync.Mutex
+	calls     []string
+	active    atomic.Int64
+	maxActive atomic.Int64
+}
+
+var _ storage.ProfileClient = (*blockingFetchClient)(nil)
+
+func (c *blockingFetchClient) GetContainerProfile(ctx context.Context, _, name string) (*v1beta1.ContainerProfile, error) {
+	active := c.active.Add(1)
+	defer c.active.Add(-1)
+	for {
+		maxActive := c.maxActive.Load()
+		if active <= maxActive || c.maxActive.CompareAndSwap(maxActive, active) {
+			break
+		}
+	}
+
+	c.mu.Lock()
+	c.calls = append(c.calls, name)
+	callNumber := len(c.calls)
+	cp := c.profiles[name]
+	c.mu.Unlock()
+
+	if callNumber == c.blockCall {
+		close(c.entered)
+		select {
+		case <-c.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if cp == nil {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "containerprofiles"}, name)
+	}
+	return cp, nil
+}
+
+func (c *blockingFetchClient) snapshotCalls() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.calls...)
+}
+
+// TestNudgeDuringTickerRefreshRunsTrailingPass starts the real tick loop and
+// blocks its first ticker-owned refresh after one entry has already been
+// processed. A spec nudge during that pass must schedule a trailing pass, so
+// the early entry is rebuilt immediately rather than waiting for another tick.
+func TestNudgeDuringTickerRefreshRunsTrailingPass(t *testing.T) {
+	cpA := learnedCPWithChecksum("cp-a", "1", "")
+	cpB := learnedCPWithChecksum("cp-b", "1", "")
+	client := &blockingFetchClient{
+		profiles:  map[string]*v1beta1.ContainerProfile{"cp-a": cpA, "cp-b": cpB},
+		blockCall: 2,
+		entered:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	c.reconcileEvery = 250 * time.Millisecond
+	c.SetProjectionSpec(execsAllSpec("spec-v1"))
+	select {
+	case <-c.nudge:
+	default:
+		t.Fatal("initial spec installation did not enqueue its nudge")
+	}
+	before := map[string]*CachedContainerProfile{
+		"cp-a": seedChecksumEntry(c, "cid-a", cpA, "", "spec-v1"),
+		"cp-b": seedChecksumEntry(c, "cid-b", cpB, "", "spec-v1"),
+	}
+	idByName := map[string]string{"cp-a": "cid-a", "cp-b": "cid-b"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		c.tickLoop(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("tick loop did not stop after cancellation")
+		}
+	})
+
+	select {
+	case <-client.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ticker-owned refresh did not reach its second profile fetch")
+	}
+	calls := client.snapshotCalls()
+	require.Len(t, calls, 2)
+	firstName := calls[0]
+	firstID := idByName[firstName]
+	stillOld, ok := c.entries.Load(firstID)
+	require.True(t, ok)
+	assert.Same(t, before[firstName], stillOld, "the first entry was already fast-skipped under the old spec")
+
+	c.SetProjectionSpec(execsAllSpec("spec-v2"))
+	require.Eventually(t, func() bool {
+		c.refreshMu.Lock()
+		defer c.refreshMu.Unlock()
+		return c.refreshInProgress && c.refreshPending
+	}, time.Second, time.Millisecond, "the nudge must queue a trailing pass behind the ticker-owned refresh")
+	close(client.release)
+
+	require.Eventually(t, func() bool {
+		for _, id := range idByName {
+			entry, ok := c.entries.Load(id)
+			if !ok || entry.SpecHash != "spec-v2" {
+				return false
+			}
+		}
+		c.refreshMu.Lock()
+		defer c.refreshMu.Unlock()
+		return !c.refreshInProgress && !c.refreshPending
+	}, 2*time.Second, time.Millisecond, "the trailing pass must rebuild every entry under the new spec")
+
+	updatedFirst, ok := c.entries.Load(firstID)
+	require.True(t, ok)
+	assert.NotSame(t, before[firstName], updatedFirst, "the trailing pass must revisit the already-processed entry")
+	assert.GreaterOrEqual(t, len(client.snapshotCalls()), 4)
+	assert.Equal(t, int64(1), client.maxActive.Load(), "ticker and nudge refreshes must remain single-flight")
+}
+
+// TestRefreshSchedulerFinalHandoffDoesNotStrandRequest places a new request at
+// the boundary where the active worker is trying to observe no pending work and
+// become idle. Whether the worker or requester acquires refreshMu first, the
+// second request must own or extend a refresh pass rather than disappear.
+func TestRefreshSchedulerFinalHandoffDoesNotStrandRequest(t *testing.T) {
+	cp := learnedCPWithChecksum("cp", "1", "")
+	client := &blockingFetchClient{
+		profiles:  map[string]*v1beta1.ContainerProfile{"cp": cp},
+		blockCall: 1,
+		entered:   make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	c := newReconcilerCache(t, client, newControllableK8sCache(), newCountingMetrics())
+	seedChecksumEntry(c, "cid", cp, "", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c.scheduleRefresh(ctx)
+	select {
+	case <-client.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first scheduled refresh did not enter the profile fetch")
+	}
+
+	// Hold the scheduler mutex before the first pass can perform its final
+	// pending/ownership handoff, then queue the competing request.
+	c.refreshMu.Lock()
+	close(client.release)
+	requestStarted := make(chan struct{})
+	go func() {
+		close(requestStarted)
+		c.scheduleRefresh(ctx)
+	}()
+	<-requestStarted
+	c.refreshMu.Unlock()
+
+	require.Eventually(t, func() bool {
+		c.refreshMu.Lock()
+		defer c.refreshMu.Unlock()
+		return len(client.snapshotCalls()) == 2 && !c.refreshInProgress && !c.refreshPending
+	}, 2*time.Second, time.Millisecond, "the handoff request must produce a second refresh")
+	assert.Equal(t, int64(1), client.maxActive.Load(), "handoff must not overlap refresh workers")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/storage/checksum.go
+++ b/pkg/storage/checksum.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"context"
+	"errors"
+)
+
+// ContainerProfileChecksumAnnotationKey is the ObjectMeta annotation under which
+// a fetched ContainerProfile carries the content checksum of its body.
+//
+// CROSS-REPO CONTRACT — this exact string is part of an interface between
+// repositories. A ProfileClient implementation that talks to a remote storage
+// backend (today: armosec/private-node-agent's pkg/backend adapter) is
+// responsible for re-keying whatever its own transport calls the checksum onto
+// THIS key before returning the profile. The container-profile cache reads the
+// validator from here and nowhere else.
+//
+// Changing this value fails silently rather than loudly: the cache simply never
+// observes a checksum, every entry keeps an empty validator, and every fetch
+// degrades to an unconditional one. Nothing breaks; the optimization just stops
+// existing. Treat it as frozen.
+//
+// The key is deliberately namespaced under backend.kubescape.io so it cannot
+// collide with the learning-lifecycle annotations in
+// k8s-interface/instanceidhandler/v1/helpers, which the cache reads for status
+// and completion.
+const ContainerProfileChecksumAnnotationKey = "backend.kubescape.io/container-profile-checksum"
+
+// ErrProfileUnchanged is returned by a ProfileClient implementation when the
+// caller supplied a known checksum via WithKnownChecksum and the source
+// confirmed the profile's content is byte-identical, so no body was
+// transferred. There is no profile to return: the caller must keep the one it
+// already holds.
+//
+// Implementations that cannot answer conditionally (for example the in-cluster
+// CRD-backed client) never return this and need no knowledge of it.
+var ErrProfileUnchanged = errors.New("container profile unchanged")
+
+// knownChecksumKey is the unexported context key type for the known checksum,
+// so no other package can collide with or forge the value.
+type knownChecksumKey struct{}
+
+// WithKnownChecksum returns a context carrying the content checksum of the
+// ContainerProfile the caller already holds, as a hint that the body may be
+// omitted if it still matches.
+//
+// It travels on the context rather than as a parameter because ProfileClient's
+// signature must stay stable for its checksum-unaware implementers. A client
+// that does not support conditional fetches ignores it and returns the body as
+// usual, so attaching it is always safe.
+//
+// Attach it per call, never to a context shared by fetches of different
+// objects: a checksum is a claim about one specific profile.
+func WithKnownChecksum(ctx context.Context, checksum string) context.Context {
+	return context.WithValue(ctx, knownChecksumKey{}, checksum)
+}
+
+// KnownChecksumFromContext returns the checksum attached by WithKnownChecksum,
+// or "" when none was attached. "" means "send the body unconditionally".
+func KnownChecksumFromContext(ctx context.Context) string {
+	checksum, _ := ctx.Value(knownChecksumKey{}).(string)
+	return checksum
+}


### PR DESCRIPTION
## Overview

Lands the client half of "conditional container-profile fetch" (step 4a of 5 in
[armosec/shared-designs-and-docs#201](https://github.com/armosec/shared-designs-and-docs/pull/201),
`status: proposed`). The container-profile cache reconciler can now present the
content checksum of the profile it already holds, and treat a server's
"unchanged" reply as "keep the cached entry, skip the rebuild" — instead of
today's behavior, which fetches the full body every tick and only decides
*after* the object is on the wire whether a rebuild is needed.

**This PR is DORMANT.** No in-tree `ProfileClient` implementer returns the new
sentinel, so no conditional fetch has been or can be observed here. Green
tests prove the contract compiles and existing behavior is byte-for-byte
unchanged — nothing more. The companion `kubescape/backend` PR (kubescape/backend#62)
adds the server-side contract; a private downstream adapter (not part of this
org, not this PR) is what will eventually make node-agent actually send the
checksum in production.

## Design constraint

`storage.ProfileClient.GetContainerProfile(ctx, namespace, name)` has a second
implementer in this repo (`pkg/storage/v1`, the in-cluster CRD/aggregated-API
backend), which has no concept of a remote checksum. This PR does **not**
change that interface's signature — `pkg/storage/v1/`, `storage_mock.go`, and
the interface definition are byte-for-byte untouched (`git diff --stat` is
empty). The checksum crosses the boundary out-of-band instead: a `context.Context`
key on the request side, a sentinel `error` plus an `ObjectMeta` annotation on
the response side.

## Changes

- `pkg/storage/checksum.go` (new): `WithKnownChecksum`/`KnownChecksumFromContext`
  over an unexported context key; `ErrProfileUnchanged`; the exported
  `ContainerProfileChecksumAnnotationKey` (`backend.kubescape.io/container-profile-checksum`,
  matching kubescape/backend#62's key exactly — pinned by a dedicated
  cross-repo equality test in the downstream adapter).
- `CachedContainerProfile` gains a `Checksum` field, populated at **both**
  places a cache entry is constructed (`rebuildEntryFromSources` and
  `buildEntry`/`tryPopulateEntry` — missing the second site would have made
  the optimization silently inert for every profile that never changes, i.e.
  exactly the population it targets).
- `refreshOneEntry`'s guard for attaching a checksum to the learned-CP fetch
  requires: no authored-CP override in play, the projection spec hash
  unchanged, a known checksum available, **and** the entry's learned status is
  already terminal (`Completed`+`Full`) — that last conjunct exists because a
  lifecycle-only change (e.g. completion status flipping) doesn't change the
  content checksum, and this cache's `State` feeds real alerting logic
  downstream, so a conditional fetch is only requested once nothing about the
  entry can still move.
- The user-authored-CP fetch (a separate call in the same function) never
  receives a checksum and is completely unaffected.
- `docs/features/container-profile-conditional-fetch-contract.md` (new):
  documents this repo's half of the cross-repo contract for future
  maintainers and upstream reviewers.

## Testing

- 17 new tests in `pkg/objectcache/containerprofilecache/reconciler_checksum_test.go`,
  covering: both construction sites (including that the *adopted* entry stores
  the learned CP's checksum, not the authored CP's), every guard conjunct
  individually, per-call-site isolation (the authored-CP fetch never sees a
  checksum even in the same tick), the sentinel keeping the cache entry
  pointer-identical with no rebuild, and the terminal-state guard walking all
  three phases (declined while partial → completion flip reaches the cache →
  shortcut engages once terminal).
- `go test ./pkg/objectcache/containerprofilecache/... -race` green.
- `go test ./pkg/objectcache/... -run Golden` green — no projection-golden
  churn from the new annotation.
- Every pre-existing test in this package passes unmodified — no assertion
  edits, no new skips.
- `go build ./...` — confirms the in-cluster `Storage` implementer still
  satisfies `ProfileClient` with zero changes on this PR's part.

## Related

Step 4a of 5 in the [conditional container-profile fetch plan](https://github.com/armosec/shared-designs-and-docs/pull/201).
Companion PR: kubescape/backend#62 (step 2, proto contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnqMRD3r2kGYUBTxMHM5vi

AI-skills: oh-my-claudecode:plan,oh-my-claudecode:team | cmds: /oh-my-claudecode:deep-interview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional fetching for unchanged container profiles, reducing unnecessary data transfers with compatible sources.
  * Container profile checksums are stored and reused during eligible refreshes.
  * Cached profiles are retained when a source confirms that content is unchanged.
  * Added refresh safeguards to periodically revalidate profiles and prevent overlapping refresh operations.
  * Added metrics for conditional-fetch requests and responses.

* **Documentation**
  * Documented the conditional-fetch contract, checksum behavior, and refresh conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->