### PR TITLE
  fix: make SBOM failure service discovery opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,13 @@ See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the complete configuratio
 | Malware Detection | `malwareDetectionEnabled` | `false` | Start the malware manager (needs an out-of-tree scanner) |
 | Network Tracing | `networkServiceEnabled` | `false` | Track network connections |
 | SBOM Generation | `sbomGenerationEnabled` | `false` | Generate SBOMs |
+| SBOM Failure Reporting | `sbomFailureReportingEnabled` | `false` | Report SBOM generation failures; service discovery runs only when this and SBOM generation are enabled |
 | File Integrity | `fimEnabled` | `false` | Monitor file changes |
 | Seccomp Profiles | `seccompServiceEnabled` | `false` | Generate seccomp profiles |
 | HTTP Detection | `httpDetectionEnabled` | `false` | Parse HTTP traffic |
 | Network Streaming | `networkStreamingEnabled` | `false` | Stream network events |
+
+SBOM failure reporting is opt-in. Setting `API_URL` or mounting `services.json` does not enable it; those sources are consulted only when both `sbomGenerationEnabled` and `sbomFailureReportingEnabled` are `true`.
 
 ## 🔌 Image-Based Gadgets
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	igconfig "github.com/inspektor-gadget/inspektor-gadget/pkg/config"
 	containercollection "github.com/inspektor-gadget/inspektor-gadget/pkg/container-collection"
 	iglogger "github.com/inspektor-gadget/inspektor-gadget/pkg/logger"
+	"github.com/kubescape/backend/pkg/servicediscovery/schema"
 	beUtils "github.com/kubescape/backend/pkg/utils"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
