### PR TITLE
[EXPERIMENT] Validate real kubescape/storage v0.0.333 release

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,6 +153,9 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
+          # (no-op, throwaway validation PR: confirms component-tests pass
+          # against the actual released kubescape/storage v0.0.333, not a
+          # manually-built test image)
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
           helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug


### PR DESCRIPTION
## Purpose

**Throwaway validation PR — do not merge.**

Prior validations ([#949](https://github.com/kubescape/node-agent/pull/949), [#950](https://github.com/kubescape/node-agent/pull/950)) used a manually-built test image from the [kubescape/storage#397](https://github.com/kubescape/storage/pull/397) fix branch. That PR has since merged and released as [v0.0.333](https://github.com/kubescape/storage/releases/tag/v0.0.333), and `kubescape/helm-charts` main now points `storage.image.tag` at it.

This PR makes no functional change — `tests/scripts/storage-tag.sh`'s normal dynamic resolution will pick up `v0.0.333` on its own. Opening this purely to trigger `component-tests` and confirm the real, merged, released fix behaves the same as the manually-built validation image did (expect ~15/30 failures, down from the 18-19/30 baseline, no sustained hangs).

## Test plan
- [ ] component-tests run on this PR — compare against #949's 15/30 result

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LLN3CgGftcnAikV13qD6yJ

AI-skills: oh-my-claudecode:cancel | cmds: /oh-my-claudecode:autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a validation-only update to component test workflow configuration. No user-facing product behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->