### PR TITLE
throwaway: validate full-ACID + write-gate-sharing (storage prototype/full-acid-containerprofile) — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=fullacid-02002737 -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5

--- a/tests/chart/templates/storage/configmap.yaml
+++ b/tests/chart/templates/storage/configmap.yaml
@@ -9,5 +9,7 @@ metadata:
 data:
   config.json: |
     {
-      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}"
+      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}",
+      "singleWriterEnabled": true,
+      "containerProfileSqliteBackend": true
     }


### PR DESCRIPTION
Real-CI validation run 1/3 for the full-ACID ContainerProfile storage
redesign + shared write-gate, on `kubescape/storage` branch
`prototype/full-acid-containerprofile` @ `02002737`.

Pins `storage.image` to `quay.io/matthiasb_1/storage:fullacid-02002737`
and overrides `tests/chart`'s storage `config.json` to
`containerProfileSqliteBackend=true` (plus explicit
`singleWriterEnabled=true`, the backend's own startup precondition), so
this run actually exercises the new ObjectStore backend and shared write
gate rather than the unchanged legacy path.

Compared against a fresh post-#401 main baseline (see the sibling
`throwaway/validate-storage-freshbaseline*` PRs) rather than the stale
pre-#401 numbers.

Throwaway PR, not for merge. Will be closed with a summary comment after
data collection.

AI-skills: ralplan,plan | cmds: /compact,/usage-credits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated component test deployments to use a consistent storage image version.
  - Enabled single-writer mode and the SQLite container profile in test storage configuration.
  - Improved test environment reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->