### PR TITLE
[EXPERIMENT] Validate kubescape/storage#397 (sharded single-writer) fix

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,9 +153,12 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
-          STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
-          echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          # EXPERIMENT: validating kubescape/storage#397 (sharded single-writer
+          # fix) before merge. Pins storage to a manually-built test image
+          # instead of the usual dynamic tag. Do not merge this override.
+          STORAGE_TAG=test-sharded-writer-397
+          echo "Storage tag that will be used: ${STORAGE_TAG} (EXPERIMENT override, repo quay.io/kubescape/storge)"
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/kubescape/storge -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
## Purpose

**This is a validation experiment, not a proposed fix — do not merge.**

Points the test storage deployment at a manually-built image (`quay.io/kubescape/storge:test-sharded-writer-397` — note: pre-existing typo in kubescape/storage's `build-image` workflow pushes to `storge`, not `storage`), built from [kubescape/storage#397](https://github.com/kubescape/storage/pull/397) (`fix/single-writer-sharded-commits`), to empirically confirm the sharded single-writer fix resolves this repo's `component-tests` regression (18-19 of ~30 matrix jobs failing since storage's `singleWriterEnabled` default flipped to `true`, see #397's description for the full root-cause writeup) before that PR merges upstream.

Expected result: **near-zero failures**, matching the pre-regression baseline, since the fix restores per-key write parallelism (default 8 shards) while keeping every existing single-writer correctness guarantee.

## Test plan
- [ ] component-tests run on this PR — compare failure count against the current baseline (18-19/30 failing) and the unmodified-storage-image baseline (0-1/30)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLN3CgGftcnAikV13qD6yJ

AI-skills: none | cmds: /oh-my-claudecode:autopilot