### PR TITLE
[EXPERIMENT] Instrument component-tests for pod restarts and node resource pressure

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -182,3 +182,22 @@ jobs:
           echo "-----------------------------------------"
           echo "Storage logs"
           kubectl logs $(kubectl get pods -n kubescape -o name | grep storage) -n kubescape
+      - name: Diagnose pod restarts and node resource pressure
+        if: always()
+        run: |
+          echo "Node describe (allocatable/capacity vs requests)"
+          kubectl describe nodes
+          echo "-----------------------------------------"
+          echo "Pods across all namespaces, with restart counts"
+          kubectl get pods -A -o wide
+          echo "-----------------------------------------"
+          echo "Pods with non-zero restarts (detail)"
+          for p in $(kubectl get pods -A --no-headers -o custom-columns=":metadata.namespace,:metadata.name,:status.containerStatuses[0].restartCount" | awk '$3!="" && $3!="<none>" && $3+0>0 {print $1"/"$2}'); do
+            ns=$(echo "$p" | cut -d/ -f1)
+            name=$(echo "$p" | cut -d/ -f2)
+            echo "=== $ns/$name ==="
+            kubectl describe pod "$name" -n "$ns"
+          done
+          echo "-----------------------------------------"
+          echo "Cluster events, sorted by time (liveness/readiness probe failures, OOMKilled, etc.)"
+          kubectl get events -A --sort-by=.lastTimestamp


### PR DESCRIPTION
## Purpose

**Diagnostic experiment, not a proposed fix — do not merge.**

Follow-up to the CPU-headroom experiment (#952, refuted): bumping the storage pod's own CPU limit 4x (500m→2000m) made no measurable difference to the residual 17-18/31 component-tests failure rate. Tracing one failing job (Test_01_BasicAlertTest) end-to-end showed the container-profile *write* path timing out repeatedly (`failed to create container profile, requeuing` / `context deadline exceeded`), with the internal write queue backing up — independent of the storage pod's own cgroup quota.

Two candidates remain, neither confirmed with hard data yet:
1. **Node-level CPU oversubscription** on the shared GitHub-hosted runner — the storage pod's own limit can't manufacture free cycles if the whole node (Kind control-plane + storage + node-agent + kube-prometheus-stack + kubelet/containerd + `go test`) is already saturated.
2. **CI pod churn/restarts** (liveness-probe failures under CI resource pressure) generating extra write traffic independent of storage, per the original investigation's (#949) observation of multiple container-instance IDs for the same logical container within ~1 minute.

This PR makes no behavioral change — it only adds an always-run diagnostic step after the existing log dump, capturing:
- `kubectl describe nodes` (allocatable vs. requested resources, to check for node-level saturation)
- `kubectl get pods -A -o wide` (restart counts across the whole cluster)
- `kubectl describe pod` for any pod with a non-zero restart count
- `kubectl get events -A --sort-by=.lastTimestamp` (liveness/readiness probe failures, OOMKilled, etc.)

...across the full ~30-job matrix, so failing vs. passing jobs can be correlated against real restart/pressure evidence instead of one manually-traced job.

## Test plan
- [ ] component-tests run on this PR — correlate failing jobs against restart counts / node pressure evidence in the new diagnostic step

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added always-run diagnostic reporting to component test workflows, including node capacity, pod status and restart details, and time-sorted cluster events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->