### PR TITLE
throwaway: falsify collapse-settings self-stall CI impact — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -159,6 +159,16 @@ jobs:
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5
+      - name: Apply CollapseConfiguration CR (falsification experiment)
+        run: |
+          for i in $(seq 1 12); do
+            if kubectl apply -f tests/chart/artifacts/collapseconfiguration-default.yaml; then
+              break
+            fi
+            echo "retrying kubectl apply of CollapseConfiguration ($i/12)..."
+            sleep 5
+          done
+          kubectl get collapseconfigurations.spdx.softwarecomposition.kubescape.io default -o yaml
       - name: Run Port Forwarding
         run: |
           ./tests/scripts/port-forward.sh

--- a/tests/chart/artifacts/collapseconfiguration-default.yaml
+++ b/tests/chart/artifacts/collapseconfiguration-default.yaml
@@ -1,0 +1,34 @@
+# THROWAWAY, experiment-only: applied by a workflow step (not a chart
+# template) in the throwaway/falsify-collapse-stall branch to test whether
+# the presence of a CollapseConfiguration/default CR reduces component-tests
+# CI flakiness. See kubescape/storage's
+# .omc/plans/collapse-settings-self-stall.md for the root-cause writeup:
+# with no CR present, storage's collapse-settings cache refresh can
+# self-stall a consolidation goroutine on its own held SQLite write lock for
+# up to the full busy timeout. Applying this CR makes the refresh a pure
+# read, which cannot self-stall.
+#
+# Copied verbatim from kubescape/storage's
+# artifacts/collapseconfiguration-default-sample.yaml (compiled-in defaults,
+# so this does not change collapsing behavior versus no CR — only removes
+# the self-stall trigger).
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: CollapseConfiguration
+metadata:
+  name: default
+spec:
+  openDynamicThreshold: 50
+  endpointDynamicThreshold: 100
+  collapseConfigs:
+    - prefix: /etc
+      threshold: 100
+    - prefix: /etc/apache2
+      threshold: 50
+    - prefix: /opt
+      threshold: 50
+    - prefix: /var/run
+      threshold: 50
+    - prefix: /app
+      threshold: 50
+  networkIPGroupThreshold: 50
+  networkCIDRFloorBits: 24


### PR DESCRIPTION
Manual validation PR — NOT for merge, will be closed after data collection.

kubescape/storage has a confirmed root cause (see storage repo's `.omc/plans/collapse-settings-self-stall.md`): whenever no `CollapseConfiguration/default` CR is present, a consolidation-path settings-cache refresh (`NewCRDCollapseSettingsProvider` / `CollapseSettings`) can self-stall a goroutine on its own held SQLite write lock for up to the full busy timeout (60s in production). During that window every other writer (every node-agent TS `Create`, every other consolidation worker) blocks behind it. This fires on essentially every consolidation tick that has data, whenever no CR exists — deterministic, not a race. `Test_34_NetworkNeighborsCIDRCollapse` is the only existing test that applies this CR today, and only for its own duration.

**This PR is the "cheapest falsification experiment" the root-cause doc calls for**: adds `tests/chart/artifacts/collapseconfiguration-default.yaml` (the compiled-in defaults, copied verbatim from storage's `artifacts/collapseconfiguration-default-sample.yaml`) and a workflow step that applies it right after the chart install, for every test in the matrix — not just Test_34. No storage-image override; uses whatever image `storage-tag.sh` resolves by default, so this isolates the effect of the CR's presence alone.

**Comparison point**: recent same-day baselines (no CR, storage main pre-Lane-0) measured 15/16/19 failed out of 31 jobs across 3 runs (mean 16.7) — see kubescape/node-agent#957/#960/#961 and the summary comment on kubescape/storage#399.

If this run (or a couple of reruns) shows a sharp drop in failure count, that's strong evidence this self-stall explains a meaningful chunk of this suite's historical flakiness — independent of, and orthogonal to, the Lane 0 write-path work. If not, its CI-level contribution is small.

Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: ralplan,plan | cmds: /compact,/usage-credits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test setup that applies a default collapse configuration during component tests.
  * Added configuration coverage for collapse thresholds, path prefixes, network IP groups, and CIDR settings.
  * The workflow retries configuration application and verifies the applied resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->