### PR TITLE
throwaway: pin storage image to fresh post-#401 main baseline — run 1/2 — do not merge

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           STORAGE_TAG=$(./tests/scripts/storage-tag.sh)
           echo "Storage tag that will be used: ${STORAGE_TAG}"
-          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} -n kubescape --create-namespace --wait --timeout 10m --debug
+          helm upgrade --install kubescape ./tests/chart --set clusterName=`kubectl config current-context` --set nodeAgent.image.tag=${{ needs.build-and-push-image.outputs.image_tag }} --set nodeAgent.image.repository=${{ needs.build-and-push-image.outputs.image_repo }} --set storage.image.tag=${STORAGE_TAG} --set storage.image.repository=quay.io/matthiasb_1/storage --set storage.image.tag=freshbaseline-6386bf23 -n kubescape --create-namespace --wait --timeout 10m --debug
           # Check that the node-agent pod is running
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=node-agent -n kubescape --timeout=600s
           sleep 5


### PR DESCRIPTION
Fresh baseline run 1/2 against quay.io/matthiasb_1/storage:freshbaseline-6386bf23,
a build of kubescape/storage main @ 6386bf23 (includes PR #401
"fix/collapse-settings-self-stall", released v0.0.334/v0.0.335).

Comparison point for the full-ACID + write-gate-sharing validation
(throwaway/validate-fullacid-writegate*). The prior same-day baseline
(15/16/19 failures) predates #401 and is no longer representative.

Throwaway PR, not for merge.

AI-skills: ralplan,plan | cmds: /compact,/usage-credits