### PR TITLE
[EXPERIMENT] Test higher singleWriterShards/sqlitePoolSize headroom

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,8 +153,11 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
-          STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
-          echo "Storage tag that will be used: ${STORAGE_TAG}"
+          # EXPERIMENT: validating kubescape/storage#397 (sharded single-writer
+          # fix) with higher shard/pool headroom before merge. Pins storage to
+          # a manually-built test image. Do not merge this override.
+          STORAGE_TAG=test-sharded-writer-397b
+          echo "Storage tag that will be used: ${STORAGE_TAG} (EXPERIMENT override)"
           helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s

--- a/tests/chart/templates/storage/configmap.yaml
+++ b/tests/chart/templates/storage/configmap.yaml
@@ -9,5 +9,7 @@ metadata:
 data:
   config.json: |
     {
-      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}"
+      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}",
+      "singleWriterShards": 16,
+      "sqlitePoolSize": 24
     }


### PR DESCRIPTION
## Purpose

**This is a diagnostic experiment, not a proposed fix — do not merge.**

Follow-up to #949 (default 8-shard validation of kubescape/storage#397): that run showed a big real improvement (15/30 failures vs 18-19/30 baseline, no more sustained 20-minute hangs, individual write latency dropped from minutes to seconds) but not the hoped-for near-zero. Traced the residual failures to occasional `context deadline exceeded` retries and one new error variant, `write metadata: insert metadata: sqlite: step: interrupted`, still occurring under concurrent write bursts even with 8-way sharding.

This PR tests whether that residual contention is simply a matter of headroom: bumps `singleWriterShards` 8→16 and `sqlitePoolSize` 10→24 via `config.json` overrides (both are config-driven in kubescape/storage, so no new image build needed — reuses the same validated `quay.io/kubescape/storage:test-sharded-writer-397b` image from #949).

If this resolves the residual flakiness, it points to needing a higher default shard/pool count for write-heavy environments. If it doesn't help, the residual failures likely have a separate cause (e.g. CI pod churn/restarts observed in #949's investigation) worth investigating independently of the storage fix.

## Test plan
- [ ] component-tests run on this PR — compare failure count against #949's 15/30 and the original 18-19/30 baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLN3CgGftcnAikV13qD6yJ

AI-skills: none | cmds: /oh-my-claudecode:autopilot