### PR TITLE
[EXPERIMENT] Test storage pod CPU starvation hypothesis for residual component-tests flakiness

### DIFF
--- a/tests/chart/values.yaml
+++ b/tests/chart/values.yaml
@@ -44,10 +44,10 @@ storage:
     app.kubernetes.io/part-of: "kubescape-storage"
   resources:
     requests:
-      cpu: 100m
+      cpu: 500m
       memory: 400Mi
     limits:
-      cpu: 500m
+      cpu: 2000m
       memory: 1500Mi
 nodeAgent:
   # The component tests run the agent with the Go profiler on. This used to ride


### PR DESCRIPTION
## Purpose

**Diagnostic experiment, not a proposed fix — do not merge.**

Follow-up to the storage single-writer investigation (kubescape/storage#397, released v0.0.333). That fix eliminated the sustained 20-minute hangs, but component-tests still shows an elevated failure rate: 15-17/30 jobs failing (confirmed fresh today on #951: 17/31), vs a historical pre-regression baseline of 0-1/30.

#950 tested whether the residual failures were a shard/pool headroom problem (singleWriterShards 8→16, sqlitePoolSize 10→24) — result was 21/32 failed, *worse*, not better. That rules out shard/pool count as the lever and points at the storage pod's CPU quota instead: `tests/chart/values.yaml`'s `storage.resources` has stayed at `requests.cpu: 100m` / `limits.cpu: 500m` across every experiment so far. Under a starved CPU quota, more concurrent write-path goroutines (the 8 fixed shards) add scheduling overhead without proportional throughput gain, which would explain why more shards didn't help.

This PR bumps `storage.resources.requests.cpu` 100m→500m and `limits.cpu` 500m→2000m, with **no shard-count or other change**, to isolate this variable. Looking for:
- Overall failure count vs the 17/31 baseline (#951, same day)
- Whether storage-side `context deadline exceeded` / `sqlite: step: interrupted` errors specifically disappear from logs (vs the heterogeneous non-storage assertion failures, which this change should NOT affect)

## Test plan
- [ ] component-tests run on this PR — compare failure count and error signature against #951's 17/31 baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the CPU capacity allocated to the storage component.
  - Memory allocation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->