### PR TITLE
throwaway: validate storage main baseline rerun 3/3 — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=baseline-4535872c -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
Manual validation PR — NOT for merge, will be closed after data collection.

Third rerun using the same image as #957/#960 (`quay.io/matthiasb_1/storage:baseline-4535872c`, kubescape/storage main pre-Lane-0), completing baseline n=3 to match Lane 0's sample size.

Companion runs: #956/#958/#959 (Lane 0, n=3), #957/#960 (baseline runs 1-2).

Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: ralplan,plan | cmds: /compact,/usage-credits