### PR TITLE
ci: cap component-tests jobs at 30 minutes

### DIFF
--- a/.github/workflows/component-tests.yaml
+++ b/.github/workflows/component-tests.yaml
@@ -70,6 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push-image
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         test: [


### PR DESCRIPTION
## Summary

A stuck post-step (observed: `actions/setup-go@v4`'s cache-save, unrelated to the actual test) can otherwise run for the full 6-hour hosted-runner ceiling, and GitHub never flushes a force-cancelled job's log tail — turning an unrelated infra stall into an undiagnosable multi-hour mystery instead of a quick, log-intact failure.

## Change

Adds `timeout-minutes: 30` to the `component-tests` job. `go test`'s own `--timeout=20m` already bounds real test hangs; this bounds everything else around it (cluster setup, helm install, post-steps) too, with enough headroom above the slowest observed real runs (~12 min for `Run test` on the heaviest matrix entries).

## Context

Found while investigating an apparent 6-hour hang during unrelated storage-backend validation — traced via GitHub's own per-step job metadata to this exact failure mode (job's real work completed successfully in ~9 minutes; the post-step then stalled for the remaining ~6 hours with no way to tell from the truncated log).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

https://claude.ai/code/session_01LCMGT6Po2tSr1VEDVrbbYd

AI-skills: ralplan,plan | cmds: /compact,/usage-credits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 30-minute time limit for component test jobs in the automated workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->