@@ -74,6 +75,26 @@ import (
 	goruntime "go.opentelemetry.io/contrib/instrumentation/runtime"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const defaultAPIURL = "api.armosec.io"
+
+func resolveSbomFailureReportReceiverURL(
+	cfg config.Config,
+	apiURL string,
+	loadServices func(string) (schema.IBackendServices, error),
+) string {
+	if !cfg.EnableSbomGeneration || !cfg.EnableSbomFailureReporting {
+		return ""
+	}
+	if apiURL == "" {
+		apiURL = defaultAPIURL
+	}
+	services, err := loadServices(apiURL)
+	if err != nil || services == nil {
+		return ""
+	}
+	return services.GetReportReceiverHttpUrl()
+}
 
 func main() {
 	ctx := context.Background()
@@ -431,13 +452,9 @@ func main() {
 
 	// Create scan failure reporter (sends SBOM failures to careportreceiver for user notifications)
 	var failureReporter sbommanager.SbomFailureReporter
-	apiURL := os.Getenv("API_URL")
-	if apiURL == "" {
-		apiURL = "api.armosec.io"
-	}
-	if services, svcErr := config.LoadServiceURLs(apiURL); svcErr == nil && services.GetReportReceiverHttpUrl() != "" {
-		failureReporter = sbommanagerv1.NewHTTPSbomFailureReporter(services.GetReportReceiverHttpUrl(), accessKey, clusterData.AccountID, clusterData.ClusterName)
-		logger.L().Info("scan failure reporting enabled", helpers.String("eventReceiverURL", services.GetReportReceiverHttpUrl()))
+	if eventReceiverURL := resolveSbomFailureReportReceiverURL(cfg, os.Getenv("API_URL"), config.LoadServiceURLs); eventReceiverURL != "" {
+		failureReporter = sbommanagerv1.NewHTTPSbomFailureReporter(eventReceiverURL, accessKey, clusterData.AccountID, clusterData.ClusterName)
+		logger.L().Info("scan failure reporting enabled", helpers.String("eventReceiverURL", eventReceiverURL))
 	}
 
 	// Create the SBOM manager

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubescape/backend/pkg/servicediscovery/schema"
+	servicediscoveryv3 "github.com/kubescape/backend/pkg/servicediscovery/v3"
+	"github.com/kubescape/node-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveSbomFailureReportReceiverURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           config.Config
+		apiURL        string
+		services      schema.IBackendServices
+		loadErr       error
+		wantURL       string
+		wantAPIURL    string
+		wantLoadCalls int
+	}{
+		{
+			name:          "disabled by default",
+			cfg:           config.Config{},
+			apiURL:        "configured.example.com",
+			wantLoadCalls: 0,
+		},
+		{
+			name: "failure reporting disabled",
+			cfg: config.Config{
+				EnableSbomGeneration: true,
+			},
+			apiURL:        "configured.example.com",
+			wantLoadCalls: 0,
+		},
+		{
+			name: "SBOM generation disabled",
+			cfg: config.Config{
+				EnableSbomFailureReporting: true,
+			},
+			apiURL:        "configured.example.com",
+			wantLoadCalls: 0,
+		},
+		{
+			name: "enabled with configured API URL",
+			cfg: config.Config{
+				EnableSbomGeneration:       true,
+				EnableSbomFailureReporting: true,
+			},
+			apiURL:        "configured.example.com",
+			services:      servicesWithReportReceiverURL("https://receiver.example.com"),
+			wantURL:       "https://receiver.example.com",
+			wantAPIURL:    "configured.example.com",
+			wantLoadCalls: 1,
+		},
+		{
+			name: "enabled with default API URL",
+			cfg: config.Config{
+				EnableSbomGeneration:       true,
+				EnableSbomFailureReporting: true,
+			},
+			services:      servicesWithReportReceiverURL("https://receiver.example.com"),
+			wantURL:       "https://receiver.example.com",
+			wantAPIURL:    defaultAPIURL,
+			wantLoadCalls: 1,
+		},
+		{
+			name: "service discovery failure",
+			cfg: config.Config{
+				EnableSbomGeneration:       true,
+				EnableSbomFailureReporting: true,
+			},
+			loadErr:       errors.New("service discovery failed"),
+			wantAPIURL:    defaultAPIURL,
+			wantLoadCalls: 1,
+		},
+		{
+			name: "nil services",
+			cfg: config.Config{
+				EnableSbomGeneration:       true,
+				EnableSbomFailureReporting: true,
+			},
+			wantAPIURL:    defaultAPIURL,
+			wantLoadCalls: 1,
+		},
+		{
+			name: "empty report receiver URL",
+			cfg: config.Config{
+				EnableSbomGeneration:       true,
+				EnableSbomFailureReporting: true,
+			},
+			services:      servicesWithReportReceiverURL(""),
+			wantAPIURL:    defaultAPIURL,
+			wantLoadCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loadCalls := 0
+			var gotAPIURL string
+			loader := func(apiURL string) (schema.IBackendServices, error) {
+				loadCalls++
+				gotAPIURL = apiURL
+				return tt.services, tt.loadErr
+			}
+
+			gotURL := resolveSbomFailureReportReceiverURL(tt.cfg, tt.apiURL, loader)
+
+			assert.Equal(t, tt.wantURL, gotURL)
+			assert.Equal(t, tt.wantLoadCalls, loadCalls)
+			assert.Equal(t, tt.wantAPIURL, gotAPIURL)
+		})
+	}
+}
+
+func servicesWithReportReceiverURL(reportReceiverURL string) schema.IBackendServices {
+	services := &servicediscoveryv3.ServicesV3{}
+	services.SetReportReceiverHttpUrl(reportReceiverURL)
+	return services
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -149,6 +149,7 @@ correlation is an upgrade, not a dependency.
 | `networkServiceEnabled` | bool | `false` | Enable network connection tracking |
 | `networkStreamingEnabled` | bool | `false` | Enable network event streaming |
 | `sbomGenerationEnabled` | bool | `false` | Enable SBOM generation |
+| `sbomFailureReportingEnabled` | bool | `false` | Report SBOM generation failures; service discovery runs only when this and SBOM generation are enabled |
 | `seccompServiceEnabled` | bool | `false` | Enable seccomp profile generation |
 | `nodeProfileServiceEnabled` | bool | `false` | Enable node profiling |
 | `fimEnabled` | bool | `false` | Enable File Integrity Monitoring |
@@ -159,6 +160,8 @@ correlation is an upgrade, not a dependency.
 | `enableEmbeddedSBOMs` | bool | `false` | Use embedded SBOMs from images |
 | `partialProfileGenerationEnabled` | bool | `true` | Allow partial profile generation |
 | `ignoreRuleBindings` | bool | `false` | Apply all rules to all pods regardless of bindings. When enabled, RuntimeAlertRuleBinding objects are not watched, every monitored container is kept for runtime detection, and per-pod binding bookkeeping is skipped (rules are resolved directly from the rule creator). |
+
+SBOM failure reporting is opt-in. Setting `API_URL` or mounting `services.json` does not enable it. Once both SBOM generation and failure reporting are enabled, service discovery retains its existing local-file-first behavior and uses `API_URL` (or `api.armosec.io` when unset) only when no services file exists.
 
 ### Timing & Performance
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,7 @@ type Config struct {
 	EnablePartialProfileGeneration bool                                 `mapstructure:"partialProfileGenerationEnabled"`
 	EnableMetricsExporter          bool                                 `mapstructure:"prometheusExporterEnabled"`
 	EnableRuntimeDetection         bool                                 `mapstructure:"runtimeDetectionEnabled"`
+	EnableSbomFailureReporting     bool                                 `mapstructure:"sbomFailureReportingEnabled"`
 	EnableSbomGeneration           bool                                 `mapstructure:"sbomGenerationEnabled"`
 	EnableSeccomp                  bool                                 `mapstructure:"seccompServiceEnabled"`
 	HostMonitoringEnabled          bool                                 `mapstructure:"hostMonitoringEnabled"`
@@ -197,6 +198,7 @@ func LoadConfigOptional(path string, errNotFound bool) (Config, error) {
 	viper.SetDefault("workerPoolSize", 3000)
 	viper.SetDefault("eventBatchSize", 15000)
 	viper.SetDefault("enableEmbeddedSBOMs", false)
+	viper.SetDefault("sbomFailureReportingEnabled", false)
 	viper.SetDefault("profilesCacheRefreshRate", 1*time.Minute)
 	viper.SetDefault("ruleCooldown::ruleCooldownDisabled", false)
 	viper.SetDefault("ruleCooldown::ruleCooldownDuration", 1*time.Hour)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -615,6 +615,39 @@ func TestLoadConfig_NoBypassByDefault(t *testing.T) {
 	assert.True(t, config.FIM.DedupConfig.DedupEnabled, "without bypass, configured suppression is preserved")
 }
 
+func TestLoadConfig_SbomFailureReporting(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "disabled by default",
+			content: `{}`,
+			want:    false,
+		},
+		{
+			name:    "explicitly enabled",
+			content: `{"sbomFailureReportingEnabled": true}`,
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(dir+"/config.json", []byte(tt.content), 0644))
+
+			config, err := LoadConfigOptional(dir, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, config.EnableSbomFailureReporting)
+		})
+	}
+}
+
 func TestGetFIMExportersConfig(t *testing.T) {
 	// Create a temporary config file
 	tempDir := t.TempDir()


### PR DESCRIPTION

  ## Overview

  Prevent node-agent from performing remote service discovery for SBOM failure reporting unless it is explicitly enabled.

  This adds the default-disabled `sbomFailureReportingEnabled` configuration option. Service discovery now runs only when both:

  - `sbomGenerationEnabled` is `true`
  - `sbomFailureReportingEnabled` is `true`

  When enabled, the existing discovery behavior is preserved:

  1. Use `SERVICES` or `/etc/config/services.json` when available.
  2. Otherwise use `API_URL`.
  3. Fall back to `api.armosec.io` when `API_URL` is unset.

  Setting `API_URL` or mounting `services.json` alone does not enable failure reporting. Discovery errors and empty receiver URLs remain
  non-fatal.

  ## Additional Information

  This changes SBOM failure reporting from implicit behavior to explicit opt-in behavior. Existing deployments that require failure reporting must add:

  ```json
  {
    "sbomGenerationEnabled": true,
    "sbomFailureReportingEnabled": true
  }
  ```

  ## How to Test

  Focused tests:

```
  go test -count=1 ./pkg/config ./cmd
  go test ./pkg/sbommanager/v1
```

  These checks pass locally.

  A serial non-e2e repository test sweep was also performed. The remaining unrelated environment-dependent failures were:

  - Tracer field tests require a generated root-level tracers.tar.
  - pkg/validator requires permission to raise the memlock limit.

  Socket-dependent exporter, node-profile, and SBOM-scanner tests passed when run outside the restricted sandbox.

  ## Related issues/PRs

  - Resolves #899

  ## Checklist before requesting a review

  - [x] My code follows the style guidelines of this project
  - [x] I have commented on my code where necessary
  - [x] I have performed a self-review of my code
  - [x] I have added thorough regression tests
  - [x] Focused unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting for reporting SBOM generation failures.
  * SBOM failure reporting remains disabled by default and is activated only when both SBOM generation and failure reporting are enabled.
  * Failure report destinations can be resolved from local service configuration or the configured API endpoint.

* **Documentation**
  * Documented the new configuration option, activation requirements, and service discovery behavior.
  * Added a link to the Kubescape documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->