### PR TITLE
[EXPERIMENT] Validate kubescape/storage's ConsolidateTimeSeries-delete shard-routing fix

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,9 +153,14 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
-          STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
-          echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          # EXPERIMENT: validating a fix for the residual component-tests
+          # write-timeout flakiness (ConsolidateTimeSeries's Delete bypassing
+          # the write-shard system) before it merges upstream in
+          # kubescape/storage. Pins storage to a manually-built test image
+          # instead of the usual dynamic tag. Do not merge this override.
+          STORAGE_TAG=test-shard-delete-fix-965bd1c1
+          echo "Storage tag that will be used: ${STORAGE_TAG} (EXPERIMENT override, repo quay.io/matthiasb_1/storage)"
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
## Purpose

**Throwaway validation PR — do not merge.**

Follow-up to the residual component-tests write-timeout flakiness investigation (15-17/31 jobs failing even after [kubescape/storage#397](https://github.com/kubescape/storage/pull/397)'s sharded single-writer fix — see PRs [#952](https://github.com/kubescape/node-agent/pull/952)/[#953](https://github.com/kubescape/node-agent/pull/953) for the CPU-starvation and pod-restart hypotheses, both ruled out).

Traced the actual root cause into kubescape/storage: `ConsolidateTimeSeries`'s `deleteProcessedTimeSeries` step deletes each processed time-series profile via `DeleteContainerProfile`, which takes a **raw pool connection outside storage's write-shard system entirely** — unlike `SaveContainerProfile` and `Create`/`GuaranteedUpdate`'s own commits, which are all routed through the 8-shard system (#397). A raw connection has no way to yield to, or be yielded by, a live shard commit, so a genuine collision for SQLite's single writer lock blocks the loser for up to the full busy-timeout (60s in production) instead of the microsecond in-process channel wait every shard-routed write enjoys.

Confirmed locally against kubescape/storage (`containerprofile_load_test.go`, `LOAD_CONSOLIDATORS=1`): a pure 20-way concurrent write burst alone was flawless (9543/9543 ops, p99=115ms), but adding one concurrent `ConsolidateTimeSeries` pass collapsed throughput by >250x (36 ops/8s, 14 failed, multi-second `database is locked` stalls) — the same fast, heterogeneous failure shape seen in this repo's CI, not the original catastrophic hang.

The fix: a new `singleWriter.runOnShard(ctx, key, priority, fn)` primitive routes that one delete call through the same shard a live commit for that key would use. (An earlier attempt at wrapping *all* of `ConsolidateTimeSeries`'s per-key work this way self-deadlocked — it calls `SaveContainerProfile` for the same key/shard partway through — caught by kubescape/storage's own test suite before this PR, fixed by only routing the leaf delete operation.) Result in the same local repro: ~5000+ ops/8s, near-zero failures, p50 in microseconds and p99 ~5ms (down from 9.9s).

This PR points the test storage deployment at that fix, manually built and pushed to `quay.io/matthiasb_1/storage:test-shard-delete-fix-965bd1c1` (commit `965bd1c1` on kubescape/storage's `fix/route-consolidation-delete-through-shard` branch, not yet merged upstream), to empirically confirm it resolves this repo's residual failures before that fix merges — the same methodology used throughout this investigation.

## Test plan
- [ ] component-tests run on this PR — compare failure count against the 17/31 (#951) and 18/31 (#952) baselines, ideally toward the historical 0-1/30 pre-regression baseline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

AI-skills: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated component-test infrastructure to use a fixed storage image for more consistent validation.
  * Added additional installation diagnostics to help investigate intermittent test failures.
  * No user-facing product behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->