### PR TITLE
throwaway: validate full-ACID + write-gate-sharing (storage prototype/full-acid-containerprofile) — rerun 3/3 — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=fullacid-02002737 -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5

--- a/tests/chart/templates/storage/configmap.yaml
+++ b/tests/chart/templates/storage/configmap.yaml
@@ -9,5 +9,7 @@ metadata:
 data:
   config.json: |
     {
-      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}"
+      "cleanupInterval": "{{ .Values.storage.cleanupInterval }}",
+      "singleWriterEnabled": true,
+      "containerProfileSqliteBackend": true
     }


### PR DESCRIPTION
Real-CI validation run 3/3, same image (quay.io/matthiasb_1/storage:fullacid-02002737)
and config overrides as the first run — third rerun to bring the sample
to n=3.

Throwaway PR, not for merge.

AI-skills: ralplan,plan | cmds: /compact,/usage-credits