### PR TITLE
throwaway: validate storage Lane 0 (PR #399) against CI — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=lane0-ddf33dc2 -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
Manual validation PR — NOT for merge, will be closed after data collection.

Pins the component-tests workflow's storage image to `quay.io/matthiasb_1/storage:lane0-ddf33dc2`, a build of kubescape/storage branch `fix/route-consolidation-delete-through-shard` (PR #399, "Lane 0" — the write-path shard-bypass bug fix bundle) at commit `ddf33dc2`.

Purpose: validate the current (expanded) Lane 0 fix bundle against real node-agent CI, since only an earlier smaller version of the branch was previously validated this way (that run showed failures drop from a ~17-18/31 baseline to 13/31).

Follow-up: results will be posted as a comment on kubescape/storage#399, and this throwaway PR will be closed (branch kept, not deleted) once data is collected.

Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: ralplan,plan | cmds: /compact,/usage-credits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the component testing environment to use a fixed storage image version.
  - This provides more consistent and repeatable results when running component tests.
  - No user-facing features, behavior, or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->