### PR TITLE
[EXPERIMENT] Validate kubescape/storage#397 (sharded single-writer) fix, take 2

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,8 +153,11 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
-          STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
-          echo "Storage tag that will be used: ${STORAGE_TAG}"
+          # EXPERIMENT: validating kubescape/storage#397 (sharded single-writer
+          # fix) before merge. Pins storage to a manually-built test image
+          # instead of the usual dynamic tag. Do not merge this override.
+          STORAGE_TAG=test-sharded-writer-397b
+          echo "Storage tag that will be used: ${STORAGE_TAG} (EXPERIMENT override)"
           helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s


### PR DESCRIPTION
## Purpose

**This is a validation experiment, not a proposed fix — do not merge.**

Retry of #948, which was a false negative: that attempt's test image landed in `quay.io/kubescape/storge` (typo'd repo name from a pre-existing bug in kubescape/storage's manual `build-image` workflow), which turned out to be a brand-new, private-by-default repo. The Kind cluster couldn't pull it at all — the storage deployment never became ready, so all 31 test jobs failed on infrastructure grounds, not on anything related to the write-throughput regression.

This retry uses a corrected build (`quay.io/kubescape/storage:test-sharded-writer-397b` — confirmed public via `curl https://quay.io/api/v1/repository/kubescape/storage/tag/` with no auth), built from [kubescape/storage#397](https://github.com/kubescape/storage/pull/397)'s `fix/single-writer-sharded-commits` via a throwaway build-workflow branch that fixes the repo-name typo and drops the `:latest` tag push so the real published tag is never touched.

Expected result: **near-zero failures**, matching the pre-regression baseline, since the fix restores per-key write parallelism (default 8 shards) while keeping every existing single-writer correctness guarantee.

## Test plan
- [ ] component-tests run on this PR — compare failure count against the current baseline (18-19/30 failing)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLN3CgGftcnAikV13qD6yJ

AI-skills: none | cmds: /oh-my-claudecode:autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Component tests now use a fixed experimental storage image version.
  * Updated test output to reflect the selected experimental version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->