### PR TITLE
[EXPERIMENT] Validate combined storage shard-writer fixes (delete + WriteTimeSeriesEntry)

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -153,9 +153,16 @@ jobs:
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s
       - name: Install Node Agent Chart
         run: |
-          STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
-          echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          # EXPERIMENT: validating a second, combined fix for the residual
+          # component-tests write-timeout flakiness (routing both
+          # ConsolidateTimeSeries's Delete AND AfterCreate's
+          # WriteTimeSeriesEntry through the write-shard system) before it
+          # merges upstream in kubescape/storage. Pins storage to a
+          # manually-built test image instead of the usual dynamic tag.
+          # Do not merge this override.
+          STORAGE_TAG=test-shard-writer-fixes-f3bf94e5
+          echo "Storage tag that will be used: ${STORAGE_TAG} (EXPERIMENT override, repo quay.io/matthiasb_1/storage)"
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
## Purpose

**Throwaway validation PR — do not merge.**

Follow-up to #954 (closed): that PR validated routing `ConsolidateTimeSeries`'s `Delete` through storage's write-shard system, which reduced failures from 17-18/31 to 13/31 and dropped `database is locked` occurrences to near-zero per job.

Re-tracing the remaining 13 failures' logs (Test_02, Test_08, Test_11 — initially assessed as an unrelated node-agent-side flakiness source, since their own assertion messages don't mention storage) found the **same raw-connection bypass** in `AfterCreate`'s `WriteTimeSeriesEntry` call — fired on essentially every TS `ContainerProfile` create, i.e. most of node-agent's write traffic — surfacing as `sqlite: step: interrupted` instead of `database is locked`.

This PR points the test storage deployment at [kubescape/storage#399](https://github.com/kubescape/storage/pull/399) with a second commit applied (routing `WriteTimeSeriesEntry` through the same `runOnShard` mechanism), manually built and pushed to `quay.io/matthiasb_1/storage:test-shard-writer-fixes-f3bf94e5`, to empirically confirm the combined fix further reduces this repo's residual failures.

Local repro (`containerprofile_load_test.go`, `LOAD_CONSOLIDATORS=1`) with both fixes: p50=55µs, p99~4ms, only 1/8s of ops over 5s — improved on the first fix's already-good numbers.

## Test plan
- [ ] component-tests run on this PR — compare failure count against 17/31 (#951), 18/31 (#952), and 13/31 (#954)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

AI-skills: none