### PR TITLE
fix: strip StatefulSet pod-identity labels from network peer selectors

### DIFF
--- a/pkg/containerprofilemanager/v1/containerprofile_manager_test.go
+++ b/pkg/containerprofilemanager/v1/containerprofile_manager_test.go
@@ -185,6 +185,17 @@ func TestFilterLabels(t *testing.T) {
 			},
 			expected: map[string]string{},
 		},
+		{
+			name: "filter StatefulSet pod-identity labels",
+			input: map[string]string{
+				"app.kubernetes.io/name":             "db",
+				"apps.kubernetes.io/pod-index":       "2",
+				"statefulset.kubernetes.io/pod-name": "db-2",
+			},
+			expected: map[string]string{
+				"app.kubernetes.io/name": "db",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -613,9 +624,11 @@ func TestTrafficTypeConstants(t *testing.T) {
 
 func TestDefaultLabelsToIgnore(t *testing.T) {
 	expectedLabels := map[string]struct{}{
-		"controller-revision-hash": {},
-		"pod-template-generation":  {},
-		"pod-template-hash":        {},
+		"controller-revision-hash":           {},
+		"pod-template-generation":            {},
+		"pod-template-hash":                  {},
+		"apps.kubernetes.io/pod-index":       {},
+		"statefulset.kubernetes.io/pod-name": {},
 	}
 
 	assert.Equal(t, expectedLabels, DefaultLabelsToIgnore)

--- a/pkg/containerprofilemanager/v1/event_reporting_test.go
+++ b/pkg/containerprofilemanager/v1/event_reporting_test.go
@@ -252,3 +252,50 @@ func TestCreateNetworkNeighbor_EmptyContainerIDWithWatchedContainerData(t *testi
 	assert.Equal(t, "93.184.216.34", resolver.lastIPAddress)
 	assert.Equal(t, "resolved.domain", neighbor.DNS)
 }
+
+// TestCreateNetworkNeighbor_StatefulSetPeerStripsPodIdentityLabels ensures per-replica
+// StatefulSet labels are stripped from PodSelector so GeneratedNetworkPolicy peers
+// select the workload, not the replicas observed during learning (#942).
+func TestCreateNetworkNeighbor_StatefulSetPeerStripsPodIdentityLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		index   string
+		podName string
+	}{
+		{name: "replica-0", index: "0", podName: "db-0"},
+		{name: "replica-1", index: "1", podName: "db-1"},
+		{name: "replica-2", index: "2", podName: "db-2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			networkEvent := NetworkEvent{
+				Port:     5432,
+				Protocol: "TCP",
+				PktType:  utils.OutgoingPktType,
+				Destination: Destination{
+					Kind:      EndpointKindPod,
+					Namespace: "default",
+					Name:      tt.podName,
+				},
+			}
+			networkEvent.SetDestinationPodLabels(map[string]string{
+				"app.kubernetes.io/name":             "db",
+				"apps.kubernetes.io/pod-index":       tt.index,
+				"statefulset.kubernetes.io/pod-name": tt.podName,
+			})
+
+			cd := &containerData{}
+			neighbor := cd.createNetworkNeighbor("", networkEvent, "default", nil, nil)
+			if !assert.NotNil(t, neighbor) {
+				return
+			}
+			if !assert.NotNil(t, neighbor.PodSelector) {
+				return
+			}
+			assert.Equal(t, map[string]string{"app.kubernetes.io/name": "db"}, neighbor.PodSelector.MatchLabels)
+			assert.NotContains(t, neighbor.PodSelector.MatchLabels, "apps.kubernetes.io/pod-index")
+			assert.NotContains(t, neighbor.PodSelector.MatchLabels, "statefulset.kubernetes.io/pod-name")
+		})
+	}
+}

--- a/pkg/containerprofilemanager/v1/network_helpers.go
+++ b/pkg/containerprofilemanager/v1/network_helpers.go
@@ -12,9 +12,11 @@ import (
 type EndpointKind string
 
 var DefaultLabelsToIgnore = map[string]struct{}{
-	"controller-revision-hash": {},
-	"pod-template-generation":  {},
-	"pod-template-hash":        {},
+	"controller-revision-hash":           {},
+	"pod-template-generation":            {},
+	"pod-template-hash":                  {},
+	"apps.kubernetes.io/pod-index":       {},
+	"statefulset.kubernetes.io/pod-name": {},
 }
 
 const (


### PR DESCRIPTION
StatefulSet pods carry `apps.kubernetes.io/pod-index` and `statefulset.kubernetes.io/pod-name` labels that are per-replica, not workload-level. Carrying them into `NetworkNeighbor` `podSelector`s caused `GeneratedNetworkPolicy` to pin peers to replicas seen during learning, denying traffic when the StatefulSet scales up.

Fixes #942

## Overview

**Current behavior:** When the peer is a StatefulSet, learned `NetworkNeighbor.PodSelector` includes per-replica identity labels (`apps.kubernetes.io/pod-index`, `statefulset.kubernetes.io/pod-name`). That produces one NetworkPolicy peer rule per replica and breaks after scale-up.

**Future behavior:** Those StatefulSet pod-identity labels are stripped in `filterLabels()` / `DefaultLabelsToIgnore`, so peer selectors keep only workload labels (e.g. `app.kubernetes.io/name`).

This PR fixes learning at the **source** (new `ContainerProfile` neighbors). A companion change in `kubescape/storage` sanitizes **legacy** profiles that already carry `pod-index` at GNP generation time.

## How to Test

```bash
go test ./pkg/containerprofilemanager/v1/ \
  -run 'TestFilterLabels|TestDefaultLabelsToIgnore|TestCreateNetworkNeighbor_StatefulSetPeerStripsPodIdentityLabels' \
  -count=1
```

Expected: all cases pass, including table-driven replicas `0`/`1`/`2` with only `app.kubernetes.io/name=db` remaining in `PodSelector.MatchLabels`.

## Related issues/PRs

* Fixes #942
* Companion: `kubescape/storage` PR — ignore `apps.kubernetes.io/pod-index` when generating network policies *(link after opening)*

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes *(targeted #942 regressions verified; full `go test ./...` not re-run in this environment)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - StatefulSet pod identity labels are now excluded from generated network selectors.
  - Network selectors retain stable workload labels while ignoring replica-specific labels, improving behavior for StatefulSet pods.

- **Tests**
  - Added coverage validating label filtering and selector generation across multiple StatefulSet replicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->