### PR TITLE
throwaway: falsify collapse-settings self-stall CI impact (rerun 2/3) — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -159,6 +159,16 @@ jobs:
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5
+      - name: Apply CollapseConfiguration CR (falsification experiment)
+        run: |
+          for i in $(seq 1 12); do
+            if kubectl apply -f tests/chart/artifacts/collapseconfiguration-default.yaml; then
+              break
+            fi
+            echo "retrying kubectl apply of CollapseConfiguration ($i/12)..."
+            sleep 5
+          done
+          kubectl get collapseconfigurations.spdx.softwarecomposition.kubescape.io default -o yaml
       - name: Run Port Forwarding
         run: |
           ./tests/scripts/port-forward.sh

--- a/tests/chart/artifacts/collapseconfiguration-default.yaml
+++ b/tests/chart/artifacts/collapseconfiguration-default.yaml
@@ -1,0 +1,34 @@
+# THROWAWAY, experiment-only: applied by a workflow step (not a chart
+# template) in the throwaway/falsify-collapse-stall branch to test whether
+# the presence of a CollapseConfiguration/default CR reduces component-tests
+# CI flakiness. See kubescape/storage's
+# .omc/plans/collapse-settings-self-stall.md for the root-cause writeup:
+# with no CR present, storage's collapse-settings cache refresh can
+# self-stall a consolidation goroutine on its own held SQLite write lock for
+# up to the full busy timeout. Applying this CR makes the refresh a pure
+# read, which cannot self-stall.
+#
+# Copied verbatim from kubescape/storage's
+# artifacts/collapseconfiguration-default-sample.yaml (compiled-in defaults,
+# so this does not change collapsing behavior versus no CR — only removes
+# the self-stall trigger).
+apiVersion: spdx.softwarecomposition.kubescape.io/v1beta1
+kind: CollapseConfiguration
+metadata:
+  name: default
+spec:
+  openDynamicThreshold: 50
+  endpointDynamicThreshold: 100
+  collapseConfigs:
+    - prefix: /etc
+      threshold: 100
+    - prefix: /etc/apache2
+      threshold: 50
+    - prefix: /opt
+      threshold: 50
+    - prefix: /var/run
+      threshold: 50
+    - prefix: /app
+      threshold: 50
+  networkIPGroupThreshold: 50
+  networkCIDRFloorBits: 24


### PR DESCRIPTION
Manual validation PR — NOT for merge, will be closed after data collection.

Rerun of #964 (same experiment: applies the compiled-in-default `CollapseConfiguration/default` CR for every test in the matrix, no storage image override) for noise-floor discipline.

Companion runs: #964 (run 1), plus one more rerun if time allows.

Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: ralplan,plan | cmds: /compact,/usage-credits