### PR TITLE
throwaway: validate storage main baseline (same-day, pre-Lane-0) — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=baseline-4535872c -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
Manual validation PR — NOT for merge, will be closed after data collection.

Pins the component-tests workflow's storage image to `quay.io/matthiasb_1/storage:baseline-4535872c`, a build of kubescape/storage `main` (commit `4535872c`, PR #397 merged — sharded single-writer, pre-Lane-0) taken the same day as the Lane 0 validation run (#956).

Purpose: get an apples-to-apples baseline failure count using TODAY's node-agent test suite, since comparing Lane 0's result against older throwaway PR numbers (#949/#951/#954/#955) risked comparing against a different node-agent test-suite snapshot. This run's storage-pod logs will also be pulled to count `Handler timeout` occurrences per failing job, for direct comparison against Lane 0's observed 290-570+/job.

Companion runs: #956 (Lane 0 original), plus two more Lane 0 reruns (same image, to establish Lane 0's own noise floor across n=3).

Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: ralplan,plan | cmds: /compact,/usage-credits